### PR TITLE
Fix back-to-projects links in unikovky

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@
 - **Write tool truncates large files (~47 KB threshold).** For files larger than that, prefer small targeted Edits. If Write does truncate, you may get orphan content after `</html>` — delete the duplicate tail with an Edit.
 - **Bash can't unlink files on the Windows mount.** `cp` works (creating new files). `rm` doesn't. `mv` doesn't. **Tell the user to delete files locally** if cleanup is needed. Same for `rmdir` on empty folders.
 - **Bash `tail`/`grep` may show stale content** while Read tool shows fresh content. Read tool is the source of truth for file state.
+- **Navigation "zpět na projekty" href rule:**
+  - Files directly in `/projects/` (e.g. `unikovka_procenta.html`, `cesta_penez.html`) → use `href="./"` → resolves to `/projects/`
+  - Files in a subfolder of `/projects/` (e.g. `prijimacky-matematika/index.html`) → use `href="../"` → resolves to `/projects/`
+  - `href="../"` from a `/projects/` file goes to `/` (home), NOT to projects. This is a common mistake — double-check whenever adding nav to a projects page.
 - **Some allowlisted domains:** `github.com`, `npmjs.org`, `pypi.org`, `cdn.playwright.dev`, `*.anthropic.com`, `*.claude.com`. NOT allowlisted: `*.github.io`, most `*.gov.cz`. Czech educational sites work selectively (umimematiku.cz, fgdoskol.cz are usually OK; financnigramotnost.gov.cz blocked).
 
 ## Workflow with the user

--- a/projects/unikovka_procenta.html
+++ b/projects/unikovka_procenta.html
@@ -203,7 +203,7 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 <body>
 
 <div class="top-bar">
-  <a href="../">← zpět na projekty</a>
+  <a href="./">← zpět na projekty</a>
   <span class="crumb">/projects/unikovka_procenta</span>
   <a href="/">domů</a>
 </div>

--- a/projects/unikovka_telesa.html
+++ b/projects/unikovka_telesa.html
@@ -205,7 +205,7 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 <body>
 
 <div class="top-bar">
-  <a href="../">← zpět na projekty</a>
+  <a href="./">← zpět na projekty</a>
   <span class="crumb">/projects/unikovka_telesa</span>
   <a href="/">domů</a>
 </div>


### PR DESCRIPTION
Fixes incorrect `href="../"` → `href="./"` in both únikovky.\n\nSoubory v `/projects/` musí používat `./` (= `/projects/index.html`). Odkaz `../` z těchto souborů vedl na `/` (domovskou stránku), ne na přehled projektů.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_