### PR TITLE
Bilingual CS/EN: all educational projects

### DIFF
--- a/projects/cesta_penez.html
+++ b/projects/cesta_penez.html
@@ -547,81 +547,46 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
   .btn-row { justify-content: stretch; }
   .btn-row .btn-primary, .btn-row .btn-check { flex: 1; }
 }
+
+#lang-bar{position:fixed;bottom:16px;right:16px;z-index:200;display:flex;gap:6px;
+  background:rgba(255,255,255,.92);border-radius:50px;padding:5px 8px;
+  box-shadow:0 2px 12px rgba(0,0,0,.12);backdrop-filter:blur(6px)}
+.lang-btn{background:none;border:2px solid transparent;border-radius:50px;
+  font-size:1.35rem;cursor:pointer;padding:3px 7px;line-height:1;
+  transition:border-color .15s,box-shadow .15s}
+.lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 </style>
 </head>
 <body>
 
+<div id="lang-bar">
+  <button class="lang-btn" data-lang="cs" onclick="setLang('cs')">&#x1F1E8;&#x1F1FF;</button>
+  <button class="lang-btn" data-lang="en" onclick="setLang('en')">&#x1F1EC;&#x1F1E7;</button>
+</div>
+
 <!-- INTRO -->
 <section id="intro" class="screen active">
   <div class="top-bar">
-    <a href="./">← zpět na projekty</a><span></span><a href="/">domů</a>
+    <a href="./" class="tp-back">← zpět na projekty</a><span></span><a href="/" class="tp-home">domů</a>
   </div>
-  <div style="text-align:center;">
-    <div class="intro-icon">💸🛣️</div>
-    <h1 class="intro-title">Cesta peněz — <span class="accent">finanční výprava</span></h1>
-    <p class="intro-sub">
-      Interaktivní příběh o tom, kudy peníze v Česku tečou. Od první brigády po vlastní byt — s reálnými sazbami, počítáním a rozhodnutími, která se ti vrátí.
-    </p>
-  </div>
-
-  <div class="intro-card">
-    <h3>👋 Co tě čeká</h3>
-    <p>Projdeš si <b>8 kapitol života</b> jedné postavy (tebe). V každé kapitole něco spočítáš — daň, RPSN, hypotéku — a uděláš pár rozhodnutí, která ovlivní, kolik ti zbude na konci.</p>
-    <p>Pracujeme s <b>reálnými českými sazbami (rok 2025)</b>. <b>Čísla se generují náhodně</b> — každý spoluhráč u stolu má svoji vlastní brigádu, plat, inflaci.</p>
-  </div>
-
-  <div class="intro-card" style="border-left-color: var(--act2-fg);">
-    <h3 style="color: var(--act2-fg);">📋 Co se naučíš</h3>
-    <ul>
-      <li><span class="bullet">①</span><span><b>Daně a odvody</b> — kolik z hrubé výplaty fakt dostaneš na účet</span></li>
-      <li><span class="bullet">②</span><span><b>Inflace a spoření</b> — proč peníze pod polštářem v čase chudnou</span></li>
-      <li><span class="bullet">③</span><span><b>Půjčky a RPSN</b> — jak srovnat dvě nabídky a nenechat se nachytat</span></li>
-      <li><span class="bullet">④</span><span><b>Hypotéka</b> — co je LTV, anuita a kolik celkem za bydlení dáš</span></li>
-      <li><span class="bullet">⑤</span><span><b>Lichva</b> — proč rychlá půjčka může skončit exekucí</span></li>
-      <li><span class="bullet">⑥</span><span><b>Kyberbezpečnost peněz</b> — phishing, falešné e-shopy, "vyhráli jste"</span></li>
-    </ul>
-  </div>
-
-  <div class="intro-card" style="border-left-color: var(--gold);">
-    <h3 style="color: var(--gold);">💡 Pravidla</h3>
-    <ul>
-      <li><span class="bullet" style="color:var(--gold)">·</span><span>Odpovídej jako <b>celé číslo</b> (v Kč nebo v procentech dle zadání).</span></li>
-      <li><span class="bullet" style="color:var(--gold)">·</span><span>Kalkulačka je v pohodě — jde o postup, ne paměť.</span></li>
-      <li><span class="bullet" style="color:var(--gold)">·</span><span><b>Nápověda má 3 úrovně:</b> 1. nasměrování → 2. vzorec → 3. řešení s výsledkem. Tlačítkem postupuješ dál.</span></li>
-      <li><span class="bullet" style="color:var(--gold)">·</span><span>Postup se ukládá v prohlížeči — můžeš si dát pauzu a pokračovat.</span></li>
-    </ul>
-  </div>
-
-  <div class="intro-card code-input-card">
-    <h3>🔑 Mám kód odjinud</h3>
-    <p>Hraješ na jiném počítači, než předtím? Zadej kód, který jsi dostal po skončení kapitoly. Posuneš se rovnou k té další.</p>
-    <div class="code-input-row">
-      <input type="text" id="code-input-intro" placeholder="třeba: brigada11500" autocomplete="off" autocapitalize="off" spellcheck="false">
-      <button class="btn-check" id="code-apply-intro">Použít</button>
-    </div>
-    <div class="code-feedback" id="code-feedback-intro"></div>
-  </div>
-
-  <div style="text-align:center;">
-    <button class="btn-primary" id="btn-go-hub">▶ Vstoupit do hry</button>
-  </div>
+  <div id="intro-content"></div>
 </section>
 
 <!-- HUB -->
 <section id="hub" class="screen">
   <div class="top-bar">
-    <a href="./">← zpět na projekty</a>
+    <a href="./" class="tp-back">← zpět na projekty</a>
     <div class="mid"><span class="coins" id="hub-coins">0 ⭐</span></div>
     <a href="javascript:void(0)" id="reset-link" title="Smazat postup">↺ reset</a>
   </div>
-  <h2 style="text-align:center; font-weight:800; margin-bottom:6px;">Mapa cesty</h2>
-  <p style="text-align:center; color:var(--muted); font-size:.92rem; margin-bottom:18px;">
+  <h2 id="hub-title" style="text-align:center; font-weight:800; margin-bottom:6px;">Mapa cesty</h2>
+  <p id="hub-subtitle" style="text-align:center; color:var(--muted); font-size:.92rem; margin-bottom:18px;">
     Kapitoly se odemykají postupně. Klikni na první bez zámku.
   </p>
   <div class="hub-grid" id="hub-grid"></div>
 
   <div class="intro-card code-input-card" style="margin-bottom: 18px;">
-    <h3>🔑 Mám kód odjinud</h3>
+    <h3 id="hub-code-title">🔑 Mám kód odjinud</h3>
     <div class="code-input-row">
       <input type="text" id="code-input-hub" placeholder="třeba: brigada11500" autocomplete="off" autocapitalize="off" spellcheck="false">
       <button class="btn-check" id="code-apply-hub">Použít</button>
@@ -637,7 +602,7 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
 <!-- ACT -->
 <section id="act" class="screen">
   <div class="top-bar">
-    <a href="javascript:void(0)" id="back-to-hub">← mapa</a>
+    <a href="javascript:void(0)" id="back-to-hub" class="tp-map">← mapa</a>
     <div class="mid"><span id="act-progress" class="scene-progress"></span></div>
     <span class="coins" id="act-coins">0 ⭐</span>
   </div>
@@ -651,27 +616,44 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
 <!-- RESULT -->
 <section id="result" class="screen">
   <div class="top-bar">
-    <a href="javascript:void(0)" id="result-to-hub">← mapa</a>
+    <a href="javascript:void(0)" id="result-to-hub" class="tp-map">← mapa</a>
     <span></span>
-    <a href="/">domů</a>
+    <a href="/" class="tp-home">domů</a>
   </div>
-  <div class="cert">
-    <div class="seal">🏆</div>
-    <p class="for">Osvědčení o finanční gramotnosti</p>
-    <div class="cert-name-input">
-      <input type="text" id="cert-name-input" placeholder="Zadej své jméno…" autocomplete="off" maxlength="40">
-    </div>
-    <p class="name" id="cert-name-display">Tomu, kdo prošel <i>Cestu peněz</i></p>
-    <h2 id="cert-title">Dokončeno!</h2>
-    <p class="score">Tvoje skóre: <b id="cert-score">— / —</b></p>
-    <p id="cert-msg" style="font-size:.92rem; color:var(--muted); margin-top:10px;"></p>
-  </div>
-  <div style="text-align:center;">
-    <button class="btn-primary" id="result-restart">🔁 Začít znovu</button>
-  </div>
+  <div id="result-content"></div>
 </section>
 
 <script>
+const LANG_KEY = 'cesta_penez_lang';
+let lang = localStorage.getItem(LANG_KEY) || 'cs';
+const i18n = (cs, en) => lang === 'en' ? en : cs;
+
+function setLang(l) {
+  lang = l;
+  try { localStorage.setItem(LANG_KEY, l); } catch(e) {}
+  document.querySelectorAll('.lang-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.lang === l));
+  document.querySelectorAll('.tp-back').forEach(el =>
+    el.textContent = i18n('← zpět na projekty', '← back to projects'));
+  document.querySelectorAll('.tp-home').forEach(el =>
+    el.textContent = i18n('domů', 'home'));
+  document.querySelectorAll('.tp-map').forEach(el =>
+    el.textContent = i18n('← mapa', '← map'));
+  const hubTitle = document.getElementById('hub-title');
+  if (hubTitle) hubTitle.textContent = i18n('Mapa cesty', 'Journey Map');
+  const hubSub = document.getElementById('hub-subtitle');
+  if (hubSub) hubSub.textContent = i18n('Kapitoly se odemykají postupně. Klikni na první bez zámku.', 'Chapters unlock in order. Click the first unlocked one.');
+  const hubCode = document.getElementById('hub-code-title');
+  if (hubCode) hubCode.textContent = i18n('🔑 Mám kód odjinud', '🔑 I have a code from elsewhere');
+  const codeHub = document.getElementById('code-apply-hub');
+  if (codeHub) codeHub.textContent = i18n('Použít', 'Apply');
+  const active = document.querySelector('.screen.active')?.id;
+  if (active === 'intro') buildIntro();
+  else if (active === 'hub') { renderHub(); }
+  else if (active === 'act') renderScene();
+  else if (active === 'result') buildResult();
+}
+
 /* ════════════════════════════════════════════════════════════════════════
    CESTA PENĚZ — finanční výprava
    8.–9. třída, lineární příběh
@@ -693,6 +675,123 @@ const ACT_CODES = {
   7: 'lichvastopka',     // po Aktu 6 (lichva)
   8: 'kyberbezpeci',     // po Aktu 7 (kyber)
 };
+
+/* English metadata for acts */
+const ACT_EN_META = {
+  1: { title: 'First Summer Job',         age: '15 years old' },
+  2: { title: 'First Real Salary',        age: '19 years old' },
+  3: { title: 'Inflation & Savings',      age: '24 years old' },
+  4: { title: 'Car Loan',                 age: '28 years old' },
+  5: { title: 'Mortgage',                 age: '32 years old' },
+  6: { title: 'Predatory Lending',        age: '34 years old' },
+  7: { title: 'Cyber Fraud',              age: '35 years old' },
+  8: { title: 'Certificate',              age: '— summary' },
+};
+
+function buildIntro() {
+  const el = document.getElementById('intro-content');
+  if (!el) return;
+  el.innerHTML = `
+    <div style="text-align:center;">
+      <div class="intro-icon">&#x1F4B8;&#x1F6E3;&#xFE0F;</div>
+      <h1 class="intro-title">${i18n('Cesta peněz — ', 'Money Journey — ')}<span class="accent">${i18n('finanční výprava', 'financial adventure')}</span></h1>
+      <p class="intro-sub">${i18n(
+        'Interaktivní příběh o tom, kudy peníze v Česku tečou. Od první brigády po vlastní byt — s reálnými sazbami, počítáním a rozhodnutími, která se ti vrátí.',
+        'An interactive story about how money flows through life — from your first summer job to your own flat — with real calculations and decisions that matter.'
+      )}</p>
+    </div>
+    <div class="intro-card">
+      <h3>&#x1F44B; ${i18n('Co tě čeká', "What's ahead")}</h3>
+      <p>${i18n(
+        'Projdeš si <b>8 kapitol života</b> jedné postavy (tebe). V každé kapitole něco spočítáš — daň, RPSN, hypotéku — a uděláš pár rozhodnutí, která ovlivní, kolik ti zbude na konci.',
+        'You\'ll travel through <b>8 life chapters</b> of one character (you). In each chapter you\'ll calculate something — tax, APR, mortgage — and make a few decisions that affect your final balance.'
+      )}</p>
+      <p>${i18n(
+        'Pracujeme s <b>reálnými českými sazbami (rok 2025)</b>. <b>Čísla se generují náhodně</b> — každý spoluhráč u stolu má svoji vlastní brigádu, plat, inflaci.',
+        'We use <b>real Czech rates (2025)</b>. <b>Numbers are randomised</b> — every player at the table gets their own job, salary, inflation rate.'
+      )}</p>
+    </div>
+    <div class="intro-card" style="border-left-color: var(--act2-fg);">
+      <h3 style="color: var(--act2-fg);">&#x1F4CB; ${i18n('Co se naučíš', "What you'll learn")}</h3>
+      <ul>
+        <li><span class="bullet">①</span><span><b>${i18n('Daně a odvody', 'Taxes & deductions')}</b> — ${i18n('kolik z hrubé výplaty fakt dostaneš na účet', 'how much of your gross pay actually lands in your account')}</span></li>
+        <li><span class="bullet">②</span><span><b>${i18n('Inflace a spoření', 'Inflation & saving')}</b> — ${i18n('proč peníze pod polštářem v čase chudnou', 'why cash under the mattress loses value over time')}</span></li>
+        <li><span class="bullet">③</span><span><b>${i18n('Půjčky a RPSN', 'Loans & APR')}</b> — ${i18n('jak srovnat dvě nabídky a nenechat se nachytat', 'how to compare two loan offers and not get caught out')}</span></li>
+        <li><span class="bullet">④</span><span><b>${i18n('Hypotéka', 'Mortgage')}</b> — ${i18n('co je LTV, anuita a kolik celkem za bydlení dáš', 'what LTV and annuity mean, and how much housing really costs')}</span></li>
+        <li><span class="bullet">⑤</span><span><b>${i18n('Lichva', 'Predatory lending')}</b> — ${i18n('proč rychlá půjčka může skončit exekucí', 'why a quick loan can end in debt enforcement')}</span></li>
+        <li><span class="bullet">⑥</span><span><b>${i18n('Kyberbezpečnost peněz', 'Cyber-financial safety')}</b> — ${i18n('phishing, falešné e-shopy, "vyhráli jste"', 'phishing, fake shops, "you\'ve won"')}</span></li>
+      </ul>
+    </div>
+    <div class="intro-card" style="border-left-color: var(--gold);">
+      <h3 style="color: var(--gold);">&#x1F4A1; ${i18n('Pravidla', 'Rules')}</h3>
+      <ul>
+        <li><span class="bullet" style="color:var(--gold)">·</span><span>${i18n('Odpovídej jako <b>celé číslo</b> (v Kč nebo v procentech dle zadání).', 'Answer as a <b>whole number</b> (in CZK or % as stated).')}</span></li>
+        <li><span class="bullet" style="color:var(--gold)">·</span><span>${i18n('Kalkulačka je v pohodě — jde o postup, ne paměť.', 'A calculator is fine — it\'s about understanding the process, not memory.')}</span></li>
+        <li><span class="bullet" style="color:var(--gold)">·</span><span><b>${i18n('Nápověda má 3 úrovně:', 'Hints have 3 levels:')}</b> ${i18n('1. nasměrování → 2. vzorec → 3. řešení s výsledkem.', '1. direction → 2. formula → 3. full solution.')} ${i18n('Tlačítkem postupuješ dál.', 'Press the button to advance.')}</span></li>
+        <li><span class="bullet" style="color:var(--gold)">·</span><span>${i18n('Postup se ukládá v prohlížeči — můžeš si dát pauzu a pokračovat.', 'Progress is saved in the browser — you can pause and continue.')}</span></li>
+      </ul>
+    </div>
+    <div class="intro-card code-input-card">
+      <h3>&#x1F511; ${i18n('Mám kód odjinud', 'I have a code from elsewhere')}</h3>
+      <p>${i18n('Hraješ na jiném počítači, než předtím? Zadej kód, který jsi dostal po skončení kapitoly. Posuneš se rovnou k té další.', 'Playing on a different computer? Enter the code you received at the end of a chapter. You\'ll jump straight to the next one.')}</p>
+      <div class="code-input-row">
+        <input type="text" id="code-input-intro" placeholder="${i18n('třeba: brigada11500', 'e.g.: brigada11500')}" autocomplete="off" autocapitalize="off" spellcheck="false">
+        <button class="btn-check" id="code-apply-intro">${i18n('Použít', 'Apply')}</button>
+      </div>
+      <div class="code-feedback" id="code-feedback-intro"></div>
+    </div>
+    <div style="text-align:center;">
+      <button class="btn-primary" id="btn-go-hub">&#x25B6; ${i18n('Vstoupit do hry', 'Enter the game')}</button>
+    </div>
+  `;
+  document.getElementById('btn-go-hub').addEventListener('click', () => { renderHub(); showScreen('hub'); });
+  bindCodeInput('code-input-intro', 'code-apply-intro', 'code-feedback-intro');
+}
+
+function buildResult() {
+  const sc = totalScore();
+  const pct = sc.max ? Math.round((sc.earned / sc.max) * 100) : 0;
+  let msg;
+  if (pct >= 90) msg = i18n('🏆 Mistr finanční gramotnosti! Skvělé výsledky napříč všemi kapitolami.', '🏆 Financial literacy master! Excellent results across all chapters.');
+  else if (pct >= 70) msg = i18n('🎉 Velmi solidní výsledek. Pár věcí si ještě můžeš zopakovat.', '🎉 Very solid result. A few things worth reviewing.');
+  else if (pct >= 50) msg = i18n('👍 Základ máš. Doporučuju projít znovu kapitoly, kde jsi měl skóre nízké.', '👍 Good foundation. Try re-reading the chapters where your score was low.');
+  else msg = i18n('📚 Začátek je tu — opakování je matkou moudrosti. Zkus to znovu.', '📚 Good start — practice makes perfect. Try again.');
+  const el = document.getElementById('result-content');
+  if (!el) return;
+  el.innerHTML = `
+    <div class="cert">
+      <div class="seal">&#x1F3C6;</div>
+      <p class="for">${i18n('Osvědčení o finanční gramotnosti', 'Certificate of Financial Literacy')}</p>
+      <div class="cert-name-input">
+        <input type="text" id="cert-name-input" placeholder="${i18n('Zadej své jméno…', 'Enter your name…')}" autocomplete="off" maxlength="40">
+      </div>
+      <p class="name" id="cert-name-display">${i18n('Tomu, kdo prošel <i>Cestu peněz</i>', 'To whoever completed <i>Money Journey</i>')}</p>
+      <h2>${i18n('Dokončeno!', 'Completed!')}</h2>
+      <p class="score">${i18n('Tvoje skóre:', 'Your score:')} <b id="cert-score">${sc.earned} / ${sc.max} ⭐</b></p>
+      <p style="font-size:.92rem; color:var(--muted); margin-top:10px;">${msg}</p>
+    </div>
+    <div style="text-align:center;">
+      <button class="btn-primary" id="result-restart">&#x1F501; ${i18n('Začít znovu', 'Start again')}</button>
+    </div>
+  `;
+  const nameInp = document.getElementById('cert-name-input');
+  const nameDisp = document.getElementById('cert-name-display');
+  const defaultName = i18n('Tomu, kdo prošel <i>Cestu peněz</i>', 'To whoever completed <i>Money Journey</i>');
+  const savedName = STATE.studentName || '';
+  nameInp.value = savedName;
+  nameDisp.innerHTML = savedName ? savedName : defaultName;
+  nameInp.oninput = () => {
+    const v = nameInp.value.trim();
+    STATE.studentName = v;
+    nameDisp.innerHTML = v ? v : defaultName;
+    saveState();
+  };
+  document.getElementById('result-restart').addEventListener('click', () => {
+    if (confirm(i18n('Začít cestu znovu? Smaže to tvůj postup.', 'Start the journey again? This will erase your progress.'))) {
+      resetState(); renderHub(); showScreen('intro');
+    }
+  });
+}
 
 /* ────────── STATE ────────── */
 
@@ -1482,6 +1581,369 @@ Při prodlení nad 30 dní: zesplatnění + exekuce</div>
   },
 ];
 
+/* ────────── ENGLISH SCENE BUILDS ────────── */
+const BUILD_EN = {
+
+  1: [
+    /* 0 story */ ctx => ({ icon: ctx.job.icon, html: `
+      <p>Summer holidays. <b>${ctx.job.who.charAt(0).toUpperCase() + ctx.job.who.slice(1)}</b> got you a summer job at a ${ctx.job.place === 'kavárna' ? 'café' : ctx.job.place === 'pizza-rozvážka' ? 'pizza delivery' : ctx.job.place === 'doučování angličtiny' ? 'tutoring agency' : ctx.job.place === 'letní tábor (asistent)' ? 'summer camp' : ctx.job.place === 'knihovna' ? 'library' : 'ice-cream parlour'}. Contract: <b>DPP — work agreement</b> (Czech short-term contract for students).</p>
+      <p>Your boss says: <i>"Hourly rate <b>${ctx.rate} CZK</b>, we're working ${ctx.job.period}, about <b>${ctx.hours} hours</b> per month."</i></p>
+      <div class="fact-box">📘 <b>DPP (work agreement)</b> is a popular Czech student work contract. <b>If you earn up to 11,500 CZK/month, no tax or insurance is deducted</b> (2025 limit). Above 11,500 CZK the 15% income tax kicks in.</div>
+      <p>Calculate your <b>gross</b> monthly earnings.</p>
+    `}),
+    /* 1 math  */ ctx => ({ q: `<b>${ctx.hours} hours × ${ctx.rate} CZK/h</b> = ?`, unit: 'CZK', answer: ctx.total, hints: [
+      'What math operation do you need — addition, subtraction, multiplication or division?',
+      `Multiply the number of hours by the hourly rate: <b>${ctx.hours} × ${ctx.rate}</b>.`,
+      `${ctx.hours} × ${ctx.rate} = <b>${fmt(ctx.total)}</b> CZK.`,
+    ], explain: `${ctx.hours} × ${ctx.rate} = <b>${fmt(ctx.total)} CZK</b>. You're under the 11,500 CZK limit — no tax or insurance to pay.` }),
+    /* 2 story */ ctx => ({ icon: '✅', html: `
+      <p>Great. <b>You earned ${fmt(ctx.total)} CZK</b>, and because you're under 11,500 CZK you receive the <b>full amount</b> in your account.</p>
+      <div class="fact-box">⚠️ <b>Common mistake:</b> If you had <b>two DPP contracts with different employers</b> and the combined total exceeded 11,500 CZK, the tax-free limit applies per contract — but social insurance is calculated on total income above the threshold.</div>
+    `}),
+    /* 3 decision */ ctx => ({ q: `What do you do with ${fmt(ctx.total)} CZK?`, options: [
+      { title: 'Spend it all on new clothes and games', kind: 'bad', feedback: 'Tempting, but if an unexpected cost comes up (broken phone, transport), you\'ll have nothing. Keep <b>some as a buffer</b>.' },
+      { title: 'Spend half, put half aside', kind: 'good', feedback: `Good decision. The <b>50/30/20 rule</b> says: 50% needs, 30% wants, 20% savings. Half-and-half is a reasonable compromise for a teenager.` },
+      { title: `Lend it to a friend who promised 10% back next month`, kind: 'meh', feedback: 'Lending to friends is risky — if they don\'t pay, you lose both the money <b>and the friendship</b>. Rule: only lend what you can afford to never see again.' },
+      { title: 'Send it to my parents to put in a savings account', kind: 'good', feedback: 'Smart! A savings account earns interest (modest, but better than nothing) and keeps money out of reach of impulse purchases.' },
+    ]}),
+    /* 4 story */ () => ({ icon: '🎯', html: `
+      <p>Chapter done. You learned that <b>DPP earnings under 11,500 CZK/month are tax-free</b> and that a buffer fund is more valuable than new trainers.</p>
+      <p>In a few years school ends and your first permanent job starts — and taxes will work differently.</p>
+    `}),
+  ],
+
+  2: [
+    /* 0 story */ ctx => ({ icon: '📄', html: `
+      <p>After secondary school you start your first permanent job (HPP — standard employment contract).</p>
+      <p>Your contract promises a <b>gross salary of ${fmt(ctx.gross)} CZK/month</b>. You think: "After a year I'll have ${fmt(ctx.gross * 12)} CZK!"</p>
+      <p>But your account receives less. Why?</p>
+      <div class="fact-box">📘 <b>Gross salary</b> is the number in the contract. <b>Net salary</b> is what you actually receive. Between them stands the state with three deductions:</div>
+      <p>① <b>Social insurance</b> — 7.1% of gross (pensions, sick pay).<br>
+         ② <b>Health insurance</b> — 4.5% of gross (doctors, hospitals).<br>
+         ③ <b>Income tax</b> — 15% of gross, <b>but</b> reduced by a <b>personal tax credit of 2,570 CZK/month</b>.</p>
+    `}),
+    /* 1 math */ ctx => ({ q: `Calculate <b>social insurance</b> on gross salary <b>${fmt(ctx.gross)} CZK</b>. (7.1%)`, unit: 'CZK', answer: ctx.social, hints: [
+      'Convert the percentage to a decimal, then multiply.',
+      `7.1% = 0.071. Multiply gross by this decimal: <b>${fmt(ctx.gross)} × 0.071</b>.`,
+      `${fmt(ctx.gross)} × 0.071 = <b>${fmt(ctx.social)}</b> CZK.`,
+    ], explain: `${fmt(ctx.gross)} × 0.071 = <b>${fmt(ctx.social)} CZK</b>. This goes to the state for pensions and sick pay.` }),
+    /* 2 math */ ctx => ({ q: `Now <b>health insurance</b> on <b>${fmt(ctx.gross)} CZK</b>. (4.5%)`, unit: 'CZK', answer: ctx.health, hints: [
+      'Same method as social insurance, just a lower rate.',
+      `4.5% = 0.045. So <b>${fmt(ctx.gross)} × 0.045</b>.`,
+      `${fmt(ctx.gross)} × 0.045 = <b>${fmt(ctx.health)}</b> CZK.`,
+    ], explain: `${fmt(ctx.gross)} × 0.045 = <b>${fmt(ctx.health)} CZK</b>. Goes to your health insurer.` }),
+    /* 3 math */ ctx => ({ q: `Income <b>tax advance</b>: 15% of ${fmt(ctx.gross)} = ? <br><span style="color:var(--muted);font-weight:400;font-size:.9rem;">(Tax before applying the personal credit.)</span>`, unit: 'CZK', answer: ctx.taxBase, hints: [
+      'Calculate 15% of gross salary — this is the advance the state holds.',
+      `15% = 0.15. So <b>${fmt(ctx.gross)} × 0.15</b>.`,
+      `${fmt(ctx.gross)} × 0.15 = <b>${fmt(ctx.taxBase)}</b> CZK.`,
+    ], explain: `${fmt(ctx.gross)} × 0.15 = <b>${fmt(ctx.taxBase)} CZK</b>. But the personal tax credit still applies.` }),
+    /* 4 math */ ctx => ({ q: `After the <b>2,570 CZK personal credit</b>: what is the <b>actual tax</b>? <br><span style="color:var(--muted);font-weight:400;font-size:.9rem;">(advance − credit)</span>`, unit: 'CZK', answer: ctx.tax, hints: [
+      'Subtract the credit from the advance you calculated in the previous step.',
+      `<b>${fmt(ctx.taxBase)} − 2,570</b> = ?`,
+      `${fmt(ctx.taxBase)} − 2,570 = <b>${fmt(ctx.tax)}</b> CZK.`,
+    ], explain: `${fmt(ctx.taxBase)} − 2,570 = <b>${fmt(ctx.tax)} CZK</b>. The <b>personal tax credit</b> saves you 2,570 CZK per month — every employee gets it.` }),
+    /* 5 math */ ctx => ({ q: `Final <b>net salary</b>: ${fmt(ctx.gross)} − social − health − tax. Calculate.`, unit: 'CZK', answer: ctx.net, hints: [
+      'Subtract all three deductions you calculated from the gross salary.',
+      `<b>${fmt(ctx.gross)} − ${fmt(ctx.social)} − ${fmt(ctx.health)} − ${fmt(ctx.tax)}</b> = ?`,
+      `${fmt(ctx.gross)} − ${fmt(ctx.social)} − ${fmt(ctx.health)} − ${fmt(ctx.tax)} = <b>${fmt(ctx.net)}</b> CZK.`,
+    ], explain: `${fmt(ctx.gross)} − ${fmt(ctx.social)} − ${fmt(ctx.health)} − ${fmt(ctx.tax)} = <b>${fmt(ctx.net)} CZK</b>. From gross ${fmt(ctx.gross)} CZK, <b>${fmt(ctx.net)} CZK</b> lands in your account (≈ ${Math.round(100 * ctx.net / ctx.gross)}%).` }),
+    /* 6 story */ ctx => ({ icon: '💡', html: `
+      <p>From ${fmt(ctx.gross)} CZK gross you receive <b>${fmt(ctx.net)} CZK net</b>. The state took <b>${fmt(ctx.gross - ctx.net)} CZK</b> in taxes and insurance — in return you get:</p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.7;">
+        <li>free medical care</li>
+        <li>entitlement to a pension at 65+</li>
+        <li>roads, schools, police and everything else funded by the state</li>
+      </ul>
+      <div class="fact-box">📊 <b>Rule of thumb:</b> About <b>78–82%</b> of gross salary arrives in your account. Above ~133,000 CZK/month (2025) a second tax rate of <b>23%</b> applies.</div>
+    `}),
+    /* 7 decision */ ctx => { const fivePct = Math.round(ctx.net * 0.05 / 100) * 100; const tenPct = Math.round(ctx.net * 0.1 / 100) * 100; const twentyPct = Math.round(ctx.net * 0.2 / 100) * 100; return { q: `From net salary ${fmt(ctx.net)} CZK — how much should you put aside immediately?`, options: [
+      { title: 'Nothing — money is for spending', kind: 'bad', feedback: 'Wrong. Without a buffer, any unexpected expense (broken car, dentist) forces you to <b>take out a loan</b>. And loans cost money — see Chapter 4.' },
+      { title: `10% (≈ ${fmt(tenPct)} CZK) — some buffer is better than nothing`, kind: 'meh', feedback: `Better than nothing, but 10% isn't much. You save ≈ ${fmt(tenPct)} CZK/month — building a 3-month buffer will take <b>nearly 2 years</b>.` },
+      { title: `20% (≈ ${fmt(twentyPct)} CZK) — the 50/30/20 rule`, kind: 'good', feedback: `Excellent! You save ${fmt(twentyPct)} CZK/month. A <b>3-month expense buffer</b> grows in about a year. ✅` },
+      { title: '50% — I want to be a millionaire soon', kind: 'meh', feedback: 'Ambitious! Works if your expenses are low (living with parents). But if you deny yourself everything you\'ll burn out and start impulse-spending.' },
+    ]}; },
+    /* 8 story */ () => ({ icon: '🎯', html: `
+      <p>Chapter done. <b>Gross ≠ net</b> — always calculate knowing the state takes ≈ 18–22%. And a 3-month expense buffer is the golden rule of financial literacy.</p>
+      <p>Next: <b>savings and inflation</b> — why cash under the mattress loses value over time.</p>
+    `}),
+  ],
+
+  3: [
+    /* 0 story */ ctx => ({ icon: '💰', html: `
+      <p>After 5 years of work you've saved <b>${fmt(ctx.savings)} CZK</b> under the mattress. You're proud — you have a buffer!</p>
+      <p>Then you hear on the radio: <i>"Annual inflation: ${ctx.inflation}%."</i> What does that mean for your money?</p>
+      <div class="fact-box">📘 <b>Inflation</b> = the rise in prices over time. With ${ctx.inflation}% inflation, something that costs 100 CZK today will cost ${100 + ctx.inflation} CZK next year. Your money stays the same <b>nominally</b> (you still have ${fmt(ctx.savings)} CZK), but its <b>purchasing power</b> falls.</div>
+    `}),
+    /* 1 math */ ctx => ({ q: `At inflation <b>${ctx.inflation}%</b> — <b>how much will next year's basket cost</b> if it costs <b>${fmt(ctx.savings)} CZK</b> today?`, unit: 'CZK', answer: ctx.basketAfter, hints: [
+      'Inflation tells you by how many % prices increase. Add that % increase to the original price.',
+      `${fmt(ctx.savings)} × (1 + ${ctx.inflation}/100) = ${fmt(ctx.savings)} × ${(1 + ctx.inflation/100).toFixed(2)}.`,
+      `${fmt(ctx.savings)} × ${(1 + ctx.inflation/100).toFixed(2)} = <b>${fmt(ctx.basketAfter)}</b> CZK.`,
+    ], explain: `${fmt(ctx.savings)} × ${(1 + ctx.inflation/100).toFixed(2)} = <b>${fmt(ctx.basketAfter)} CZK</b>. To buy the same things next year you'd need ${fmt(ctx.inflationLoss)} CZK more.` }),
+    /* 2 math */ ctx => ({ q: `Your <b>${fmt(ctx.savings)} CZK</b> under the mattress is nominally unchanged. By how many CZK did your <b>purchasing power</b> fall?`, unit: 'CZK', answer: ctx.inflationLoss, hints: [
+      'Before, you could buy the whole basket. Now the basket costs more but you have the same amount.',
+      `Difference between the new basket price and what you have: <b>${fmt(ctx.basketAfter)} − ${fmt(ctx.savings)}</b>.`,
+      `${fmt(ctx.basketAfter)} − ${fmt(ctx.savings)} = <b>${fmt(ctx.inflationLoss)}</b> CZK.`,
+    ], explain: `Your ${fmt(ctx.savings)} CZK buys <b>${fmt(ctx.inflationLoss)} CZK less in goods</b> than last year. Your money doesn't move — <b>it gets poorer because prices around it rise</b>.` }),
+    /* 3 story */ ctx => ({ icon: '🏦', html: `
+      <p>What to do? Banks offer <b>savings accounts</b> — your money at least grows slowly.</p>
+      <p>A savings account offers you <b>≈ ${ctx.savingsRate}% interest per year</b> (to compare with inflation).</p>
+    `}),
+    /* 4 math */ ctx => ({ q: `If you deposit <b>${fmt(ctx.savings)} CZK</b> in a savings account at <b>${ctx.savingsRate}%/year</b>, how much do you have after one year?`, unit: 'CZK', answer: ctx.savingsAfter, hints: [
+      'Same method as inflation — you\'re now asking how much your money grows instead of prices.',
+      `${fmt(ctx.savings)} × (1 + ${ctx.savingsRate}/100) = ${fmt(ctx.savings)} × ${(1 + ctx.savingsRate/100).toFixed(2)}.`,
+      `${fmt(ctx.savings)} × ${(1 + ctx.savingsRate/100).toFixed(2)} = <b>${fmt(ctx.savingsAfter)}</b> CZK.`,
+    ], explain: `${fmt(ctx.savings)} × ${(1 + ctx.savingsRate/100).toFixed(2)} = <b>${fmt(ctx.savingsAfter)} CZK</b>. You earned ${fmt(ctx.savingsAfter - ctx.savings)} CZK in interest.` }),
+    /* 5 story */ ctx => ({ icon: '⚖️', html: `
+      <p>Let's compare: <b>inflation ${ctx.inflation}%, interest ${ctx.savingsRate}%.</b></p>
+      <div class="calc-box">Basket price next year: ${fmt(ctx.basketAfter)} CZK
+Your money next year:   ${fmt(ctx.savingsAfter)} CZK
+Real loss:              ${fmt(ctx.realLoss)} CZK</div>
+      <p>Even with a savings account you're <b>effectively ${fmt(ctx.realLoss)} CZK poorer in real terms</b>. Inflation ran faster than interest. <b>Real interest rate</b> = rate − inflation = ${ctx.savingsRate} − ${ctx.inflation} = <b>${ctx.savingsRate - ctx.inflation}%</b>.</p>
+      <div class="fact-box">📘 The <b>real interest rate</b> can be negative! Then a savings account <i>slows</i> the loss of purchasing power but doesn't stop it. Higher returns come from investments (equities, funds) — at higher risk.</div>
+    `}),
+    /* 6 story */ ctx => { const items = [
+        { e: '📱', name: 'iPhone (≈ 30,000 CZK)', price: 30000 },
+        { e: '🏠', name: 'monthly rent 2-bed flat (≈ 25,000 CZK)', price: 25000 },
+        { e: '🏖️', name: 'week holiday for two (≈ 25,000 CZK)', price: 25000 },
+        { e: '🥐', name: 'bread roll (3.50 CZK)', price: 3.5 },
+      ];
+      const f = ctx.factor10;
+      const li = (item, factor) => { const n = Math.floor(ctx.savings / (item.price * factor)); return `<li><span>${item.e}</span><span><b>${fmt(n)}×</b> ${item.name}</span></li>`; };
+      return { icon: '🛒', html: `
+        <p>But what does it <b>actually mean</b>? Let's convert this to things you know.</p>
+        <p>Your <b>${fmt(ctx.savings)} CZK</b> — what can you really buy with it?</p>
+        <div class="kupni-sila">
+          <div class="ks-now">
+            <h4>📅 Today (2025)</h4>
+            <ul>${items.map(it => li(it, 1)).join('')}</ul>
+          </div>
+          <div class="ks-future">
+            <h4>⏭️ In 10 years (inflation ${ctx.inflation}%/yr)</h4>
+            <ul>${items.map(it => li(it, f)).join('')}</ul>
+            <p class="ks-note">The same ${fmt(ctx.savings)} CZK in 2035 will buy only <b>${ctx.pct10}%</b> of what it does today.<br>(Basket price rises from ${fmt(ctx.savings)} to ~${fmt(Math.round(ctx.savings * f))} CZK.)</p>
+          </div>
+        </div>
+        <div class="fact-box">💡 <b>Takeaway:</b> money you <b>don't use now or invest</b> slowly slips through your fingers. Cash and mattresses are for <b>short-term</b> reserves (3–6 months). For the long term you need something that beats inflation.</div>
+      `}; },
+    /* 7 decision */ ctx => ({ q: `You have ${fmt(ctx.savings)} CZK saved. What do you do with it?`, options: [
+      { title: 'Leave it under the mattress', kind: 'bad', feedback: `Worst choice — no interest, inflation eats it at full speed (−${ctx.inflation}%/yr). In 10 years it would have the purchasing power of ≈${ctx.pct10}% of today's value.` },
+      { title: `All in a savings account (${ctx.savingsRate}%)`, kind: 'meh', feedback: `Better than the mattress — money is accessible anytime, but you're mildly losing purchasing power (${ctx.savingsRate - ctx.inflation}%/yr). Good for a <b>short-term buffer</b> (3–6 months of expenses).` },
+      { title: 'Half in savings, half invested', kind: 'good', feedback: 'Sensible compromise! Half <b>liquid reserve</b>, half <b>long-term growth</b>. Equities/funds historically return 6–8%/yr (beating inflation) but fluctuate.' },
+      { title: 'Invest everything in equities', kind: 'meh', feedback: 'Good for returns, but <b>no liquid reserve</b> — if an unexpected cost hits while markets are down, you sell at a loss. <b>Buffer first, invest with the surplus.</b>' },
+    ]}),
+    /* 8 story */ () => ({ icon: '🎯', html: `
+      <p>Chapter 3 summary: <b>cash under the mattress loses value</b>, a savings account is first aid, but for the long run you need investments. <b>Buffer first, invest with the surplus.</b></p>
+      <p>Next chapter: <b>car loan and what APR means</b>.</p>
+    `}),
+  ],
+
+  4: [
+    /* 0 story */ ctx => ({ icon: '🚗', html: `
+      <p>A few years into work your boss gives you a raise. You want to buy a <b>used car for ${fmt(ctx.price)} CZK</b>. You only have <b>50,000 CZK</b> — you need a loan for the rest.</p>
+      <p>Three offers:</p>
+      <div class="calc-box">A) Bank <b>APR 9%</b> · payment <b>${fmt(ctx.monthlyA)} CZK/month</b> · 48 months
+B) Non-bank lender <b>APR 22%</b> · payment <b>${fmt(ctx.monthlyB)} CZK/month</b> · 48 months
+C) "Instant cash, no paperwork" <b>APR 38%</b> · payment <b>${fmt(ctx.monthlyC)} CZK/month</b> · 48 months</div>
+      <div class="fact-box">📘 <b>APR (Annual Percentage Rate)</b> is the <b>only correct comparison number</b> for loans. It includes both interest and all fees. Lower APR = cheaper loan. Marketing loves to show "from X CZK/month", but that's a trap — a low payment can mean a long term and a huge overpayment.</div>
+    `}),
+    /* 1 math */ ctx => ({ q: `Calculate the <b>total you'd pay to Bank (A)</b>. <br><span style="color:var(--muted);font-weight:400;font-size:.9rem;">monthly payment × number of months</span>`, unit: 'CZK', answer: ctx.totalA, hints: [
+      'Just multiplication: payment times number of months.',
+      `${fmt(ctx.monthlyA)} × 48 = ?`,
+      `${fmt(ctx.monthlyA)} × 48 = <b>${fmt(ctx.totalA)}</b> CZK.`,
+    ], explain: `${fmt(ctx.monthlyA)} × 48 = <b>${fmt(ctx.totalA)} CZK</b>. Car cost ${fmt(ctx.price)} CZK → loan overpayment: ${fmt(ctx.totalA - ctx.price)} CZK.` }),
+    /* 2 math */ ctx => ({ q: `Now calculate the <b>total for "Instant Cash" (C)</b>.`, unit: 'CZK', answer: ctx.totalC, hints: [
+      'Same method as Bank — payment × 48 months.',
+      `${fmt(ctx.monthlyC)} × 48 = ?`,
+      `${fmt(ctx.monthlyC)} × 48 = <b>${fmt(ctx.totalC)}</b> CZK.`,
+    ], explain: `${fmt(ctx.monthlyC)} × 48 = <b>${fmt(ctx.totalC)} CZK</b>. For a car worth ${fmt(ctx.price)} CZK you'd overpay <b>${fmt(ctx.overpayC)} CZK</b> — more than the car itself cost.` }),
+    /* 3 math */ ctx => ({ q: `<b>How much more do you pay with "Instant Cash" (C) vs Bank (A)?</b>`, unit: 'CZK', answer: ctx.diffCA, hints: [
+      'Subtract the Bank total from the Instant Cash total.',
+      `${fmt(ctx.totalC)} − ${fmt(ctx.totalA)} = ?`,
+      `${fmt(ctx.totalC)} − ${fmt(ctx.totalA)} = <b>${fmt(ctx.diffCA)}</b> CZK.`,
+    ], explain: `<b>${fmt(ctx.diffCA)} CZK extra</b> just for "faster paperwork". That's almost enough to buy a second car.` }),
+    /* 4 decision */ ctx => ({ q: 'Which loan do you choose?', options: [
+      { title: `A) Bank (APR 9%, ${fmt(ctx.monthlyA)} CZK/month)`, kind: 'good', feedback: 'Correct! The bank is the best deal — lowest APR, smallest overpayment. You need to show proof of income and it takes a little longer, but you save a huge amount.' },
+      { title: `B) Non-bank lender (APR 22%, ${fmt(ctx.monthlyB)} CZK/month)`, kind: 'meh', feedback: 'Not ideal. Non-bank lenders are sometimes necessary (when banks refuse), but you overpay thousands. A bank loan is almost always better.' },
+      { title: `C) Instant Cash (APR 38%, ${fmt(ctx.monthlyC)} CZK/month)`, kind: 'bad', feedback: `Very bad. You'd pay ${fmt(ctx.overpayC)} CZK in overpayments — more than the car cost. "Instant cash" lenders are often predatory.` },
+    ]}),
+    /* 5 story */ () => ({ icon: '🎯', html: `
+      <p>Three rules to keep in mind before any loan:</p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.7;">
+        <li><b>① Compare by APR</b>, not by monthly payment.</li>
+        <li><b>② Calculate the <i>total</i> amount paid</b> (payment × number of months).</li>
+        <li><b>③ "No income proof / approved in 15 min / no credit check" = red flag.</b></li>
+      </ul>
+      <div class="fact-box">📘 <b>Czech APR benchmarks (2025):</b> bank consumer loan <b>7–13%</b>, non-bank <b>15–30%</b>, predatory "instant" loans <b>30%+</b>. Consumer credit law provides some protection, but always read the contract.</div>
+      <p>Next chapter: <b>mortgage</b> — the biggest loan of your life.</p>
+    `}),
+  ],
+
+  5: [
+    /* 0 story */ ctx => ({ icon: '🏠', html: `
+      <p>You're at the bank. You've found a flat for <b>${fmt(ctx.price)} CZK</b>. The banker explains:</p>
+      <p><i>"The maximum loan is <b>${ctx.ltv}% of the property value</b> — this is called <b>LTV (Loan-to-Value)</b>. You must have the rest saved as a <b>down payment</b>."</i></p>
+      <div class="fact-box">📘 <b>LTV 80%</b> = bank lends 80% of the price, you need 20% of your own money. <b>LTV 90%</b> = bank lends 90%, you need 10%. Lower LTV = lower interest rate, but you need more saved first.</div>
+      <p>Calculate how much of your own money you need as a down payment.</p>
+    `}),
+    /* 1 math */ ctx => ({ q: `Down payment = price × <b>(100 − LTV)/100</b>. Calculate: ${fmt(ctx.price)} × (100 − ${ctx.ltv}) / 100.`, unit: 'CZK', answer: ctx.akontace, hints: [
+      'The down payment is your own share — the part the bank does NOT lend you.',
+      `${fmt(ctx.price)} × ${100 - ctx.ltv} / 100 = ?`,
+      `${fmt(ctx.price)} × ${100 - ctx.ltv} / 100 = <b>${fmt(ctx.akontace)}</b> CZK.`,
+    ], explain: `<b>${fmt(ctx.akontace)} CZK</b> must be in your account. The bank will lend you the remaining <b>${fmt(ctx.loan)} CZK</b>.` }),
+    /* 2 story */ ctx => ({ icon: '💸', html: `
+      <p>The banker continues: <i>"At today's interest rate of approx. <b>5%</b> and a term of <b>30 years</b>, your <b>monthly payment will be approximately ${fmt(ctx.monthly)} CZK</b>."</i></p>
+      <div class="fact-box">📘 The <b>monthly annuity</b> is mathematically complex (geometric series with interest). The bank calculates it for you. What matters to you: <b>how much per month</b> and <b>how much in total over 30 years</b>.</div>
+      <p>Now calculate how much in total you'll repay to the bank over 30 years.</p>
+    `}),
+    /* 3 math */ ctx => ({ q: `<b>Total repaid over 30 years</b> = monthly payment × number of months (360). Calculate.`, unit: 'CZK', answer: ctx.totalPaid, hints: [
+      'Multiply the monthly payment by the number of months (30 years = 360 months).',
+      `${fmt(ctx.monthly)} × 360 = ?`,
+      `${fmt(ctx.monthly)} × 360 = <b>${fmt(ctx.totalPaid)}</b> CZK.`,
+    ], explain: `<b>${fmt(ctx.totalPaid)} CZK</b> will be repaid to the bank over 30 years. The bank lent you ${fmt(ctx.loan)} CZK.` }),
+    /* 4 math */ ctx => ({ q: `How much <b>overpayment</b> is there beyond the amount the bank lent you? <br><span style="color:var(--muted);font-weight:400;font-size:.9rem;">total repaid − principal</span>`, unit: 'CZK', answer: ctx.overpaid, hints: [
+      'Difference between what you repay in total and what the bank originally lent you.',
+      `${fmt(ctx.totalPaid)} − ${fmt(ctx.loan)} = ?`,
+      `${fmt(ctx.totalPaid)} − ${fmt(ctx.loan)} = <b>${fmt(ctx.overpaid)}</b> CZK.`,
+    ], explain: `<b>${fmt(ctx.overpaid)} CZK</b> in interest over 30 years — nearly as much as the principal itself! That's the cost of borrowing money for 30 years.` }),
+    /* 5 decision */ () => ({ q: 'Your mortgage strategy:', options: [
+      { title: 'Take max LTV (90%) to avoid saving too much', kind: 'bad', feedback: 'Risky. Lower down payment = higher interest rate + greater risk if property value falls. Bigger loan = bigger total overpayment.' },
+      { title: 'Save up to 20% down payment (LTV 80%), then get mortgage', kind: 'good', feedback: 'Best. The bank gives you a better rate, you have less risk and pay less overall. It takes longer, but it pays off financially.' },
+      { title: 'Avoid mortgage completely, rent forever', kind: 'meh', feedback: 'Possible, but over 30 years you\'ll pay roughly as much in rent as in a mortgage — and have nothing to show for it. A mortgage is often better long-term.' },
+      { title: 'Take the mortgage and make overpayments straight away', kind: 'good', feedback: 'Excellent! Overpayments significantly reduce the total interest paid. Just watch the fixed-rate period conditions — there can be early repayment fees.' },
+    ]}),
+    /* 6 story */ () => ({ icon: '🎯', html: `
+      <p>Three things to know before a mortgage:</p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.7;">
+        <li><b>LTV</b> = how much of the price the bank lends. Lower LTV = better rate.</li>
+        <li><b>Fixed-rate period</b> (3, 5, 10 years) = how long the rate is locked. Recalculated after.</li>
+        <li><b>Overpayment</b> = you can repay more at once (sometimes with a fee).</li>
+      </ul>
+      <div class="fact-box">📘 <b>Rule:</b> a mortgage is the biggest loan in your life. Negotiating a rate <b>0.3% lower</b> with the bank can save you hundreds of thousands over 30 years. It's worth checking twice.</div>
+      <p>Next chapter: <b>predatory lending</b> — how debt spirals into enforcement proceedings.</p>
+    `}),
+  ],
+
+  6: [
+    /* 0 story */ ctx => ({ icon: '⚠️', html: `
+      <p>Your friend Tereza calls. <i>"I need ${fmt(ctx.jistina)} CZK within three days. Car in the garage, invoice due. Bank says 'no product for me' — I'm on a part-time contract. I keep seeing ads for 'loans in 15 minutes, no income proof'..."</i></p>
+      <p>You go look at it with her. The website looks cheerful, animations of smiling people. The tiny print at the very bottom says:</p>
+      <div class="calc-box">Principal: ${fmt(ctx.jistina)} CZK
+Payment: ${fmt(ctx.monthly)} CZK/month for 36 months
+APR: 74.9%
+Penalty for late payment: 1,000 CZK
+After 30 days in arrears: full acceleration + enforcement</div>
+      <div class="fact-box">⚠️ <b>74.9% APR</b> is not yet illegal in the Czech Republic (no legal cap), but it's a <b>typical predatory rate</b>. A bank consumer loan is 7–13%. Here you'd pay 10× as much.</div>
+    `}),
+    /* 1 math */ ctx => ({ q: `How much will Tereza pay <b>in total</b> if she pays every instalment on time?`, unit: 'CZK', answer: ctx.total, hints: [
+      'Payment × number of months.',
+      `${fmt(ctx.monthly)} × 36 = ?`,
+      `${fmt(ctx.monthly)} × 36 = <b>${fmt(ctx.total)}</b> CZK.`,
+    ], explain: `${fmt(ctx.monthly)} × 36 = <b>${fmt(ctx.total)} CZK</b>. For a ${fmt(ctx.jistina)} CZK loan.` }),
+    /* 2 math */ ctx => ({ q: `What is the <b>overpayment</b> above the original principal of ${fmt(ctx.jistina)} CZK?`, unit: 'CZK', answer: ctx.overpay, hints: [
+      'Difference between total paid and the amount borrowed.',
+      `${fmt(ctx.total)} − ${fmt(ctx.jistina)} = ?`,
+      `${fmt(ctx.total)} − ${fmt(ctx.jistina)} = <b>${fmt(ctx.overpay)}</b> CZK.`,
+    ], explain: `<b>${fmt(ctx.overpay)} CZK overpayment</b> — about <b>3× the amount borrowed</b>. And that's the <i>best-case</i> scenario (all paid on time).` }),
+    /* 3 story */ ctx => ({ icon: '🔥', html: `
+      <p>Six months later comes bad news. Tereza was made redundant, two instalments missed. <b>What happens:</b></p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.7;">
+        <li><b>① Contractual penalty</b> 1,000 CZK for each late payment</li>
+        <li><b>② Default interest</b> (statutory, on top of the original interest)</li>
+        <li><b>③ Acceleration</b> — creditor demands the entire remaining balance at once</li>
+        <li><b>④ Lawsuit and enforcement</b> — bailiff attaches the car, wages</li>
+        <li><b>⑤ Enforcement costs</b> 10–20k extra</li>
+      </ul>
+      <div class="fact-box">⚠️ <b>Tereza borrowed ${fmt(ctx.jistina)} CZK. After a year of non-payment the debt can exceed ${fmt(ctx.penalty)} CZK.</b> Debt grows exponentially. This is a <b>debt trap</b> — even if she wanted to, she can't pay it back because every month the debt grows faster than she can earn.</div>
+    `}),
+    /* 4 decision */ () => ({ q: 'What do you advise Tereza?', options: [
+      { title: 'Lend her the money from me/family to pay it all off now', kind: 'meh', feedback: 'Noble, but 1) you may not have it, 2) you\'re transferring her problem to yourself. If you decide to help, pay the creditor directly, and agree on repayment instalments.' },
+      { title: 'Go immediately to a <b>free debt advice charity</b>', kind: 'good', feedback: 'Best option. Charities help with acceleration, negotiating with creditors, and even <b>personal insolvency</b>. It\'s not shameful — debt traps affect hundreds of thousands of people.' },
+      { title: 'Take out another quick loan to pay off the first one', kind: 'bad', feedback: 'Classic spiral. The second loan will be even more expensive and the first penalties keep running. This only deepens the debt trap.' },
+      { title: 'Ignore it — it\'ll sort itself out', kind: 'bad', feedback: 'Worst option. Without action a lawsuit and enforcement will follow. Early communication with the creditor or a charity is the only way out.' },
+    ]}),
+    /* 5 story */ () => ({ icon: '🎯', html: `
+      <p>Rules for when someone close to you says "I urgently need money":</p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.7;">
+        <li><b>① Never a "quick loan".</b> APR above 30% = trap. Always prefer bank, credit card, family — in that order.</li>
+        <li><b>② Free debt advice charities exist.</b> They all help for free.</li>
+        <li><b>③ Personal insolvency</b> is a legal way out of a debt trap. It takes 3–5 years, but you start with a clean slate.</li>
+        <li><b>④ Communicate with the creditor.</b> Even predatory ones sometimes agree to a repayment plan — they know enforcement yields less.</li>
+      </ul>
+      <p>Next chapter: <b>cyber fraud</b> — how money disappears through a screen.</p>
+    `}),
+  ],
+
+  7: [
+    /* 0 story */ () => ({ icon: '🎣', html: `
+      <p>You open the news in the morning. Headline: <i>"Czechs lost billions to cyber fraud last year. Most common: fake Czech Post SMS and bank phishing."</i></p>
+      <div class="fact-box">📊 <b>Reality:</b> Police statistics show <b>tens of thousands of victims per year</b>. Average loss per person is <b>≈ 30,000 CZK</b>, but record cases exceeded one million. The vast majority begin with <b>a single click</b> on a suspicious link.</div>
+      <p>Let's try 4 real scenarios — can you spot the fraud?</p>
+    `}),
+    /* 1 decision */ () => ({ q: '📱 You receive an SMS: <i>"Czech Post: Your parcel is awaiting a customs fee of 30 CZK. Pay here: ceska-posta.cz.balik-id4729.com/pay"</i>. What do you do?', options: [
+      { title: 'Click — 30 CZK is a small amount, I want my parcel', kind: 'bad', feedback: `<b>Classic phishing.</b> After clicking, the page asks for your card. Instead of 30 CZK they drain everything they can. Watch the <b>domain</b>: the real one is <b>ceskaposta.cz</b>, not <b>ceska-posta.cz.balik-id4729.com</b> (the real domain here is the last <i>.com</i>!). The real Czech Post never asks for customs payment via a link in an SMS.` },
+      { title: 'Open the real ceskaposta.cz website and check parcel tracking', kind: 'good', feedback: 'Correct. Rule: <b>never click</b> links in SMS/emails. Always go directly to the official website via your browser. If the parcel exists, you\'ll find it there.' },
+      { title: 'Call the number in the SMS', kind: 'bad', feedback: 'Also a trap. The number in the SMS connects to fraudsters posing as the post office who extract your details. Always use <b>official numbers</b> from the provider\'s website.' },
+      { title: 'Delete and ignore', kind: 'good', feedback: 'Safe. If a parcel was expected, the notification will arrive via an official channel (email from the official domain or a paper card).' },
+    ]}),
+    /* 2 decision */ () => ({ q: '📧 Email: <i>"CONGRATULATIONS! You have been selected as our thousandth customer. You\'ve won an iPhone 15 Pro Max. Claim your prize here and pay only the postage of 99 CZK."</i> Looks like it\'s from a major retailer.', options: [
+      { title: 'Great, I\'ll fill in my details and pay 99 CZK', kind: 'bad', feedback: `<b>Fake prize</b> — one of the oldest fraud tactics. After entering your card they charge recurring fees (e.g. 500 CZK/week "subscription"). Rule: <b>prizes you didn't enter for don't exist.</b> Genuine competitions never require payment.` },
+      { title: 'Forward the link to the retailer so they can check it', kind: 'good', feedback: 'Good response. Major retailers have a security or phishing reporting email. You help others by reporting the fraud.' },
+      { title: 'Delete it — it\'s obviously a scam', kind: 'good', feedback: 'Correct. If you\'re in doubt — prizes you don\'t know about, or "you\'re our thousandth customer", are almost always fraud.' },
+      { title: 'Forward the link to friends so they can see it', kind: 'meh', feedback: 'Better not. Some friends might click without realising it\'s fraud. Warn them with words, not the link.' },
+    ]}),
+    /* 3 decision */ () => ({ q: '🛒 You see a social media ad: <i>"Apple-outlet.sale — iPhone 15 for £499, tonight only!"</i>. The website looks very similar to the real Apple store. What do you do?', options: [
+      { title: 'Buy it — great price', kind: 'bad', feedback: `<b>Fake shop.</b> The domain is not the real Apple store. After payment nothing arrives. Rule: <b>price significantly below market = fraud</b>. Real sales are at most 20–30% off, not 70%.` },
+      { title: 'Find the same phone on the real apple.com and compare', kind: 'good', feedback: 'Well done. If apple.com doesn\'t have that deal, it\'s fake. Always verify via the <b>official domain</b>, not via a link in an ad.' },
+      { title: 'Check reviews and company registration (who runs the shop)', kind: 'good', feedback: 'Professional approach. Company registries tell you who is behind the business — fake shops are often not registered. Google reviews help too.' },
+      { title: 'Ignore it — something looks off', kind: 'good', feedback: 'Safe. Rule: if the price looks too good to be true — it isn\'t true.' },
+    ]}),
+    /* 4 decision */ () => ({ q: '☎️ You get a call from someone with an accent: <i>"Good day, I\'m calling from your bank. A suspicious transaction is leaving your account. To block it, please read me the verification SMS we\'ll send you."</i>', options: [
+      { title: 'I dictate it — they\'re supposed to block it for me', kind: 'bad', feedback: `<b>Total fraud (vishing).</b> Your bank will <b>NEVER</b> ask for a verification SMS code over the phone. That code <b>authorises a payment</b> — by dictating it you give the fraudster permission to transfer your money. Result: immediate loss of your entire balance.` },
+      { title: 'Hang up and call the number on the bank\'s website myself', kind: 'good', feedback: 'Exactly right. <b>Banks never call about SMS codes.</b> If suspicious, hang up and call the <b>official line</b> (on the bank\'s website or from your card). They\'ll confirm whether anything was actually suspicious.' },
+      { title: 'Say I\'ll call back, and check via the bank\'s app', kind: 'good', feedback: 'Safe. The bank app shows real account activity. If nothing suspicious appears, it was fraud.' },
+      { title: 'Dictate only half the code so they can\'t get me completely', kind: 'bad', feedback: 'Even "just half" is often enough — they combine it with a follow-up call. Most importantly: a legitimate bank employee will never ask for any code.' },
+    ]}),
+    /* 5 story */ () => ({ icon: '🛡️', html: `
+      <p>Universal rules that protect against most fraud:</p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.7;">
+        <li><b>① Never click links in SMS/emails.</b> Always go to the official site manually via your browser.</li>
+        <li><b>② Banks never ask for passwords or SMS codes over the phone.</b> Nor does the police. Nor Microsoft.</li>
+        <li><b>③ Too-good price / prize / offer = fraud.</b> Always check the domain (not just "contains the brand name").</li>
+        <li><b>④ If you paid a fraudster by card, immediately call the bank and dispute the transaction.</b> Sometimes it can still be recovered.</li>
+      </ul>
+      <div class="fact-box">🔗 Your bank has a <b>24/7 fraud line</b>. The police have an online fraud reporting page. Always report — it helps protect others too.</div>
+      <p>Final chapter: <b>certificate</b> — what you take away from the 7 chapters.</p>
+    `}),
+  ],
+
+  8: [
+    /* 0 story */ () => ({ icon: '🎓', html: `
+      <p>Congratulations — you've completed the entire Money Journey. Let's take two minutes to review what you've learned.</p>
+      <h3 style="font-family:var(--sans);font-weight:700;font-size:1rem;margin:14px 0 8px;color:var(--act2-fg);">7 rules of financial literacy</h3>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.75;">
+        <li><b>① Gross ≠ net.</b> The state takes ≈ 18–22% of your gross salary (income tax 15% + social 7.1% + health 4.5%, minus personal credit 2,570 CZK/month).</li>
+        <li><b>② Keep a 3–6 month expense buffer.</b> Without it, any loss forces you to borrow.</li>
+        <li><b>③ Cash loses value.</b> Inflation 5–8% per year. A savings account slows the loss; investments beat it.</li>
+        <li><b>④ Compare loans by APR</b>, not monthly payment. Bank 7–13%, "instant" 30%+ = trap.</li>
+        <li><b>⑤ Mortgage:</b> lower LTV (bigger down payment) = better rate. Overpayments save huge sums.</li>
+        <li><b>⑥ Debt traps exist.</b> Free debt advice charities help at no cost.</li>
+        <li><b>⑦ Banks NEVER</b> ask for passwords or SMS codes over the phone. Click only the official domain, never via a link in an SMS.</li>
+      </ul>
+    `}),
+    /* 1 story */ () => ({ icon: '🔗', html: `
+      <p>Where to continue if financial literacy interests you:</p>
+      <ul style="margin:8px 0 8px 20px;font-size:.95rem;line-height:1.75;">
+        <li><b>Your national financial regulator</b> — official information about consumer credit, mortgages, investments.</li>
+        <li><b>MoneySavingExpert.com</b> — practical UK-focused money advice.</li>
+        <li><b>Khan Academy — Personal Finance</b> — free video courses covering budgeting, loans, investing.</li>
+        <li><b>Your bank's financial literacy resources</b> — most major banks publish free guides.</li>
+      </ul>
+      <p>When you click <b>Continue →</b> you'll receive your <b>certificate</b>. You can enter your name and print or screenshot it.</p>
+    `}),
+  ],
+
+};
+
 /* ────────── NAVIGACE ────────── */
 
 function showScreen(id) {
@@ -1498,13 +1960,16 @@ function renderHub() {
     const done = STATE.done.includes(act.id);
     const tile = document.createElement('button');
     tile.className = `hub-tile act${act.id} ${!unlocked ? 'locked' : ''} ${done ? 'done' : ''}`;
+    const enMeta = ACT_EN_META[act.id];
+    const title = i18n(act.title, enMeta?.title || act.title);
+    const age   = i18n(act.age,   enMeta?.age   || act.age);
     tile.innerHTML = `
       <div>
-        <div class="hub-num">Kapitola ${act.id}</div>
+        <div class="hub-num">${i18n('Kapitola', 'Chapter')} ${act.id}</div>
         <div class="hub-icon">${act.icon}</div>
-        <div class="hub-title">${act.title}</div>
+        <div class="hub-title">${title}</div>
       </div>
-      <div class="hub-age">${act.age}</div>
+      <div class="hub-age">${age}</div>
     `;
     if (unlocked) tile.addEventListener('click', () => startAct(act.id));
     else tile.disabled = true;
@@ -1512,6 +1977,12 @@ function renderHub() {
   }
   const sc = totalScore();
   document.getElementById('hub-coins').textContent = `${sc.earned}/${sc.max} ⭐`;
+  const hubTitle = document.getElementById('hub-title');
+  if (hubTitle) hubTitle.textContent = i18n('Mapa cesty', 'Journey Map');
+  const hubSub = document.getElementById('hub-subtitle');
+  if (hubSub) hubSub.textContent = i18n('Kapitoly se odemykají postupně. Klikni na první bez zámku.', 'Chapters unlock in order. Click the first unlocked one.');
+  const codeHub = document.getElementById('code-apply-hub');
+  if (codeHub) codeHub.textContent = i18n('Použít', 'Apply');
 }
 
 /* ────────── PŘEHRÁVÁNÍ ────────── */
@@ -1527,9 +1998,10 @@ function startAct(id) {
   activeCtx = activeAct.setup ? activeAct.setup() : {};
   sceneIdx = 0;
   actScore = { earned: 0, max: 0 };
-  document.getElementById('act-title').textContent = activeAct.title;
+  const enMeta = ACT_EN_META[activeAct.id];
+  document.getElementById('act-title').textContent = i18n(activeAct.title, enMeta?.title || activeAct.title);
   const badge = document.getElementById('act-badge');
-  badge.textContent = `Kapitola ${activeAct.id} · ${activeAct.age}`;
+  badge.textContent = `${i18n('Kapitola', 'Chapter')} ${activeAct.id} · ${i18n(activeAct.age, enMeta?.age || activeAct.age)}`;
   badge.className = `badge ${activeAct.color}`;
   showScreen('act');
   renderScene();
@@ -1538,8 +2010,11 @@ function startAct(id) {
 function renderScene() {
   const scenes = activeAct.scenes;
   const s = scenes[sceneIdx];
-  const content = s.build ? s.build(activeCtx) : s;
-  document.getElementById('act-progress').textContent = `Scéna ${sceneIdx+1} / ${scenes.length}`;
+  // Resolve content: check BUILD_EN lookup, then s.build_en, then s.build
+  const enBuild = lang === 'en' && BUILD_EN[activeAct.id]?.[sceneIdx];
+  const builder = enBuild || (lang === 'en' && s.build_en ? s.build_en : s.build);
+  const content = builder ? builder(activeCtx) : s;
+  document.getElementById('act-progress').textContent = i18n(`Scéna ${sceneIdx+1} / ${scenes.length}`, `Scene ${sceneIdx+1} / ${scenes.length}`);
   document.getElementById('act-coins').textContent = `${actScore.earned}/${actScore.max} ⭐`;
   const cont = document.getElementById('scene-container');
   cont.innerHTML = '';
@@ -1550,7 +2025,7 @@ function renderScene() {
         ${content.icon ? `<span class="scene-icon">${content.icon}</span>` : ''}
         ${content.html}
         <div class="btn-row">
-          <button class="btn-primary" id="btn-continue">Pokračovat →</button>
+          <button class="btn-primary" id="btn-continue">${i18n('Pokračovat →', 'Continue →')}</button>
         </div>
       </div>
     `;
@@ -1560,16 +2035,17 @@ function renderScene() {
   else if (s.type === 'math') {
     actScore.max += 1;
     hintLevel = 0;
+    const unitLabel = content.unit ? (lang === 'en' ? 'CZK' : content.unit) : '';
     cont.innerHTML = `
       <div class="scene ${activeAct.color}">
         <div class="math-q">${content.q}</div>
         <div class="input-row">
           <input class="answer" id="m-ans" type="number" inputmode="numeric" placeholder="?" autocomplete="off" autofocus>
-          ${content.unit ? `<span class="unit">${content.unit}</span>` : ''}
-          <button class="btn-check" id="m-check">Zkontrolovat</button>
+          ${unitLabel ? `<span class="unit">${unitLabel}</span>` : ''}
+          <button class="btn-check" id="m-check">${i18n('Zkontrolovat', 'Check')}</button>
         </div>
         <div class="hint-bar">
-          <button class="hint-btn" id="m-hint-btn">💡 Nápověda 1/3</button>
+          <button class="hint-btn" id="m-hint-btn">&#x1F4A1; ${i18n('Nápověda 1/3', 'Hint 1/3')}</button>
           <span class="hint-counter" id="m-hint-counter">
             <span class="dot"></span><span class="dot"></span><span class="dot"></span>
           </span>
@@ -1617,18 +2093,18 @@ function advanceHint(content) {
   const counter = document.getElementById('m-hint-counter');
   box.classList.add('show');
   box.dataset.level = hintLevel;
-  const labels = ['Nasměrování', 'Vzorec', 'Postup s výsledkem'];
-  box.innerHTML = `<span class="h-label">Nápověda ${hintLevel}/3 — ${labels[hintLevel-1]}</span>${content.hints[hintLevel - 1]}`;
+  const labels = i18n(['Nasměrování', 'Vzorec', 'Postup s výsledkem'], ['Direction', 'Formula', 'Solution steps']);
+  box.innerHTML = `<span class="h-label">${i18n('Nápověda', 'Hint')} ${hintLevel}/3 — ${labels[hintLevel-1]}</span>${content.hints[hintLevel - 1]}`;
   const dots = counter.querySelectorAll('.dot');
   dots.forEach((d, i) => {
     d.classList.toggle('shown', i < hintLevel);
     if (i === 2 && hintLevel === 3) d.classList.add('warn');
   });
   if (hintLevel < 3) {
-    btn.textContent = `💡 Další nápověda ${hintLevel+1}/3`;
+    btn.textContent = `💡 ${i18n('Další nápověda', 'Next hint')} ${hintLevel+1}/3`;
   } else {
     btn.disabled = true;
-    btn.textContent = '💡 Všechny nápovědy ukázány';
+    btn.textContent = `💡 ${i18n('Všechny nápovědy ukázány', 'All hints shown')}`;
   }
 }
 
@@ -1643,15 +2119,16 @@ function checkMath(content) {
   const val = Number(raw);
   const correct = val === content.answer;
   inp.disabled = true; btn.disabled = true;
+  const unitLabel = content.unit ? (lang === 'en' ? ' CZK' : ' ' + content.unit) : '';
   if (correct) {
     actScore.earned += 1;
     inp.classList.add('correct');
     fb.className = 'feedback ok show';
-    fb.innerHTML = `<strong>✓ Správně!</strong> ${content.explain || ''} <div class="btn-row"><button class="btn-primary" id="m-next">Pokračovat →</button></div>`;
+    fb.innerHTML = `<strong>&#x2713; ${i18n('Správně!', 'Correct!')}</strong> ${content.explain || ''} <div class="btn-row"><button class="btn-primary" id="m-next">${i18n('Pokračovat →', 'Continue →')}</button></div>`;
   } else {
     inp.classList.add('wrong');
     fb.className = 'feedback err show';
-    fb.innerHTML = `<strong>✗ Bohužel.</strong> Správně je <b>${fmt(content.answer)}${content.unit ? ' ' + content.unit : ''}</b>. ${content.explain || ''} <div class="btn-row"><button class="btn-primary" id="m-next">Pokračovat →</button></div>`;
+    fb.innerHTML = `<strong>&#x2717; ${i18n('Bohužel.', 'Not quite.')}</strong> ${i18n('Správně je', 'Correct answer:')} <b>${fmt(content.answer)}${unitLabel}</b>. ${content.explain || ''} <div class="btn-row"><button class="btn-primary" id="m-next">${i18n('Pokračovat →', 'Continue →')}</button></div>`;
   }
   document.getElementById('act-coins').textContent = `${actScore.earned}/${actScore.max} ⭐`;
   document.getElementById('m-next').addEventListener('click', nextScene);
@@ -1668,7 +2145,12 @@ function chooseDecision(content, i) {
   if (opt.kind === 'good') actScore.earned += 1;
   else if (opt.kind === 'meh') actScore.earned += 0.5;
   fb.className = `feedback ${opt.kind === 'good' ? 'ok' : opt.kind === 'bad' ? 'err' : 'info'} show`;
-  fb.innerHTML = `<strong>${opt.kind === 'good' ? '✓ Dobrá volba' : opt.kind === 'meh' ? '~ Spíš obstojné' : '✗ Riskantní'}</strong> — ${opt.feedback} <div class="btn-row"><button class="btn-primary" id="d-next">Pokračovat →</button></div>`;
+  const decLabel = opt.kind === 'good'
+    ? i18n('✓ Dobrá volba', '✓ Good choice')
+    : opt.kind === 'meh'
+    ? i18n('~ Spíš obstojné', '~ Fairly reasonable')
+    : i18n('✗ Riskantní', '✗ Risky');
+  fb.innerHTML = `<strong>${decLabel}</strong> — ${opt.feedback} <div class="btn-row"><button class="btn-primary" id="d-next">${i18n('Pokračovat →', 'Continue →')}</button></div>`;
   document.getElementById('act-coins').textContent = `${actScore.earned}/${actScore.max} ⭐`;
   document.getElementById('d-next').addEventListener('click', nextScene);
   document.getElementById('d-next').focus();
@@ -1699,18 +2181,18 @@ function showActComplete() {
   const cont = document.getElementById('scene-container');
   cont.innerHTML = `
     <div class="scene ${activeAct.color}" style="text-align:center;">
-      <div class="scene-icon" style="font-size:3rem;">🎉</div>
-      <h2 style="font-size:1.4rem; margin-bottom:8px;">Kapitola ${activeAct.id} hotová!</h2>
-      <p>Skóre: <b>${actScore.earned} / ${actScore.max} ⭐</b></p>
+      <div class="scene-icon" style="font-size:3rem;">&#x1F389;</div>
+      <h2 style="font-size:1.4rem; margin-bottom:8px;">${i18n('Kapitola', 'Chapter')} ${activeAct.id} ${i18n('hotová!', 'done!')}</h2>
+      <p>${i18n('Skóre:', 'Score:')} <b>${actScore.earned} / ${actScore.max} ⭐</b></p>
       ${code ? `
         <div class="code-reveal">
-          <p class="code-label">🔑 Kód pro Kapitolu ${nextId}:</p>
+          <p class="code-label">&#x1F511; ${i18n(`Kód pro Kapitolu ${nextId}:`, `Code for Chapter ${nextId}:`)}</p>
           <code class="code-value">${code}</code>
-          <p class="code-hint">Zapiš si ho. Jakmile přijdeš k jinému počítači, zadáš ho na úvodní obrazovce a pokračuješ rovnou z téhle kapitoly.</p>
+          <p class="code-hint">${i18n('Zapiš si ho. Jakmile přijdeš k jinému počítači, zadáš ho na úvodní obrazovce a pokračuješ rovnou z téhle kapitoly.', 'Write it down. On a different computer, enter it on the intro screen to jump straight to this chapter.')}</p>
         </div>
       ` : ''}
       <div class="btn-row" style="justify-content:center;">
-        <button class="btn-primary" id="btn-to-hub">Mapa →</button>
+        <button class="btn-primary" id="btn-to-hub">${i18n('Mapa →', 'Map →')}</button>
       </div>
     </div>
   `;
@@ -1743,12 +2225,12 @@ function applyCode(raw, fbEl) {
     if (!STATE.unlocked.includes(foundId)) STATE.unlocked.push(foundId);
     saveState();
     fbEl.className = 'code-feedback ok';
-    fbEl.innerHTML = `✓ Kód platí! Odemkl jsi přístup ke <b>Kapitole ${foundId}</b>. Otvírám mapu…`;
+    fbEl.innerHTML = i18n(`✓ Kód platí! Odemkl jsi přístup ke <b>Kapitole ${foundId}</b>. Otvírám mapu…`, `✓ Valid code! Unlocked access to <b>Chapter ${foundId}</b>. Opening map…`);
     renderHub();
     setTimeout(() => showScreen('hub'), 900);
   } else {
     fbEl.className = 'code-feedback err';
-    fbEl.textContent = '✗ Tento kód nesedí. Zkontroluj překlepy (vše malými písmeny, bez mezer).';
+    fbEl.textContent = i18n('✗ Tento kód nesedí. Zkontroluj překlepy (vše malými písmeny, bez mezer).', '✗ This code doesn\'t match. Check for typos (all lowercase, no spaces).');
   }
 }
 
@@ -1761,54 +2243,35 @@ function bindCodeInput(inputId, btnId, fbId) {
   btn.addEventListener('click', submit);
   inp.addEventListener('keydown', e => { if (e.key === 'Enter') submit(); });
 }
-bindCodeInput('code-input-intro', 'code-apply-intro', 'code-feedback-intro');
-bindCodeInput('code-input-hub', 'code-apply-hub', 'code-feedback-hub');
+// code-input-intro is bound in buildIntro(); hub binding done in wire-up section
 
 function showResult() {
-  const sc = totalScore();
-  document.getElementById('cert-score').textContent = `${sc.earned} / ${sc.max} ⭐`;
-  const pct = sc.max ? Math.round((sc.earned / sc.max) * 100) : 0;
-  let msg = 'Prošel jsi celou Cestu peněz! Hodně teoretických základů máš.';
-  if (pct >= 90) msg = '🏆 Mistr finanční gramotnosti! Skvělé výsledky napříč všemi kapitolami.';
-  else if (pct >= 70) msg = '🎉 Velmi solidní výsledek. Pár věcí si ještě můžeš zopakovat — koukni do scén, kde jsi měl chybu.';
-  else if (pct >= 50) msg = '👍 Základ máš. Doporučuju projít znovu kapitoly, kde jsi měl skóre nízké.';
-  else msg = '📚 Začátek je tu — opakování je matkou moudrosti. Klikni na "Začít znovu" a zkus to ještě jednou.';
-  document.getElementById('cert-msg').textContent = msg;
-
-  // Jméno na osvědčení — uloží se do localStorage a aktualizuje živě
-  const nameInp = document.getElementById('cert-name-input');
-  const nameDisp = document.getElementById('cert-name-display');
-  const defaultName = 'Tomu, kdo prošel <i>Cestu peněz</i>';
-  const savedName = STATE.studentName || '';
-  nameInp.value = savedName;
-  nameDisp.innerHTML = savedName ? savedName : defaultName;
-  nameInp.oninput = () => {
-    const v = nameInp.value.trim();
-    STATE.studentName = v;
-    nameDisp.innerHTML = v ? v : defaultName;
-    saveState();
-  };
-
   showScreen('result');
+  buildResult();
 }
 
 /* ────────── WIRE UP ────────── */
 
-document.getElementById('btn-go-hub').addEventListener('click', () => { renderHub(); showScreen('hub'); });
 document.getElementById('back-to-hub').addEventListener('click', () => { renderHub(); showScreen('hub'); });
 document.getElementById('result-to-hub').addEventListener('click', () => { renderHub(); showScreen('hub'); });
-document.getElementById('result-restart').addEventListener('click', () => {
-  if (confirm('Začít cestu znovu? Smaže to tvůj postup.')) {
-    resetState(); renderHub(); showScreen('intro');
-  }
-});
 document.getElementById('reset-link').addEventListener('click', () => {
-  if (confirm('Smazat všechen postup? Tohle nelze vrátit.')) {
+  if (confirm(i18n('Smazat všechen postup? Tohle nelze vrátit.', 'Delete all progress? This cannot be undone.'))) {
     resetState(); renderHub();
   }
 });
+bindCodeInput('code-input-hub', 'code-apply-hub', 'code-feedback-hub');
 
 loadState();
+
+// Init lang bar
+document.querySelectorAll('.lang-btn').forEach(b =>
+  b.classList.toggle('active', b.dataset.lang === lang));
+document.querySelectorAll('.tp-back').forEach(el =>
+  el.textContent = i18n('← zpět na projekty', '← back to projects'));
+document.querySelectorAll('.tp-home').forEach(el =>
+  el.textContent = i18n('domů', 'home'));
+
+buildIntro();
 renderHub();
 </script>
 </body>

--- a/projects/index.html
+++ b/projects/index.html
@@ -218,7 +218,6 @@
               <span class="perm">drwxr-xr-x</span>
               <a class="filename" href="./prijimacky-matematika/">prijimacky-matematika/</a>
             </div>
-            <p class="desc-en">CERMAT entrance-exam tests for 4-year secondary school programs, organised by year and term, with hand-annotated solutions.</p>
             <p class="desc-cs">Sbírka jednotných přijímacích testů z matematiky (CERMAT) pro 4leté obory SŠ, řazená po ročnících a termínech — s vlastnoručně dopsanými řešeními.</p>
             <p class="meta">tags: math · education · czech · pdf-archive · entrance-exams · sš</p>
           </div>

--- a/projects/unikovka_procenta.html
+++ b/projects/unikovka_procenta.html
@@ -198,36 +198,30 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 .top-bar a{color:var(--muted);text-decoration:none}
 .top-bar a:hover{color:var(--blue)}
 .top-bar .crumb{color:var(--text);font-weight:500}
+#lang-bar{position:fixed;bottom:16px;right:16px;z-index:200;display:flex;gap:6px}
+.lang-btn{background:#fff;border:1.5px solid #e0dbd0;border-radius:8px;
+  padding:4px 8px;font-size:1.1rem;cursor:pointer;transition:border-color .12s,box-shadow .12s;
+  line-height:1;box-shadow:0 1px 4px rgba(0,0,0,.08)}
+.lang-btn:hover{border-color:var(--blue);box-shadow:0 2px 8px rgba(26,115,200,.2)}
+.lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 </style>
 </head>
 <body>
 
+<div id="lang-bar">
+  <button class="lang-btn active" data-lang="cs" onclick="setLang('cs')">&#x1F1E8;&#x1F1FF;</button>
+  <button class="lang-btn" data-lang="en" onclick="setLang('en')">&#x1F1EC;&#x1F1E7;</button>
+</div>
+
 <div class="top-bar">
-  <a href="./">← zpět na projekty</a>
+  <a href="./" class="tp-back">&#8592; zpět na projekty</a>
   <span class="crumb">/projects/unikovka_procenta</span>
-  <a href="/">domů</a>
+  <a href="/" class="tp-home">domů</a>
 </div>
 
 <!-- INTRO -->
 <div id="intro" class="screen active">
-  <div class="chest">🏴‍☠️</div>
-  <div class="title-main">Únikovka z matiky</div>
-  <div class="title-sub">⚡ PROCENTA ⚡</div>
-  <div class="intro-card">
-    <p>Před tebou je <b>truhla s pokladem</b> – uzamčena <b>10 zámky</b>.</p>
-    <p>Každý zámek se odemkne správným kódem. Výpočty dělej <b>do sešitu</b>, kód zadej sem.</p>
-    <p>Žádné kalkulačky – dnes přijdeš na to, jak procenta fungují <b>vlastní hlavou</b> 🧠</p>
-  </div>
-  <div class="rules">
-    <h3>📋 Pravidla</h3>
-    <ul>
-      <li><span>✏️</span> Výpočty piš do sešitu – každý příklad celý.</li>
-      <li><span>🚫</span> Bez kalkulačky, bez opisování.</li>
-      <li><span>💡</span> Nevíš? Zkus nápovědu – ale nejdřív se zamysli!</li>
-      <li><span>🔢</span> Kód zadej jako číslo (bez mezer, bez %).</li>
-    </ul>
-  </div>
-  <button class="btn-primary" id="btn-start">🔓 Začít dobrodružství!</button>
+  <div id="intro-content"></div>
 </div>
 
 <!-- GAME -->
@@ -245,176 +239,270 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 <!-- FINISH -->
 <div id="finish" class="screen">
   <div class="confetti-wrap" id="confetti"></div>
-  <div class="final-chest">🏆</div>
-  <div class="final-title">Poklad je tvůj!</div>
-  <p class="final-sub">Zvládl(a) jsi všech 10 zámků a pronikl(a) do tajemství procent. Gratulace!</p>
-  <div class="summary-card">
-    <h3>📖 Co jsi dnes objevil(a)</h3>
-    <div class="summary-row"><span class="s-icon">1️⃣</span><span>1 % = 1 setina celku = základ ÷ 100</span></div>
-    <div class="summary-row"><span class="s-icon">2️⃣</span><span>n % ze základu = (základ ÷ 100) × n</span></div>
-    <div class="summary-row"><span class="s-icon">3️⃣</span><span>Procento = zlomek = desetinné číslo (25 % = 25/100 = 0,25)</span></div>
-    <div class="summary-row"><span class="s-icon">4️⃣</span><span>Kolik procent? → část ÷ celek × 100</span></div>
-  </div>
-  <button class="btn-primary" id="btn-restart">🔄 Hrát znovu</button>
+  <div id="finish-content"></div>
 </div>
 
 <script>
-// Veškerý český text je přímo v UTF-8 – žádné HTML entity
+/* ─── i18n ───────────────────────────────────────────────────────────── */
+const LANG_KEY = 'unikovka_procenta_lang';
+let lang = localStorage.getItem(LANG_KEY) || 'cs';
+const i18n = (cs, en) => lang === 'en' ? en : cs;
+
+function setLang(l) {
+  lang = l;
+  try { localStorage.setItem(LANG_KEY, l); } catch(e) {}
+  document.querySelectorAll('.lang-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.lang === l));
+  document.querySelectorAll('.tp-back').forEach(el =>
+    el.textContent = i18n('← zpět na projekty', '← back to projects'));
+  document.querySelectorAll('.tp-home').forEach(el =>
+    el.textContent = i18n('domů', 'home'));
+  const activeId = document.querySelector('.screen.active')?.id;
+  if (activeId === 'intro') buildIntro();
+  else if (activeId === 'game') render(cur);
+  else if (activeId === 'finish') buildFinish();
+}
+
+function buildIntro() {
+  document.getElementById('intro-content').innerHTML = `
+    <div class="chest">🏴‍☠️</div>
+    <div class="title-main">${i18n('Únikovka z matiky','Math Escape Room')}</div>
+    <div class="title-sub">⚡ ${i18n('PROCENTA','PERCENTAGES')} ⚡</div>
+    <div class="intro-card">
+      <p>${i18n('Před tebou je <b>truhla s pokladem</b> – uzamčena <b>10 zámky</b>.','Before you lies a <b>treasure chest</b> – locked with <b>10 locks</b>.')}</p>
+      <p>${i18n('Každý zámek se odemkne správným kódem. Výpočty dělej <b>do sešitu</b>, kód zadej sem.','Each lock opens with the correct code. Do your calculations <b>in a notebook</b>, then enter the code here.')}</p>
+      <p>${i18n('Žádné kalkulаčky – dnes přijd eš na to, jak procenta fungují <b>vlastní hlavou</b> 🧠','No calculators – today you\'ll figure out how percentages work <b>on your own</b> 🧠')}</p>
+    </div>
+    <div class="rules">
+      <h3>📋 ${i18n('Pravidla','Rules')}</h3>
+      <ul>
+        <li><span>✏️</span> ${i18n('Výpočty piš do sešitu – každý příklad celý.','Write your calculations in a notebook – show every step.')}</li>
+        <li><span>🚫</span> ${i18n('Bez kalkulаčky, bez opisování.','No calculator, no copying.')}</li>
+        <li><span>💡</span> ${i18n('Nevíš? Zkus nápovědu – ale nejdřív se zamysli!','Stuck? Try a hint – but think first!')}</li>
+        <li><span>🔢</span> ${i18n('Kód zadej jako číslo (bez mezer, bez %).','Enter the code as a number (no spaces, no %).')}</li>
+      </ul>
+    </div>
+    <button class="btn-primary" id="btn-start">${i18n('🔓 Začít dobrodružství!','🔓 Start the adventure!')}</button>
+  `;
+  document.getElementById('btn-start').addEventListener('click', startGame);
+}
+
+function buildFinish() {
+  document.getElementById('finish-content').innerHTML = `
+    <div class="final-chest">🏆</div>
+    <div class="final-title">${i18n('Poklad je tvůj!','The treasure is yours!')}</div>
+    <p class="final-sub">${i18n('Zvládl(a) jsi všech 10 zámků a pronikl(a) do tajemství procent. Gratulace!','You cracked all 10 locks and unlocked the secrets of percentages. Congratulations!')}</p>
+    <div class="summary-card">
+      <h3>📖 ${i18n('Co jsi dnes objevil(a)','What you discovered today')}</h3>
+      <div class="summary-row"><span class="s-icon">1️⃣</span><span>${i18n('1 % = 1 setina celku = základ ÷ 100','1% = 1 hundredth of the whole = base ÷ 100')}</span></div>
+      <div class="summary-row"><span class="s-icon">2️⃣</span><span>${i18n('n % ze základu = (základ ÷ 100) × n','n% of base = (base ÷ 100) × n')}</span></div>
+      <div class="summary-row"><span class="s-icon">3️⃣</span><span>${i18n('Procento = zlomek = desetinné číslo (25 % = 25/100 = 0,25)','Percent = fraction = decimal (25% = 25/100 = 0.25)')}</span></div>
+      <div class="summary-row"><span class="s-icon">4️⃣</span><span>${i18n('Kolik procent? → část ÷ celek × 100','How many percent? → part ÷ whole × 100')}</span></div>
+    </div>
+    <button class="btn-primary" id="btn-restart">${i18n('🔄 Hrát znovu','🔄 Play again')}</button>
+  `;
+  document.getElementById('btn-restart').addEventListener('click', () => location.reload());
+}
+
 const STEPS = [
 {
   id:1, color:'blue', icon:'🔵',
-  title:'Zámek 1 – Co je to 1 %?',
-  tag:'Definice procenta', tagClass:'blue',
+  title:'Zámek 1 – Co je to 1 %?', title_en:'Lock 1 – What is 1%?',
+  tag:'Definice procenta', tag_en:'Definition of percent', tagClass:'blue',
   tasks:[
-    { title:'🧩 Objev to sám(a)',
-      body:'<p>Máš celý koláč rozdělený na <b>100 stejně velkých dílků</b>. Jeden dílek = <b>1 %</b>.</p><p>Vypočítej <b>1 % z každého čísla</b>:</p><table class="tt"><tr><th>Základ</th><th>200</th><th>500</th><th>1 000</th><th>4 000</th><th>300</th></tr><tr><td><b>1 %</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
-      hint:'💡 Jakým číslem musíš dělit, aby ses dostal(a) na 1 setinu? Zkus číslo 100.' },
-    { title:'🔢 Kód zámku',
+    { title:'🧩 Objev to sám(a)', title_en:'🧩 Discover it yourself',
+      body:'<p>Máš celý koláč rozdělený na <b>100 stejně velkých dílků</b>. Jeden dílek = <b>1 %</b>.</p><p>Vypočítej <b>1 % z každého čísla</b>:</p><table class="tt"><tr><th>Základ</th><th>200</th><th>500</th><th>1 000</th><th>4 000</th><th>300</th></tr><tr><td><b>1 %</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      body_en:'<p>You have a whole pie divided into <b>100 equal pieces</b>. One piece = <b>1%</b>.</p><p>Calculate <b>1% of each number</b>:</p><table class="tt"><tr><th>Base</th><th>200</th><th>500</th><th>1 000</th><th>4 000</th><th>300</th></tr><tr><td><b>1%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      hint:'💡 Jakým číslem musíš dělit, aby ses dostal(a) na 1 setinu? Zkus číslo 100.',
+      hint_en:'💡 What number do you divide by to get one hundredth? Try 100.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Vypočítej <b>1 % ze 700</b>. Výsledek je tvůj kód.</p>',
-      hint:'💡 700 ÷ 100 = ?' }
+      body_en:'<p>Calculate <b>1% of 700</b>. The result is your code.</p>',
+      hint:'💡 700 ÷ 100 = ?', hint_en:'💡 700 ÷ 100 = ?' }
   ],
   code:'7',
-  successMsg:'🔓 Správně! 1 % = základ ÷ 100. Zámek 1 otevřen!'
+  successMsg:'🔓 Správně! 1 % = základ ÷ 100. Zámek 1 otevřen!',
+  successMsg_en:'🔓 Correct! 1% = base ÷ 100. Lock 1 opened!'
 },
 {
   id:2, color:'green', icon:'🟢',
-  title:'Zámek 2 – Víc než 1 %',
-  tag:'Výpočet procentové části', tagClass:'green',
+  title:'Zámek 2 – Víc než 1 %', title_en:'Lock 2 – More than 1%',
+  tag:'Výpočet procentové části', tag_en:'Calculating a percentage part', tagClass:'green',
   tasks:[
-    { title:'🧩 Jak spočítat více procent',
+    { title:'🧩 Jak spočítat více procent', title_en:'🧩 How to calculate more percent',
       body:'<p>Víš již, jak spočítat 1 %. Jak spočítat <b>n %</b>?</p><table class="tt"><tr><th>Příklad</th><th>1. krok: 1 %</th><th>2. krok: n %</th></tr><tr><td><b>3 % z 200</b></td><td>1 % = 2</td><td>3 % = ?</td></tr><tr><td><b>25 % z 400</b></td><td>1 % = 4</td><td>25 % = ?</td></tr><tr><td><b>10 % z 80</b></td><td>1 % = ?</td><td>10 % = ?</td></tr></table>',
-      hint:'💡 Máš-li 1 %, třikrát ho vynásobíš pro 3 %, dvacetpětkrát pro 25 %.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>You already know how to calculate 1%. How do you calculate <b>n%</b>?</p><table class="tt"><tr><th>Example</th><th>Step 1: 1%</th><th>Step 2: n%</th></tr><tr><td><b>3% of 200</b></td><td>1% = 2</td><td>3% = ?</td></tr><tr><td><b>25% of 400</b></td><td>1% = 4</td><td>25% = ?</td></tr><tr><td><b>10% of 80</b></td><td>1% = ?</td><td>10% = ?</td></tr></table>',
+      hint:'💡 Máš-li 1 %, třikrát ho vynásobíš pro 3 %, dvacetipětkrát pro 25 %.',
+      hint_en:'💡 If you have 1%, multiply it 3× for 3%, 25× for 25%.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>a) <b>5 % z 600</b> = ?</p><p>b) <b>20 % z 500</b> = ?</p><p>Kód = a + b</p>',
-      hint:'💡 a) 1 % ze 600 = 6, pak ×5. b) 1 % ze 500 = 5, pak ×20.' }
+      body_en:'<p>a) <b>5% of 600</b> = ?</p><p>b) <b>20% of 500</b> = ?</p><p>Code = a + b</p>',
+      hint:'💡 a) 1 % ze 600 = 6, pak ×5. b) 1 % ze 500 = 5, pak ×20.',
+      hint_en:'💡 a) 1% of 600 = 6, then ×5. b) 1% of 500 = 5, then ×20.' }
   ],
   code:'130',
-  successMsg:'🔓 Výborně! n % = 1 % × n. Zámek 2 otevřen!'
+  successMsg:'🔓 Výborně! n % = 1 % × n. Zámek 2 otevřen!',
+  successMsg_en:'🔓 Excellent! n% = 1% × n. Lock 2 opened!'
 },
 {
   id:3, color:'purple', icon:'🟣',
-  title:'Zámek 3 – Procenta zpaměti',
-  tag:'Počítání zpaměti', tagClass:'purple',
+  title:'Zámek 3 – Procenta zpaměti', title_en:'Lock 3 – Mental arithmetic',
+  tag:'Počítání zpaměti', tag_en:'Mental calculation', tagClass:'purple',
   tasks:[
-    { title:'🧩 Zpaměti!',
-      body:'<p>Vypočítej <b>zpaměti</b> a doplň tabulku:</p><table class="tt"><tr><th>Základ</th><th>300</th><th>250</th><th>4 000</th><th>600</th><th>500</th></tr><tr><td><b>1 %</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>10 %</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
-      hint:'💡 10 % = základ ÷ 10.' },
-    { title:'🔢 Kód zámku',
+    { title:'🧩 Zpaměti!', title_en:'🧩 In your head!',
+      body:'<p>Vypočítej <b>zpaměti</b> a doplň tabulku:</p><table class="tt"><tr><th>Základ</th><th>300</th><th>250</th><th>4 000</th><th>600</th><th>500</th></tr><tr><td><b>1 %</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>10 %</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      body_en:'<p>Calculate <b>mentally</b> and fill in the table:</p><table class="tt"><tr><th>Base</th><th>300</th><th>250</th><th>4 000</th><th>600</th><th>500</th></tr><tr><td><b>1%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>10%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      hint:'💡 10 % = základ ÷ 10.', hint_en:'💡 10% = base ÷ 10.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Vypočítej zpaměti:<br><b>2 % z 500</b> = a<br><b>50 % z 200</b> = b<br>Kód = a + b</p>',
-      hint:'💡 50 % = polovina celku.' }
+      body_en:'<p>Calculate mentally:<br><b>2% of 500</b> = a<br><b>50% of 200</b> = b<br>Code = a + b</p>',
+      hint:'💡 50 % = polovina celku.', hint_en:'💡 50% = half of the whole.' }
   ],
   code:'110',
-  successMsg:'🔓 Přesně! 10 + 100 = 110. Zámek 3 otevřen!'
+  successMsg:'🔓 Přesně! 10 + 100 = 110. Zámek 3 otevřen!',
+  successMsg_en:'🔓 Exactly! 10 + 100 = 110. Lock 3 opened!'
 },
 {
-  id:4, color:'teal', icon:'🩵',
-  title:'Zámek 4 – Tři zápisy',
-  tag:'Procento = zlomek = des. číslo', tagClass:'teal',
+  id:4, color:'teal', icon:'💙',
+  title:'Zámek 4 – Tři zápisy', title_en:'Lock 4 – Three notations',
+  tag:'Procento = zlomek = des. číslo', tag_en:'Percent = fraction = decimal', tagClass:'teal',
   tasks:[
-    { title:'🧩 Tři způsoby, jak zapsat totéž',
+    { title:'🧩 Tři způsoby, jak zapsat totéž', title_en:'🧩 Three ways to write the same thing',
       body:'<p>Vzor: <b>25 % = 25/100 = 0,25</b></p><table class="tt"><tr><th>Procenta</th><th>Zlomek</th><th>Des. číslo</th></tr><tr><td><b>50 %</b></td><td>50/100</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>7/100</td><td>0,07</td></tr><tr><td><b>3 %</b></td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>150 %</b></td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>200 %</b></td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
-      hint:'💡 Desetinné číslo: přesuň desetinnou čárku o 2 místa doleva. 150 % = 1,50.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>Example: <b>25% = 25/100 = 0.25</b></p><table class="tt"><tr><th>Percent</th><th>Fraction</th><th>Decimal</th></tr><tr><td><b>50%</b></td><td>50/100</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>7/100</td><td>0.07</td></tr><tr><td><b>3%</b></td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>150%</b></td><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td><b>200%</b></td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      hint:'💡 Desetinné číslo: přesunň desetinnou čárku o 2 místa doleva. 150 % = 1,50.',
+      hint_en:'💡 Decimal: move the decimal point 2 places left. 150% = 1.50.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Převeď na desetinné číslo:<br>a) <b>40 %</b> = ? &nbsp; b) <b>5 %</b> = ? &nbsp; c) <b>200 %</b> = ?</p><p>Kód = (a + b + c) × 100 &nbsp;(zadej jako celé číslo)</p>',
-      hint:'💡 40 % = 0,40; 5 % = 0,05; 200 % = 2,00. Součet = 2,45, pak ×100.' }
+      body_en:'<p>Convert to decimal:<br>a) <b>40%</b> = ? &nbsp; b) <b>5%</b> = ? &nbsp; c) <b>200%</b> = ?</p><p>Code = (a + b + c) × 100 &nbsp;(enter as whole number)</p>',
+      hint:'💡 40 % = 0,40; 5 % = 0,05; 200 % = 2,00. Součet = 2,45, pak ×100.',
+      hint_en:'💡 40%=0.40; 5%=0.05; 200%=2.00. Sum=2.45, then ×100.' }
   ],
   code:'245',
-  successMsg:'🔓 Správně! Součet 2,45 × 100 = 245. Zámek 4 otevřen!'
+  successMsg:'🔓 Správně! Součet 2,45 × 100 = 245. Zámek 4 otevřen!',
+  successMsg_en:'🔓 Correct! Sum 2.45 × 100 = 245. Lock 4 opened!'
 },
 {
   id:5, color:'orange', icon:'🟠',
-  title:'Zámek 5 – Zlomek → procento',
-  tag:'Převody zlomek → %', tagClass:'orange',
+  title:'Zámek 5 – Zlomek → procento', title_en:'Lock 5 – Fraction → percent',
+  tag:'Převody zlomek → %', tag_en:'Converting fraction → %', tagClass:'orange',
   tasks:[
-    { title:'🧩 Zlomek vyjádři v procentech',
+    { title:'🧩 Zlomek vyjádři v procentech', title_en:'🧩 Express a fraction as percent',
       body:'<p>Vzor: 31/100 = <b>31 %</b></p><p>Vypočítej:</p><table class="tt"><tr><th>Zlomek</th><th>64/100</th><th>125/100</th><th>24/100</th><th>350/100</th><th>4/100</th></tr><tr><td><b>%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
-      hint:'💡 Číslo v čitateli = počet procent.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>Example: 31/100 = <b>31%</b></p><p>Calculate:</p><table class="tt"><tr><th>Fraction</th><th>64/100</th><th>125/100</th><th>24/100</th><th>350/100</th><th>4/100</th></tr><tr><td><b>%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      hint:'💡 Číslo v čitateli = počet procent.',
+      hint_en:'💡 The numerator = the percentage.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Vyjádři v procentech:<br>a) <b>119/100</b> = ? &nbsp; b) <b>700/100</b> = ?</p><p>Kód = a + b</p>',
-      hint:'💡 119/100 = 119 %, 700/100 = 700 %.' }
+      body_en:'<p>Express as percent:<br>a) <b>119/100</b> = ? &nbsp; b) <b>700/100</b> = ?</p><p>Code = a + b</p>',
+      hint:'💡 119/100 = 119 %, 700/100 = 700 %.',
+      hint_en:'💡 119/100 = 119%, 700/100 = 700%.' }
   ],
   code:'819',
-  successMsg:'🔓 Správně! 119 + 700 = 819. Zámek 5 otevřen!'
+  successMsg:'🔓 Správně! 119 + 700 = 819. Zámek 5 otevřen!',
+  successMsg_en:'🔓 Correct! 119 + 700 = 819. Lock 5 opened!'
 },
 {
-  id:6, color:'pink', icon:'🩷',
-  title:'Zámek 6 – Vybarvování',
-  tag:'Procento jako část celku', tagClass:'pink',
+  id:6, color:'pink', icon:'🪷',
+  title:'Zámek 6 – Vybarvování', title_en:'Lock 6 – Shading',
+  tag:'Procento jako část celku', tag_en:'Percent as part of the whole', tagClass:'pink',
   tasks:[
-    { title:'🧩 Procento a grafické znázornění',
-      body:'<p>Do sešitu nakresli obdélník z 10 čtverečků (1 řada) a vybarvuj:</p><p>a) 10 % – kolik čtverečků?</p><p>b) 40 % – kolik čtverečků?</p><p>c) 100 % – kolik čtverečků?</p>',
-      hint:'💡 10 % z 10 čtverečků = 1 čtvereček.' },
-    { title:'🔢 Kód zámku',
-      body:'<p>Obdélník má <b>20 čtverečků</b>:<br>a) 50 % = kolik čtverečků?<br>b) 25 % = kolik čtverečků?</p><p>Kód = a + b</p>',
-      hint:'💡 50 % z 20 = 10. 25 % z 20 = 5.' }
+    { title:'🧩 Procento a grafické znázornění', title_en:'🧩 Percent and visual representation',
+      body:'<p>Do sešitu nakresli obdélník z 10 čtverecek (1 řada) a vybarv uj:</p><p>a) 10 % – kolik čtverecek?</p><p>b) 40 % – kolik čtverecek?</p><p>c) 100 % – kolik čtverecek?</p>',
+      body_en:'<p>In your notebook, draw a rectangle with 10 squares (1 row) and shade:</p><p>a) 10% – how many squares?</p><p>b) 40% – how many squares?</p><p>c) 100% – how many squares?</p>',
+      hint:'💡 10 % z 10 čtverecek = 1 čtvereček.',
+      hint_en:'💡 10% of 10 squares = 1 square.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
+      body:'<p>Obdélník má <b>20 čtverecek</b>:<br>a) 50 % = kolik čtverecek?<br>b) 25 % = kolik čtverecek?</p><p>Kód = a + b</p>',
+      body_en:'<p>A rectangle has <b>20 squares</b>:<br>a) 50% = how many squares?<br>b) 25% = how many squares?</p><p>Code = a + b</p>',
+      hint:'💡 50 % z 20 = 10. 25 % z 20 = 5.',
+      hint_en:'💡 50% of 20 = 10. 25% of 20 = 5.' }
   ],
   code:'15',
-  successMsg:'🔓 Správně! 10 + 5 = 15. Zámek 6 otevřen!'
+  successMsg:'🔓 Správně! 10 + 5 = 15. Zámek 6 otevřen!',
+  successMsg_en:'🔓 Correct! 10 + 5 = 15. Lock 6 opened!'
 },
 {
   id:7, color:'indigo', icon:'🔷',
-  title:'Zámek 7 – Des. číslo → procento',
-  tag:'Převod des. čísla na %', tagClass:'indigo',
+  title:'Zámek 7 – Des. číslo → procento', title_en:'Lock 7 – Decimal → percent',
+  tag:'Převod des. čísla na %', tag_en:'Converting decimal to %', tagClass:'indigo',
   tasks:[
-    { title:'🧩 Z desetinného čísla na procenta',
+    { title:'🧩 Z desetinného čísla na procenta', title_en:'🧩 From decimal to percent',
       body:'<p>Vzor: 0,25 = 25/100 = <b>25 %</b></p><p>Pravidlo: desetinné číslo × 100 = počet procent</p><table class="tt"><tr><th>Des. číslo</th><th>0,01</th><th>0,03</th><th>0,25</th><th>0,18</th><th>0,95</th><th>1,25</th></tr><tr><td><b>%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
-      hint:'💡 Desetinné číslo × 100 = přesuň čárku o 2 místa doprava.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>Example: 0.25 = 25/100 = <b>25%</b></p><p>Rule: decimal × 100 = percentage</p><table class="tt"><tr><th>Decimal</th><th>0.01</th><th>0.03</th><th>0.25</th><th>0.18</th><th>0.95</th><th>1.25</th></tr><tr><td><b>%</b></td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td></tr></table>',
+      hint:'💡 Desetinné číslo × 100 = přesunň čárku o 2 místa doprava.',
+      hint_en:'💡 Decimal × 100 = move the point 2 places right.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Převeď a sečti:<br>a) <b>0,75</b> = ? &nbsp; b) <b>2,4</b> = ?</p><p>Kód = a + b</p>',
-      hint:'💡 0,75 × 100 = 75; 2,4 × 100 = 240.' }
+      body_en:'<p>Convert and add:<br>a) <b>0.75</b> = ? &nbsp; b) <b>2.4</b> = ?</p><p>Code = a + b</p>',
+      hint:'💡 0,75 × 100 = 75; 2,4 × 100 = 240.',
+      hint_en:'💡 0.75 × 100 = 75; 2.4 × 100 = 240.' }
   ],
   code:'315',
-  successMsg:'🔓 Přesně! 75 + 240 = 315. Zámek 7 otevřen!'
+  successMsg:'🔓 Přesně! 75 + 240 = 315. Zámek 7 otevřen!',
+  successMsg_en:'🔓 Exactly! 75 + 240 = 315. Lock 7 opened!'
 },
 {
   id:8, color:'rose', icon:'🌹',
-  title:'Zámek 8 – Kolik procent?',
-  tag:'Počet procent', tagClass:'rose',
+  title:'Zámek 8 – Kolik procent?', title_en:'Lock 8 – How many percent?',
+  tag:'Počet procent', tag_en:'Number of percent', tagClass:'rose',
   tasks:[
-    { title:'🧩 Kolik procent je část z celku?',
+    { title:'🧩 Kolik procent je část z celku?', title_en:'🧩 What percentage is the part of the whole?',
       body:'<p>Vzorec: <b>část ÷ celek × 100 = počet %</b></p><p>Procvič:</p><table class="tt"><tr><th>Část</th><th>Celek</th><th>Kolik %?</th></tr><tr><td>1</td><td>100</td><td>&nbsp;</td></tr><tr><td>25</td><td>100</td><td>&nbsp;</td></tr><tr><td>3</td><td>300</td><td>&nbsp;</td></tr><tr><td>40</td><td>200</td><td>&nbsp;</td></tr><tr><td>32</td><td>800</td><td>&nbsp;</td></tr></table>',
-      hint:'💡 Např. 3 ze 300: 3 ÷ 300 = 0,01 → × 100 = 1 %.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>Formula: <b>part ÷ whole × 100 = percentage</b></p><p>Practice:</p><table class="tt"><tr><th>Part</th><th>Whole</th><th>How many %?</th></tr><tr><td>1</td><td>100</td><td>&nbsp;</td></tr><tr><td>25</td><td>100</td><td>&nbsp;</td></tr><tr><td>3</td><td>300</td><td>&nbsp;</td></tr><tr><td>40</td><td>200</td><td>&nbsp;</td></tr><tr><td>32</td><td>800</td><td>&nbsp;</td></tr></table>',
+      hint:'💡 Např. 3 ze 300: 3 ÷ 300 = 0,01 → × 100 = 1 %.',
+      hint_en:'💡 E.g. 3 out of 300: 3 ÷ 300 = 0.01 → × 100 = 1%.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Ve třídě je <b>30 žáků</b>. <b>6</b> zapomnělo sešit.</p><p>Kolik procent žáků zapomnělo?</p><p>Kód = výsledek (bez %)</p>',
-      hint:'💡 6 ÷ 30 × 100 = ?' }
+      body_en:'<p>A class has <b>30 students</b>. <b>6</b> forgot their notebook.</p><p>What percentage of students forgot?</p><p>Code = result (without %)</p>',
+      hint:'💡 6 ÷ 30 × 100 = ?', hint_en:'💡 6 ÷ 30 × 100 = ?' }
   ],
   code:'20',
-  successMsg:'🔓 Správně! 6 ÷ 30 × 100 = 20 %. Zámek 8 otevřen!'
+  successMsg:'🔓 Správně! 6 ÷ 30 × 100 = 20 %. Zámek 8 otevřen!',
+  successMsg_en:'🔓 Correct! 6 ÷ 30 × 100 = 20%. Lock 8 opened!'
 },
 {
-  id:9, color:'cyan', icon:'🩵',
-  title:'Zámek 9 – Slovní úloha',
-  tag:'Slovní úloha – mix', tagClass:'cyan',
+  id:9, color:'cyan', icon:'💙',
+  title:'Zámek 9 – Slovní úloha', title_en:'Lock 9 – Word problem',
+  tag:'Slovní úloha – mix', tag_en:'Word problem – mix', tagClass:'cyan',
   tasks:[
-    { title:'🧩 Počtárna v obchodě',
-      body:'<p>Vypočítej každou úlohu do sešitu.</p><p>a) V obchodě bylo <b>400 výrobků</b>. Prodali <b>30 %</b>. Kolik výrobků prodali?</p><p>b) Cena tričku je <b>500 Kč</b>. Sleva činí <b>20 %</b>. Kolik korun stojí sleva?</p><p>c) Každý žák má <b>1 % z 1 000 bodů</b> na začátku roku. Kolik bodů má?</p>',
-      hint:'💡 Postup: 1 % ze základu, pak vynásob počtem procent.' },
-    { title:'🔢 Kód zámku',
+    { title:'🧩 Počtárna v obchodě', title_en:'🧩 Calculations in a shop',
+      body:'<p>Vypočítej každou úlohu do sešitu.</p><p>a) V obchodě bylo <b>400 výrobků</b>. Prodali <b>30 %</b>. Kolik výrobků prodali?</p><p>b) Cena tričku je <b>500 Kč</b>. Sleva činí <b>20 %</b>. Kolik korun stojí sleva?</p><p>c) Každý žák má <b>1 % z 1 000 bodů</b> na začátku roku. Kolik bodů má?</p>',
+      body_en:'<p>Calculate each problem in your notebook.</p><p>a) A shop had <b>400 items</b>. They sold <b>30%</b>. How many items did they sell?</p><p>b) A T-shirt costs <b>500 CZK</b>. The discount is <b>20%</b>. How much is the discount?</p><p>c) Every student gets <b>1% of 1 000 points</b> at the start of the year. How many points do they get?</p>',
+      hint:'💡 Postup: 1 % ze základu, pak vynásob počtem procent.',
+      hint_en:'💡 Method: find 1% of the base, then multiply by the percentage.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Kód = součet výsledků a + b + c</p>',
-      hint:'💡 a) 120, b) 100, c) 10. Součet = ?' }
+      body_en:'<p>Code = sum of results a + b + c</p>',
+      hint:'💡 a) 120, b) 100, c) 10. Součet = ?',
+      hint_en:'💡 a) 120, b) 100, c) 10. Sum = ?' }
   ],
   code:'230',
-  successMsg:'🔓 Skvostně! 120 + 100 + 10 = 230. Zámek 9 otevřen!'
+  successMsg:'🔓 Skvostně! 120 + 100 + 10 = 230. Zámek 9 otevřen!',
+  successMsg_en:'🔓 Brilliant! 120 + 100 + 10 = 230. Lock 9 opened!'
 },
 {
   id:10, color:'gold', icon:'🏆',
-  title:'Zámek 10 – Finále!',
-  tag:'Komplexní úloha', tagClass:'gold',
+  title:'Zámek 10 – Finále!', title_en:'Lock 10 – Final!',
+  tag:'Komplexní úloha', tag_en:'Complex problem', tagClass:'gold',
   tasks:[
-    { title:'🏆 Poslední výzva',
+    { title:'🏆 Poslední výzva', title_en:'🏆 Final challenge',
       body:'<p>Tyto úlohy spojují vše, co jsi dnes naučil(a).</p><p>a) Vypočítej: <b>150 % ze 40</b></p><p>b) V týmu je 25 hráčů. 8 je zraněných. Kolik procent je zraněno? (zaokrouhli na celé %)</p><p>c) Převeď <b>0,37</b> na procenta.</p>',
-      hint:'💡 a) 150 % = 1,5 × 40 = 60. b) 8 ÷ 25 × 100 = 32. c) 0,37 × 100 = 37.' },
-    { title:'🔢 Finální kód',
+      body_en:'<p>These problems combine everything you\'ve learned today.</p><p>a) Calculate: <b>150% of 40</b></p><p>b) A team has 25 players. 8 are injured. What percentage are injured? (round to whole %)</p><p>c) Convert <b>0.37</b> to a percentage.</p>',
+      hint:'💡 a) 150 % = 1,5 × 40 = 60. b) 8 ÷ 25 × 100 = 32. c) 0,37 × 100 = 37.',
+      hint_en:'💡 a) 150% = 1.5 × 40 = 60. b) 8 ÷ 25 × 100 = 32. c) 0.37 × 100 = 37.' },
+    { title:'🔢 Finální kód', title_en:'🔢 Final code',
       body:'<p>Kód = součet a + b + c</p><p>Zadej výsledek a otevři poslední zámek!</p>',
-      hint:'💡 60 + 32 + 37 = ?' }
+      body_en:'<p>Code = sum a + b + c</p><p>Enter the result and open the last lock!</p>',
+      hint:'💡 60 + 32 + 37 = ?', hint_en:'💡 60 + 32 + 37 = ?' }
   ],
   code:'129',
-  successMsg:'🏆 BRAVO! Všech 10 zámků otevřeno! Poklad je tvůj!'
+  successMsg:'🏆 BRAVO! Všech 10 zámků otevřeno! Poklad je tvůj!',
+  successMsg_en:'🏆 BRAVO! All 10 locks opened! The treasure is yours!'
 }
 ];
 
-/* Progresivní nápověda ke kódu zámku — 3 úrovně (L1 směr → L2 vzorec → L3 výsledek) */
-const CODE_HINTS = {
+const CODE_HINTS_CS = {
   1: ['Tahle úloha se ptá: 1 % ze 700. Jakou operací dostaneš jednu setinu?', '1 % = základ ÷ 100. Tedy 700 ÷ 100 = ?', '700 ÷ 100 = 7. Kód: <b>7</b>.'],
   2: ['Najdi 1 % pro každé číslo, vynásob počtem procent, pak sečti.', 'a) 1 % ze 600 = 6, ×5 = 30. b) 1 % ze 500 = 5, ×20 = 100.', '30 + 100 = <b>130</b>.'],
   3: ['Najdi 1 % a vynásob, nebo využij fintu — 50 % je polovina.', 'a) 2 % z 500 = 10. b) 50 % z 200 = polovina = 100.', '10 + 100 = <b>110</b>.'],
@@ -423,8 +511,20 @@ const CODE_HINTS = {
   6: ['50 % je polovina celku, 25 % je čtvrtina. Spočítej obě a sečti.', 'a) 50 % z 20 = 10. b) 25 % z 20 = 5.', '10 + 5 = <b>15</b>.'],
   7: ['Desetinné číslo × 100 = procenta. Posuň čárku o 2 místa doprava.', '0,75 × 100 = 75. 2,4 × 100 = 240.', '75 + 240 = <b>315</b>.'],
   8: ['Vzorec: <b>část ÷ celek × 100 = počet procent</b>.', '6 ÷ 30 × 100 = ?', '6 ÷ 30 × 100 = <b>20</b> %.'],
-  9: ['Tři úlohy — spočítej procentovou část v každé a sečti.', 'a) 30 % ze 400 = 120. b) 20 % z 500 = 100. c) 1 % z 1 000 = 10.', '120 + 100 + 10 = <b>230</b>.'],
+  9: ['Tři úlohy — spočítej procentovou část v každé a sečti.', 'a) 30 % ze 400 = 120. b) 20 % z 500 = 100. c) 1 % z 1 000 = 10.', '120 + 100 + 10 = <b>230</b>.'],
   10: ['Tři úlohy najednou: procentová část, počet procent, převod desetinného čísla.', 'a) 150 % ze 40 = 60. b) 8 ÷ 25 × 100 = 32. c) 0,37 × 100 = 37.', '60 + 32 + 37 = <b>129</b>.'],
+};
+const CODE_HINTS_EN = {
+  1: ['This problem asks: 1% of 700. What operation gives you one hundredth?', '1% = base ÷ 100. So 700 ÷ 100 = ?', '700 ÷ 100 = 7. Code: <b>7</b>.'],
+  2: ['Find 1% for each number, multiply by the percentage, then add up.', 'a) 1% of 600 = 6, ×5 = 30. b) 1% of 500 = 5, ×20 = 100.', '30 + 100 = <b>130</b>.'],
+  3: ['Find 1% and multiply, or use the shortcut — 50% is half.', 'a) 2% of 500 = 10. b) 50% of 200 = half = 100.', '10 + 100 = <b>110</b>.'],
+  4: ['Percent → decimal: move the point 2 places left. Then add up and ×100.', '40%=0.40; 5%=0.05; 200%=2.00. Add them up.', '0.40 + 0.05 + 2.00 = 2.45. ×100 = <b>245</b>.'],
+  5: ['With a fraction X/100, the numerator directly = percentage.', '119/100 = 119%. 700/100 = 700%. Add them up.', '119 + 700 = <b>819</b>.'],
+  6: ['50% is half the whole, 25% is a quarter. Calculate both and add up.', 'a) 50% of 20 = 10. b) 25% of 20 = 5.', '10 + 5 = <b>15</b>.'],
+  7: ['Decimal × 100 = percentage. Move the point 2 places right.', '0.75 × 100 = 75. 2.4 × 100 = 240.', '75 + 240 = <b>315</b>.'],
+  8: ['Formula: <b>part ÷ whole × 100 = percentage</b>.', '6 ÷ 30 × 100 = ?', '6 ÷ 30 × 100 = <b>20</b>%.'],
+  9: ['Three problems — calculate the percentage part for each and add up.', 'a) 30% of 400 = 120. b) 20% of 500 = 100. c) 1% of 1 000 = 10.', '120 + 100 + 10 = <b>230</b>.'],
+  10: ['Three problems: percentage part, number of percent, converting a decimal.', 'a) 150% of 40 = 60. b) 8 ÷ 25 × 100 = 32. c) 0.37 × 100 = 37.', '60 + 32 + 37 = <b>129</b>.'],
 };
 
 let codeHintLevel = 0;
@@ -432,34 +532,36 @@ let codeHintLevel = 0;
 function advanceCodeHint() {
   if (codeHintLevel >= 3) return;
   codeHintLevel++;
-  const hints = CODE_HINTS[STEPS[cur].id] || ['Přečti si pozorně postup nahoře.', 'Postupně spočítej, co se ptají.', 'Výsledek vyplyne z výpočtu.'];
+  const CODE_HINTS = lang === 'en' ? CODE_HINTS_EN : CODE_HINTS_CS;
+  const fallback = i18n(
+    ['Čti si pozorně postup nahoře.', 'Postupně spočítej, co se ptá.', 'Výsledek vyplyne z výpočtu.'],
+    ['Read the instructions above carefully.', 'Work through the problem step by step.', 'The result follows from the calculation.']
+  );
+  const hints = CODE_HINTS[STEPS[cur].id] || fallback;
   const box = document.getElementById('ch-box');
   const btn = document.getElementById('ch-btn');
   const counter = document.getElementById('ch-counter');
   if (!box || !btn) return;
   box.classList.add('show');
   box.dataset.level = codeHintLevel;
-  const labels = ['Nasměrování', 'Vzorec', 'Postup s výsledkem'];
-  box.innerHTML = `<span class="h-label">Nápověda ${codeHintLevel}/3 — ${labels[codeHintLevel-1]}</span>${hints[codeHintLevel - 1]}`;
+  const labels = i18n(['Nasměrování','Vzorec','Postup s výsledkem'],['Direction','Formula','Solution steps']);
+  box.innerHTML = `<span class="h-label">${i18n('Nápověda','Hint')} ${codeHintLevel}/3 — ${labels[codeHintLevel-1]}</span>${hints[codeHintLevel-1]}`;
   if (counter) {
-    counter.querySelectorAll('.dot').forEach((d, i) => {
+    counter.querySelectorAll('.dot').forEach((d,i) => {
       d.classList.toggle('shown', i < codeHintLevel);
       if (i === 2 && codeHintLevel === 3) d.classList.add('warn');
     });
   }
   if (codeHintLevel < 3) {
-    btn.textContent = `💡 Další nápověda ${codeHintLevel+1}/3`;
+    btn.textContent = i18n(`💡 Další nápověda ${codeHintLevel+1}/3`, `💡 Next hint ${codeHintLevel+1}/3`);
   } else {
     btn.disabled = true;
-    btn.textContent = '💡 Všechny nápovědy ukázány';
+    btn.textContent = i18n('💡 Všechny nápovědy ukázány','💡 All hints shown');
   }
 }
 
 let cur = 0;
 let att = new Array(STEPS.length).fill(0);
-
-document.getElementById('btn-start').addEventListener('click', startGame);
-document.getElementById('btn-restart').addEventListener('click', () => location.reload());
 
 function startGame() {
   document.getElementById('intro').classList.remove('active');
@@ -473,7 +575,7 @@ function render(idx) {
   cur = idx;
   codeHintLevel = 0;
   const s = STEPS[idx];
-  document.getElementById('prog-label').textContent = `Zámek ${idx+1} z ${STEPS.length}`;
+  document.getElementById('prog-label').textContent = i18n(`Zámek ${idx+1} z ${STEPS.length}`,`Lock ${idx+1} of ${STEPS.length}`);
   document.getElementById('prog-fill').style.width = `${(idx / STEPS.length) * 100}%`;
   for (let i = 0; i < STEPS.length; i++) {
     const el = document.getElementById(`s${i}`);
@@ -481,38 +583,38 @@ function render(idx) {
   }
 
   const colorMap = {
-    blue:'--blue', green:'--green', purple:'--purple', teal:'--teal',
-    orange:'--orange', pink:'--pink', indigo:'--indigo', rose:'--rose',
-    cyan:'--cyan', gold:'--gold-dark'
+    blue:'--blue',green:'--green',purple:'--purple',teal:'--teal',
+    orange:'--orange',pink:'--pink',indigo:'--indigo',rose:'--rose',
+    cyan:'--cyan',gold:'--gold-dark'
   };
   const cv = colorMap[s.color] || '--blue';
 
   const tasksHTML = s.tasks.map(t => `
     <div class="task-card ${s.color}">
-      <span class="tag ${s.tagClass}">${s.tag}</span>
-      <h3>${t.title}</h3>
-      ${t.body}
-      <button class="hint-btn" onclick="toggleHint(this)">💡 Potřebuji nápovědu</button>
-      <div class="hint-box">${t.hint}</div>
+      <span class="tag ${s.tagClass}">${i18n(s.tag, s.tag_en)}</span>
+      <h3>${i18n(t.title, t.title_en)}</h3>
+      ${i18n(t.body, t.body_en)}
+      <button class="hint-btn" onclick="toggleHint(this)">${i18n('💡 Potřebuji nápovědu','💡 I need a hint')}</button>
+      <div class="hint-box">${i18n(t.hint, t.hint_en)}</div>
     </div>
   `).join('');
 
   document.getElementById('step-container').innerHTML = `
     <div class="lock-header">
       <span class="lock-icon-big">${s.icon}</span>
-      <span class="lock-title" style="color:var(${cv})">${s.title}</span>
+      <span class="lock-title" style="color:var(${cv})">${i18n(s.title, s.title_en)}</span>
       <span class="lock-badge">${idx+1}/${STEPS.length}</span>
     </div>
     ${tasksHTML}
     <div class="code-wrap">
-      <label>🔐 Zadej kód zámku ${idx+1}:</label>
+      <label>🔐 ${i18n(`Zadej kód zámku ${idx+1}:`,`Enter lock ${idx+1} code:`)}</label>
       <div class="code-row">
         <input type="number" class="code-input" id="ci" placeholder="???"
           onkeydown="if(event.key==='Enter') chk()">
-        <button class="btn-check" onclick="chk()">Odemknout 🔓</button>
+        <button class="btn-check" onclick="chk()">${i18n('Odemknout 🔓','Unlock 🔓')}</button>
       </div>
       <div class="code-hint-bar">
-        <button class="code-hint-btn" id="ch-btn" onclick="advanceCodeHint()">💡 Nápověda ke kódu 1/3</button>
+        <button class="code-hint-btn" id="ch-btn" onclick="advanceCodeHint()">💡 ${i18n('Nápověda ke kódu 1/3','Code hint 1/3')}</button>
         <span class="code-hint-counter" id="ch-counter">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
         </span>
@@ -522,7 +624,7 @@ function render(idx) {
     </div>
     <div class="unlock-anim" id="ua">
       <div class="big-icon">🔓✨</div>
-      <p>${s.successMsg}</p>
+      <p>${i18n(s.successMsg, s.successMsg_en)}</p>
     </div>
   `;
   window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -531,7 +633,9 @@ function render(idx) {
 function toggleHint(btn) {
   const h = btn.nextElementSibling;
   h.classList.toggle('show');
-  btn.textContent = h.classList.contains('show') ? '🙈 Skrýt nápovědu' : '💡 Potřebuji nápovědu';
+  btn.textContent = h.classList.contains('show')
+    ? i18n('🙈 Skrýt nápovědu','🙈 Hide hint')
+    : i18n('💡 Potřebuji nápovědu','💡 I need a hint');
 }
 
 function chk() {
@@ -552,12 +656,10 @@ function chk() {
     inp.classList.add('error');
     inp.classList.remove('success');
     setTimeout(() => inp.classList.remove('error'), 380);
-    const msgs = [
-      'Hmm, to není ono. Zkontroluj postup!',
-      'Zkus to znovu – možná jiný výpočet?',
-      'Nevzdávej se! Přečti si nápovědu.',
-      'Ještě jednou, jsi blízko!'
-    ];
+    const msgs = i18n(
+      ['Hmm, to není ono. Zkontroluj postup!','Zkus to znovu – možná jiný výpočet?','Nevzdávej se! Přečti si nápovědu.','Ještě jednou, jsi blízko!'],
+      ['Hmm, not quite. Check your working!','Try again – maybe a different calculation?','Don\'t give up! Read the hint.','One more try, you\'re close!']
+    );
     fb.className = 'feedback err';
     fb.textContent = msgs[Math.min(att[cur] - 1, msgs.length - 1)];
   }
@@ -566,6 +668,7 @@ function chk() {
 function finish() {
   document.getElementById('game').classList.remove('active');
   document.getElementById('finish').classList.add('active');
+  buildFinish();
   const wrap = document.getElementById('confetti');
   const cols = ['#f5c842','#1a73c8','#1e9e5a','#e74c3c','#7c3aad','#0f8a72','#ff7f50','#b5286e'];
   for (let i = 0; i < 90; i++) {
@@ -582,6 +685,11 @@ function finish() {
     wrap.appendChild(el);
   }
 }
+
+// Init
+document.querySelectorAll('.lang-btn').forEach(b =>
+  b.classList.toggle('active', b.dataset.lang === lang));
+buildIntro();
 </script>
 </body>
 </html>

--- a/projects/unikovka_telesa.html
+++ b/projects/unikovka_telesa.html
@@ -200,43 +200,40 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 .top-bar a{color:var(--muted);text-decoration:none}
 .top-bar a:hover{color:var(--blue)}
 .top-bar .crumb{color:var(--text);font-weight:500}
+
+/* LANG BAR */
+#lang-bar{position:fixed;bottom:16px;right:16px;z-index:200;display:flex;gap:6px;
+  background:rgba(255,255,255,.92);border-radius:50px;padding:5px 8px;
+  box-shadow:0 2px 12px rgba(0,0,0,.12);backdrop-filter:blur(6px)}
+.lang-btn{background:none;border:2px solid transparent;border-radius:50px;
+  font-size:1.35rem;cursor:pointer;padding:3px 7px;line-height:1;
+  transition:border-color .15s,box-shadow .15s}
+.lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 </style>
 </head>
 <body>
 
 <div class="top-bar">
-  <a href="./">← zpět na projekty</a>
+  <a href="./" class="tp-back">&#8592; zpět na projekty</a>
   <span class="crumb">/projects/unikovka_telesa</span>
-  <a href="/">domů</a>
+  <a href="/" class="tp-home">domů</a>
+</div>
+
+<div id="lang-bar">
+  <button class="lang-btn" data-lang="cs" onclick="setLang('cs')">&#x1F1E8;&#x1F1FF;</button>
+  <button class="lang-btn" data-lang="en" onclick="setLang('en')">&#x1F1EC;&#x1F1E7;</button>
 </div>
 
 <!-- INTRO -->
 <div id="intro" class="screen active">
-  <div class="chest">📦</div>
-  <div class="title-main">Únikovka z matiky</div>
-  <div class="title-sub">📦 KRYCHLE & KVÁDR 📦</div>
-  <div class="intro-card">
-    <p>Před tebou je <b>truhla s pokladem</b> – uzamčena <b>10 zámky</b>.</p>
-    <p>Každý zámek se odemkne správným kódem. Výpočty si dělej <b>do sešitu</b> a kód zadej sem.</p>
-    <p>Žádné kalkulačky – dnes prozkoumáš <b>krychli a kvádr</b> vlastní hlavou 🧠</p>
-  </div>
-  <div class="rules">
-    <h3>📋 Pravidla</h3>
-    <ul>
-      <li><span>✏️</span> Výpočty piš do sešitu – každý příklad celý.</li>
-      <li><span>🚫</span> Bez kalkulačky, bez opisování.</li>
-      <li><span>💡</span> Nevíš? Zkus nápovědu – ale nejdřív se zamysli!</li>
-      <li><span>🔢</span> Kód zadej jako celé číslo (bez jednotek, bez mezer).</li>
-    </ul>
-  </div>
-  <button class="btn-primary" id="btn-start">🔓 Začít dobrodružství!</button>
+  <div id="intro-content"></div>
 </div>
 
 <!-- GAME -->
 <div id="game" class="screen">
   <div class="progress-wrap" style="width:100%">
     <div class="progress-label">
-      <span id="prog-label">Zámek 1 z 10</span>
+      <span id="prog-label"></span>
       <span class="stars-wrap" id="stars-wrap"></span>
     </div>
     <div class="progress-bar"><div class="progress-fill" id="prog-fill" style="width:0%"></div></div>
@@ -247,176 +244,274 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 <!-- FINISH -->
 <div id="finish" class="screen">
   <div class="confetti-wrap" id="confetti"></div>
-  <div class="final-chest">🏆</div>
-  <div class="final-title">Poklad je tvůj!</div>
-  <p class="final-sub">Zvládl(a) jsi všech 10 zámků a pronikl(a) do tajemství krychle a kvádru. Gratulace!</p>
-  <div class="summary-card">
-    <h3>📖 Co jsi dnes objevil(a)</h3>
-    <div class="summary-row"><span class="s-icon">1️⃣</span><span>Krychle i kvádr mají <b>8 vrcholů, 12 hran a 6 stěn</b>.</span></div>
-    <div class="summary-row"><span class="s-icon">2️⃣</span><span>Síť krychle = <b>6 stejných čtverců</b>. Síť kvádru = <b>6 obdélníků</b> (po dvojicích shodných).</span></div>
-    <div class="summary-row"><span class="s-icon">3️⃣</span><span>Povrch krychle: <b>S = 6 · a²</b>. Povrch kvádru: <b>S = 2 · (ab + bc + ac)</b>.</span></div>
-    <div class="summary-row"><span class="s-icon">4️⃣</span><span>Objem krychle: <b>V = a³</b>. Objem kvádru: <b>V = a · b · c</b>.</span></div>
-  </div>
-  <button class="btn-primary" id="btn-restart">🔄 Hrát znovu</button>
+  <div id="finish-content"></div>
 </div>
 
 <script>
-// Veškerý český text je přímo v UTF-8 – žádné HTML entity
+const LANG_KEY = 'unikovka_telesa_lang';
+let lang = localStorage.getItem(LANG_KEY) || 'cs';
+const i18n = (cs, en) => lang === 'en' ? en : cs;
+
+function setLang(l) {
+  lang = l;
+  try { localStorage.setItem(LANG_KEY, l); } catch(e) {}
+  document.querySelectorAll('.lang-btn').forEach(b =>
+    b.classList.toggle('active', b.dataset.lang === l));
+  document.querySelectorAll('.tp-back').forEach(el =>
+    el.textContent = i18n('← zpět na projekty', '← back to projects'));
+  document.querySelectorAll('.tp-home').forEach(el =>
+    el.textContent = i18n('domů', 'home'));
+  const activeId = document.querySelector('.screen.active')?.id;
+  if (activeId === 'intro') buildIntro();
+  else if (activeId === 'game') render(cur);
+  else if (activeId === 'finish') buildFinish();
+}
+
+function buildIntro() {
+  document.getElementById('intro-content').innerHTML = `
+    <div class="chest">&#x1F4E6;</div>
+    <div class="title-main">${i18n('Únikovka z matiky', 'Math Escape Room')}</div>
+    <div class="title-sub">&#x1F4E6; ${i18n('KRYCHLE & KVÁDR', 'CUBE & CUBOID')} &#x1F4E6;</div>
+    <div class="intro-card">
+      <p>${i18n('Před tebou je <b>truhla s pokladem</b> – uzamčena <b>10 zámky</b>.', 'Before you is a <b>treasure chest</b> – locked with <b>10 locks</b>.')}</p>
+      <p>${i18n('Každý zámek se odemkne správným kódem. Výpočty si dělej <b>do sešitu</b> a kód zadej sem.', 'Each lock opens with the correct code. Do your calculations <b>in your notebook</b> and enter the code here.')}</p>
+      <p>${i18n('Žádné kalkulačky – dnes prozkoumáš <b>krychli a kvádr</b> vlastní hlavou 🧠', 'No calculators – today you\'ll explore <b>cubes and cuboids</b> with your own mind 🧠')}</p>
+    </div>
+    <div class="rules">
+      <h3>&#x1F4CB; ${i18n('Pravidla', 'Rules')}</h3>
+      <ul>
+        <li><span>&#x270F;&#xFE0F;</span> ${i18n('Výpočty piš do sešitu – každý příklad celý.', 'Write your calculations in your notebook – every step.')}</li>
+        <li><span>&#x1F6AB;</span> ${i18n('Bez kalkulačky, bez opisování.', 'No calculator, no copying.')}</li>
+        <li><span>&#x1F4A1;</span> ${i18n('Nevíš? Zkus nápovědu – ale nejdřív se zamysli!', 'Stuck? Try the hint – but think first!')}</li>
+        <li><span>&#x1F522;</span> ${i18n('Kód zadej jako celé číslo (bez jednotek, bez mezer).', 'Enter the code as a whole number (no units, no spaces).')}</li>
+      </ul>
+    </div>
+    <button class="btn-primary" id="btn-start">&#x1F513; ${i18n('Začít dobrodružství!', 'Start the adventure!')}</button>
+  `;
+  document.getElementById('btn-start').addEventListener('click', startGame);
+}
+
+function buildFinish() {
+  document.getElementById('finish-content').innerHTML = `
+    <div class="final-chest">&#x1F3C6;</div>
+    <div class="final-title">${i18n('Poklad je tvůj!', 'The treasure is yours!')}</div>
+    <p class="final-sub">${i18n('Zvládl(a) jsi všech 10 zámků a pronikl(a) do tajemství krychle a kvádru. Gratulace!', 'You solved all 10 locks and unlocked the secrets of the cube and cuboid. Congratulations!')}</p>
+    <div class="summary-card">
+      <h3>&#x1F4D6; ${i18n('Co jsi dnes objevil(a)', 'What you discovered today')}</h3>
+      <div class="summary-row"><span class="s-icon">1&#xFE0F;&#x20E3;</span><span>${i18n('Krychle i kvádr mají <b>8 vrcholů, 12 hran a 6 stěn</b>.', 'A cube and cuboid both have <b>8 vertices, 12 edges, and 6 faces</b>.')}</span></div>
+      <div class="summary-row"><span class="s-icon">2&#xFE0F;&#x20E3;</span><span>${i18n('Síť krychle = <b>6 stejných čtverců</b>. Síť kvádru = <b>6 obdélníků</b> (po dvojicích shodných).', 'Net of a cube = <b>6 identical squares</b>. Net of a cuboid = <b>6 rectangles</b> (in matching pairs).')}</span></div>
+      <div class="summary-row"><span class="s-icon">3&#xFE0F;&#x20E3;</span><span>${i18n('Povrch krychle: <b>S = 6 · a²</b>. Povrch kvádru: <b>S = 2 · (ab + bc + ac)</b>.', 'Surface area of a cube: <b>S = 6 · a²</b>. Cuboid: <b>S = 2 · (ab + bc + ac)</b>.')}</span></div>
+      <div class="summary-row"><span class="s-icon">4&#xFE0F;&#x20E3;</span><span>${i18n('Objem krychle: <b>V = a³</b>. Objem kvádru: <b>V = a · b · c</b>.', 'Volume of a cube: <b>V = a³</b>. Cuboid: <b>V = a · b · c</b>.')}</span></div>
+    </div>
+    <button class="btn-primary" id="btn-restart">&#x1F504; ${i18n('Hrát znovu', 'Play again')}</button>
+  `;
+  document.getElementById('btn-restart').addEventListener('click', () => location.reload());
+}
+
 const STEPS = [
 {
   id:1, color:'blue', icon:'🔵',
-  title:'Zámek 1 – Co je to těleso?',
-  tag:'Rovinný útvar vs těleso', tagClass:'blue',
+  title:'Zámek 1 – Co je to těleso?', title_en:'Lock 1 – What is a solid?',
+  tag:'Rovinný útvar vs těleso', tag_en:'Flat shape vs. solid', tagClass:'blue',
   tasks:[
-    { title:'🧩 Rovina nebo prostor?',
+    { title:'🧩 Rovina nebo prostor?', title_en:'🧩 Flat or 3D?',
       body:'<p><b>Rovinný útvar</b> má 2 rozměry – délku a šířku (např. čtverec, obdélník, kruh).</p><p><b>Těleso</b> má 3 rozměry – délku, šířku a <b>výšku</b>. Můžeš ho vzít do ruky.</p><p>Roztřiď tyto věci na <b>rovinné útvary</b> a <b>tělesa</b>: <i>čtverec, krabice, trojúhelník, kostka, kniha, kruh, balón, obdélník</i>.</p>',
-      hint:'💡 Můžeš to vzít do ruky? Má to objem? Pak je to těleso.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>A <b>flat shape</b> has 2 dimensions – length and width (e.g. square, rectangle, circle).</p><p>A <b>solid</b> has 3 dimensions – length, width and <b>height</b>. You can pick it up.</p><p>Sort these into <b>flat shapes</b> and <b>solids</b>: <i>square, box, triangle, cube, book, circle, balloon, rectangle</i>.</p>',
+      hint:'💡 Můžeš to vzít do ruky? Má to objem? Pak je to těleso.',
+      hint_en:'💡 Can you pick it up? Does it have volume? Then it\'s a solid.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>V seznamu spočítej, kolik je <b>těles</b>:</p><p><b>kostka, kniha, obdélník, krabice, kruh, balón</b></p><p>Kód = počet těles.</p>',
-      hint:'💡 Obdélník a kruh jsou rovinné útvary (mají jen 2 rozměry).' }
+      body_en:'<p>From the list, count how many are <b>solids</b>:</p><p><b>cube, book, rectangle, box, circle, balloon</b></p><p>Code = number of solids.</p>',
+      hint:'💡 Obdélník a kruh jsou rovinné útvary (mají jen 2 rozměry).',
+      hint_en:'💡 Rectangle and circle are flat shapes (they only have 2 dimensions).' }
   ],
   code:'4',
-  successMsg:'🔓 Správně! Tělesa: kostka, kniha, krabice, balón = 4. Zámek 1 otevřen!'
+  successMsg:'🔓 Správně! Tělesa: kostka, kniha, krabice, balón = 4. Zámek 1 otevřen!',
+  successMsg_en:'🔓 Correct! Solids: cube, book, box, balloon = 4. Lock 1 opened!'
 },
 {
   id:2, color:'green', icon:'🟢',
-  title:'Zámek 2 – Vrcholy, hrany, stěny',
-  tag:'Z čeho se těleso skládá', tagClass:'green',
+  title:'Zámek 2 – Vrcholy, hrany, stěny', title_en:'Lock 2 – Vertices, Edges, Faces',
+  tag:'Z čeho se těleso skládá', tag_en:'Parts of a solid', tagClass:'green',
   tasks:[
-    { title:'🧩 Tři důležité části',
+    { title:'🧩 Tři důležité části', title_en:'🧩 Three key parts',
       body:'<p>Krychle a kvádr mají:</p><ul><li><b>Vrcholy</b> – body, kde se sbíhají hrany (rohy krabice).</li><li><b>Hrany</b> – úsečky mezi vrcholy.</li><li><b>Stěny</b> – ploché části (boky krabice).</li></ul><p>Spočítej je u <b>krychle</b> a <b>kvádru</b>:</p><table class="tt"><tr><th></th><th>Krychle</th><th>Kvádr</th></tr><tr><td><b>Vrcholy</b></td><td>?</td><td>?</td></tr><tr><td><b>Hrany</b></td><td>?</td><td>?</td></tr><tr><td><b>Stěny</b></td><td>?</td><td>?</td></tr></table>',
-      hint:'💡 Krychle a kvádr mají <b>úplně stejný počet</b> vrcholů, hran i stěn! Zkus si představit hrací kostku.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>A cube and cuboid have:</p><ul><li><b>Vertices</b> – points where edges meet (corners of a box).</li><li><b>Edges</b> – line segments between vertices.</li><li><b>Faces</b> – flat surfaces (sides of a box).</li></ul><p>Count them for a <b>cube</b> and <b>cuboid</b>:</p><table class="tt"><tr><th></th><th>Cube</th><th>Cuboid</th></tr><tr><td><b>Vertices</b></td><td>?</td><td>?</td></tr><tr><td><b>Edges</b></td><td>?</td><td>?</td></tr><tr><td><b>Faces</b></td><td>?</td><td>?</td></tr></table>',
+      hint:'💡 Krychle a kvádr mají <b>úplně stejný počet</b> vrcholů, hran i stěn! Zkus si představit hrací kostku.',
+      hint_en:'💡 A cube and cuboid have <b>exactly the same number</b> of vertices, edges, and faces! Imagine a dice.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Sečti u <b>krychle</b>: <b>počet vrcholů + počet hran + počet stěn</b>.</p>',
-      hint:'💡 8 + 12 + 6 = ?' }
+      body_en:'<p>Add up for a <b>cube</b>: <b>number of vertices + number of edges + number of faces</b>.</p>',
+      hint:'💡 8 + 12 + 6 = ?',
+      hint_en:'💡 8 + 12 + 6 = ?' }
   ],
   code:'26',
-  successMsg:'🔓 Výborně! 8 + 12 + 6 = 26. Zámek 2 otevřen!'
+  successMsg:'🔓 Výborně! 8 + 12 + 6 = 26. Zámek 2 otevřen!',
+  successMsg_en:'🔓 Excellent! 8 + 12 + 6 = 26. Lock 2 opened!'
 },
 {
   id:3, color:'purple', icon:'🟣',
-  title:'Zámek 3 – Krychle vs Kvádr',
-  tag:'Rozlišení krychle a kvádru', tagClass:'purple',
+  title:'Zámek 3 – Krychle vs Kvádr', title_en:'Lock 3 – Cube vs Cuboid',
+  tag:'Rozlišení krychle a kvádru', tag_en:'Identifying cube and cuboid', tagClass:'purple',
   tasks:[
-    { title:'🧩 Co je krychle a co kvádr?',
+    { title:'🧩 Co je krychle a co kvádr?', title_en:'🧩 What is a cube and what is a cuboid?',
       body:'<p><b>Krychle</b>: všechny hrany jsou <b>stejně dlouhé</b> (a × a × a). Stěny = <b>čtverce</b>.</p><p><b>Kvádr</b>: hrany mohou mít <b>různé délky</b> (a × b × c). Stěny = <b>obdélníky</b> (někdy i čtverce).</p><p>Přiřaď ke každé věci, jestli je to <b>krychle</b> nebo <b>kvádr</b>:</p><ul><li>hrací kostka</li><li>krabice od mléka (1 l)</li><li>kostka cukru</li><li>kniha</li><li>cihla</li><li>kostka ledu</li></ul>',
-      hint:'💡 Pokud má všechny strany stejné = krychle. Pokud různé = kvádr.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p><b>Cube</b>: all edges are <b>the same length</b> (a × a × a). Faces = <b>squares</b>.</p><p><b>Cuboid</b>: edges can have <b>different lengths</b> (a × b × c). Faces = <b>rectangles</b> (sometimes squares too).</p><p>Classify each object as a <b>cube</b> or <b>cuboid</b>:</p><ul><li>dice</li><li>milk carton (1 L)</li><li>sugar cube</li><li>book</li><li>brick</li><li>ice cube</li></ul>',
+      hint:'💡 Pokud má všechny strany stejné = krychle. Pokud různé = kvádr.',
+      hint_en:'💡 All sides equal = cube. Different sides = cuboid.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Z těchto věcí spočítej, kolik je <b>krychlí</b>:</p><p><b>hrací kostka, kostka cukru, kostka ledu, Rubikova kostka, krabice od bot, kniha</b></p><p>Kód = počet krychlí.</p>',
-      hint:'💡 Krabice od bot a kniha jsou kvádry (mají různě dlouhé strany).' }
+      body_en:'<p>Count how many are <b>cubes</b>:</p><p><b>dice, sugar cube, ice cube, Rubik\'s cube, shoebox, book</b></p><p>Code = number of cubes.</p>',
+      hint:'💡 Krabice od bot a kniha jsou kvádry (mají různě dlouhé strany).',
+      hint_en:'💡 Shoebox and book are cuboids (they have different-length sides).' }
   ],
   code:'4',
-  successMsg:'🔓 Přesně! Krychle: hrací kostka, kostka cukru, kostka ledu, Rubikova kostka = 4. Zámek 3 otevřen!'
+  successMsg:'🔓 Přesně! Krychle: hrací kostka, kostka cukru, kostka ledu, Rubikova kostka = 4. Zámek 3 otevřen!',
+  successMsg_en:'🔓 Exactly! Cubes: dice, sugar cube, ice cube, Rubik\'s cube = 4. Lock 3 opened!'
 },
 {
   id:4, color:'teal', icon:'🩵',
-  title:'Zámek 4 – Síť krychle',
-  tag:'Síť tělesa – krychle', tagClass:'teal',
+  title:'Zámek 4 – Síť krychle', title_en:'Lock 4 – Net of a Cube',
+  tag:'Síť tělesa – krychle', tag_en:'Net of a solid – cube', tagClass:'teal',
   tasks:[
-    { title:'🧩 Co je síť tělesa',
+    { title:'🧩 Co je síť tělesa', title_en:'🧩 What is a net?',
       body:'<p>Když krabici rozložíš a "narovnáš" ji, dostaneš <b>síť tělesa</b> – plochý obrazec.</p><p>Síť <b>krychle</b> tvoří <b>6 stejných čtverců</b> spojených hranami.</p><p>Existuje <b>11 různých sítí krychle</b> (různě uspořádaných).</p><p>Zkus si nakreslit do sešitu jednu síť krychle. Kolik má <b>čtverců</b>?</p>',
-      hint:'💡 Krychle má 6 stěn, každá je čtverec → síť má 6 čtverců.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>When you unfold a box flat, you get a <b>net</b> – a flat diagram of all its faces.</p><p>The net of a <b>cube</b> consists of <b>6 identical squares</b> joined along edges.</p><p>There are <b>11 different nets</b> of a cube.</p><p>Try drawing one net of a cube in your notebook. How many <b>squares</b> does it have?</p>',
+      hint:'💡 Krychle má 6 stěn, každá je čtverec → síť má 6 čtverců.',
+      hint_en:'💡 A cube has 6 faces, each a square → the net has 6 squares.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Krychle má hranu <b>a = 5 cm</b>.</p><p>Kolik je <b>obvod jedné stěny</b> (jednoho čtverce ze sítě) v cm?</p>',
-      hint:'💡 Obvod čtverce = 4 × strana. 4 × 5 = ?' }
+      body_en:'<p>A cube has edge <b>a = 5 cm</b>.</p><p>What is the <b>perimeter of one face</b> (one square from the net) in cm?</p>',
+      hint:'💡 Obvod čtverce = 4 × strana. 4 × 5 = ?',
+      hint_en:'💡 Perimeter of a square = 4 × side. 4 × 5 = ?' }
   ],
   code:'20',
-  successMsg:'🔓 Správně! Obvod čtverce = 4 · 5 = 20 cm. Zámek 4 otevřen!'
+  successMsg:'🔓 Správně! Obvod čtverce = 4 · 5 = 20 cm. Zámek 4 otevřen!',
+  successMsg_en:'🔓 Correct! Perimeter of a square = 4 · 5 = 20 cm. Lock 4 opened!'
 },
 {
   id:5, color:'orange', icon:'🟠',
-  title:'Zámek 5 – Síť kvádru',
-  tag:'Síť tělesa – kvádr', tagClass:'orange',
+  title:'Zámek 5 – Síť kvádru', title_en:'Lock 5 – Net of a Cuboid',
+  tag:'Síť tělesa – kvádr', tag_en:'Net of a solid – cuboid', tagClass:'orange',
   tasks:[
-    { title:'🧩 Síť kvádru',
+    { title:'🧩 Síť kvádru', title_en:'🧩 Net of a cuboid',
       body:'<p>Síť <b>kvádru</b> tvoří <b>6 obdélníků</b>, vždy <b>2 a 2 jsou shodné</b>:</p><ul><li>2× přední/zadní stěna</li><li>2× horní/dolní stěna</li><li>2× levá/pravá stěna</li></ul><p>Kvádr s rozměry <b>3 × 4 × 5 cm</b> má v síti <b>3 různé tvary obdélníků</b>:</p><ul><li>3 × 4 cm (2×)</li><li>4 × 5 cm (2×)</li><li>3 × 5 cm (2×)</li></ul>',
-      hint:'💡 Vezmi 2 ze 3 rozměrů – to jsou strany jedné stěny. To uděláš třikrát.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>The net of a <b>cuboid</b> has <b>6 rectangles</b>, always <b>in matching pairs</b>:</p><ul><li>2× front/back face</li><li>2× top/bottom face</li><li>2× left/right face</li></ul><p>A cuboid with dimensions <b>3 × 4 × 5 cm</b> has <b>3 different rectangle shapes</b>:</p><ul><li>3 × 4 cm (×2)</li><li>4 × 5 cm (×2)</li><li>3 × 5 cm (×2)</li></ul>',
+      hint:'💡 Vezmi 2 ze 3 rozměrů – to jsou strany jedné stěny. To uděláš třikrát.',
+      hint_en:'💡 Take 2 of the 3 dimensions – those are the sides of one face. Do this three times.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Kvádr má rozměry <b>2 × 3 × 4 cm</b>.</p><p>Spočítej <b>obsah jedné stěny</b> o stranách <b>2 × 3</b> v cm².</p>',
-      hint:'💡 Obsah obdélníku = délka × šířka.' }
+      body_en:'<p>A cuboid has dimensions <b>2 × 3 × 4 cm</b>.</p><p>Calculate the <b>area of one face</b> with sides <b>2 × 3</b> in cm².</p>',
+      hint:'💡 Obsah obdélníku = délka × šířka.',
+      hint_en:'💡 Area of a rectangle = length × width.' }
   ],
   code:'6',
-  successMsg:'🔓 Správně! 2 · 3 = 6 cm². Zámek 5 otevřen!'
+  successMsg:'🔓 Správně! 2 · 3 = 6 cm². Zámek 5 otevřen!',
+  successMsg_en:'🔓 Correct! 2 · 3 = 6 cm². Lock 5 opened!'
 },
 {
   id:6, color:'pink', icon:'🩷',
-  title:'Zámek 6 – Hrany krychle',
-  tag:'Součet hran krychle', tagClass:'pink',
+  title:'Zámek 6 – Hrany krychle', title_en:'Lock 6 – Edges of a Cube',
+  tag:'Součet hran krychle', tag_en:'Sum of edges of a cube', tagClass:'pink',
   tasks:[
-    { title:'🧩 Kolik je hran dohromady?',
+    { title:'🧩 Kolik je hran dohromady?', title_en:'🧩 Total length of all edges?',
       body:'<p>Krychle má <b>12 hran</b>, všechny stejně dlouhé.</p><p>Pokud má hrana délku <b>a</b>, pak <b>součet všech hran</b> = <b>12 · a</b>.</p><p>Doplň tabulku:</p><table class="tt"><tr><th>a</th><th>2 cm</th><th>5 cm</th><th>10 cm</th></tr><tr><td><b>12 · a</b></td><td>?</td><td>?</td><td>?</td></tr></table>',
-      hint:'💡 Vynásob každé a číslem 12: 12·2 = 24, 12·5 = 60, 12·10 = 120.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>A cube has <b>12 edges</b>, all the same length.</p><p>If the edge length is <b>a</b>, then the <b>sum of all edges</b> = <b>12 · a</b>.</p><p>Complete the table:</p><table class="tt"><tr><th>a</th><th>2 cm</th><th>5 cm</th><th>10 cm</th></tr><tr><td><b>12 · a</b></td><td>?</td><td>?</td><td>?</td></tr></table>',
+      hint:'💡 Vynásob každé a číslem 12: 12·2 = 24, 12·5 = 60, 12·10 = 120.',
+      hint_en:'💡 Multiply each a by 12: 12·2 = 24, 12·5 = 60, 12·10 = 120.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Krychle má hranu <b>a = 7 cm</b>.</p><p>Kolik je <b>součet všech hran</b> v cm?</p>',
-      hint:'💡 12 · 7 = ?' }
+      body_en:'<p>A cube has edge <b>a = 7 cm</b>.</p><p>What is the <b>sum of all edges</b> in cm?</p>',
+      hint:'💡 12 · 7 = ?',
+      hint_en:'💡 12 · 7 = ?' }
   ],
   code:'84',
-  successMsg:'🔓 Přesně! 12 · 7 = 84 cm. Zámek 6 otevřen!'
+  successMsg:'🔓 Přesně! 12 · 7 = 84 cm. Zámek 6 otevřen!',
+  successMsg_en:'🔓 Exactly! 12 · 7 = 84 cm. Lock 6 opened!'
 },
 {
   id:7, color:'indigo', icon:'🔷',
-  title:'Zámek 7 – Hrany kvádru',
-  tag:'Součet hran kvádru', tagClass:'indigo',
+  title:'Zámek 7 – Hrany kvádru', title_en:'Lock 7 – Edges of a Cuboid',
+  tag:'Součet hran kvádru', tag_en:'Sum of edges of a cuboid', tagClass:'indigo',
   tasks:[
-    { title:'🧩 Kvádr má hrany ve třech délkách',
+    { title:'🧩 Kvádr má hrany ve třech délkách', title_en:'🧩 A cuboid has edges in three lengths',
       body:'<p>Kvádr má taky <b>12 hran</b>, ale ve <b>třech délkách</b>: <b>4 hrany délky a, 4 délky b, 4 délky c</b>.</p><p>Vzorec: <b>součet hran = 4 · (a + b + c)</b></p><p>Zkus pro kvádr <b>a = 2, b = 3, c = 4</b>:</p><p>4 · (2 + 3 + 4) = 4 · 9 = ?</p>',
-      hint:'💡 Nejdřív sečti všechny tři rozměry, pak vynásob 4.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>A cuboid also has <b>12 edges</b>, but in <b>three lengths</b>: <b>4 edges of length a, 4 of b, 4 of c</b>.</p><p>Formula: <b>sum of edges = 4 · (a + b + c)</b></p><p>Try it for a cuboid <b>a = 2, b = 3, c = 4</b>:</p><p>4 · (2 + 3 + 4) = 4 · 9 = ?</p>',
+      hint:'💡 Nejdřív sečti všechny tři rozměry, pak vynásob 4.',
+      hint_en:'💡 First add all three dimensions, then multiply by 4.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Kvádr má rozměry <b>3 × 5 × 7 cm</b>.</p><p>Spočítej <b>součet všech hran</b> v cm.</p>',
-      hint:'💡 4 · (3 + 5 + 7) = 4 · 15 = ?' }
+      body_en:'<p>A cuboid has dimensions <b>3 × 5 × 7 cm</b>.</p><p>Calculate the <b>sum of all edges</b> in cm.</p>',
+      hint:'💡 4 · (3 + 5 + 7) = 4 · 15 = ?',
+      hint_en:'💡 4 · (3 + 5 + 7) = 4 · 15 = ?' }
   ],
   code:'60',
-  successMsg:'🔓 Skvěle! 4 · (3+5+7) = 4 · 15 = 60 cm. Zámek 7 otevřen!'
+  successMsg:'🔓 Skvěle! 4 · (3+5+7) = 4 · 15 = 60 cm. Zámek 7 otevřen!',
+  successMsg_en:'🔓 Great! 4 · (3+5+7) = 4 · 15 = 60 cm. Lock 7 opened!'
 },
 {
   id:8, color:'rose', icon:'🌹',
-  title:'Zámek 8 – Povrch krychle',
-  tag:'Povrch S = 6·a²', tagClass:'rose',
+  title:'Zámek 8 – Povrch krychle', title_en:'Lock 8 – Surface Area of a Cube',
+  tag:'Povrch S = 6·a²', tag_en:'Surface S = 6·a²', tagClass:'rose',
   tasks:[
-    { title:'🧩 Co je povrch tělesa',
+    { title:'🧩 Co je povrch tělesa', title_en:'🧩 What is surface area?',
       body:'<p><b>Povrch (S)</b> tělesa = <b>obsah všech stěn dohromady</b>.</p><p>Krychle má 6 stejných čtverců. Obsah jednoho čtverce = <b>a · a = a²</b>.</p><p>Vzorec: <b>S = 6 · a²</b></p><p>Doplň:</p><table class="tt"><tr><th>a</th><th>1 cm</th><th>2 cm</th><th>3 cm</th><th>4 cm</th></tr><tr><td><b>a²</b></td><td>?</td><td>?</td><td>?</td><td>?</td></tr><tr><td><b>S = 6·a²</b></td><td>?</td><td>?</td><td>?</td><td>?</td></tr></table>',
-      hint:'💡 Nejdřív umocni a (a · a), pak vynásob 6. Pro a=2: 2·2=4, pak 6·4=24.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>The <b>surface area (S)</b> of a solid = <b>the total area of all its faces</b>.</p><p>A cube has 6 identical squares. Area of one square = <b>a · a = a²</b>.</p><p>Formula: <b>S = 6 · a²</b></p><p>Complete:</p><table class="tt"><tr><th>a</th><th>1 cm</th><th>2 cm</th><th>3 cm</th><th>4 cm</th></tr><tr><td><b>a²</b></td><td>?</td><td>?</td><td>?</td><td>?</td></tr><tr><td><b>S = 6·a²</b></td><td>?</td><td>?</td><td>?</td><td>?</td></tr></table>',
+      hint:'💡 Nejdřív umocni a (a · a), pak vynásob 6. Pro a=2: 2·2=4, pak 6·4=24.',
+      hint_en:'💡 First square a (a · a), then multiply by 6. For a=2: 2·2=4, then 6·4=24.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Krychle má hranu <b>a = 5 cm</b>.</p><p>Kolik je její <b>povrch</b> v cm²?</p>',
-      hint:'💡 a² = 5·5 = 25; pak S = 6 · 25 = ?' }
+      body_en:'<p>A cube has edge <b>a = 5 cm</b>.</p><p>What is its <b>surface area</b> in cm²?</p>',
+      hint:'💡 a² = 5·5 = 25; pak S = 6 · 25 = ?',
+      hint_en:'💡 a² = 5·5 = 25; then S = 6 · 25 = ?' }
   ],
   code:'150',
-  successMsg:'🔓 Bezvadně! S = 6 · 25 = 150 cm². Zámek 8 otevřen!'
+  successMsg:'🔓 Bezvadně! S = 6 · 25 = 150 cm². Zámek 8 otevřen!',
+  successMsg_en:'🔓 Perfect! S = 6 · 25 = 150 cm². Lock 8 opened!'
 },
 {
   id:9, color:'cyan', icon:'🩵',
-  title:'Zámek 9 – Povrch kvádru',
-  tag:'Povrch S = 2·(ab+bc+ac)', tagClass:'cyan',
+  title:'Zámek 9 – Povrch kvádru', title_en:'Lock 9 – Surface Area of a Cuboid',
+  tag:'Povrch S = 2·(ab+bc+ac)', tag_en:'Surface S = 2·(ab+bc+ac)', tagClass:'cyan',
   tasks:[
-    { title:'🧩 Vzorec pro povrch kvádru',
+    { title:'🧩 Vzorec pro povrch kvádru', title_en:'🧩 Formula for the surface area of a cuboid',
       body:'<p>Kvádr má 3 různé velikosti stěn (vždy po 2 stejných):</p><ul><li>2× obdélník <b>a × b</b></li><li>2× obdélník <b>b × c</b></li><li>2× obdélník <b>a × c</b></li></ul><p>Vzorec: <b>S = 2 · (a·b + b·c + a·c)</b></p><p>Zkus pro <b>a = 2, b = 3, c = 4</b>:</p><p>S = 2 · (2·3 + 3·4 + 2·4) = 2 · (6 + 12 + 8) = 2 · 26 = ?</p>',
-      hint:'💡 Spočítej tři součiny dvojic stran (ab, bc, ac), sečti je, vynásob 2.' },
-    { title:'🔢 Kód zámku',
+      body_en:'<p>A cuboid has 3 different face sizes (always 2 of each):</p><ul><li>2× rectangle <b>a × b</b></li><li>2× rectangle <b>b × c</b></li><li>2× rectangle <b>a × c</b></li></ul><p>Formula: <b>S = 2 · (a·b + b·c + a·c)</b></p><p>Try for <b>a = 2, b = 3, c = 4</b>:</p><p>S = 2 · (2·3 + 3·4 + 2·4) = 2 · (6 + 12 + 8) = 2 · 26 = ?</p>',
+      hint:'💡 Spočítej tři součiny dvojic stran (ab, bc, ac), sečti je, vynásob 2.',
+      hint_en:'💡 Calculate the three pairwise products (ab, bc, ac), add them, multiply by 2.' },
+    { title:'🔢 Kód zámku', title_en:'🔢 Lock code',
       body:'<p>Kvádr má rozměry <b>3 × 4 × 5 cm</b>.</p><p>Spočítej jeho <b>povrch</b> v cm².</p>',
-      hint:'💡 a·b = 12, b·c = 20, a·c = 15. Součet = 47. S = 2 · 47 = ?' }
+      body_en:'<p>A cuboid has dimensions <b>3 × 4 × 5 cm</b>.</p><p>Calculate its <b>surface area</b> in cm².</p>',
+      hint:'💡 a·b = 12, b·c = 20, a·c = 15. Součet = 47. S = 2 · 47 = ?',
+      hint_en:'💡 a·b = 12, b·c = 20, a·c = 15. Sum = 47. S = 2 · 47 = ?' }
   ],
   code:'94',
-  successMsg:'🔓 Výborně! S = 2 · (12+20+15) = 2 · 47 = 94 cm². Zámek 9 otevřen!'
+  successMsg:'🔓 Výborně! S = 2 · (12+20+15) = 2 · 47 = 94 cm². Zámek 9 otevřen!',
+  successMsg_en:'🔓 Excellent! S = 2 · (12+20+15) = 2 · 47 = 94 cm². Lock 9 opened!'
 },
 {
   id:10, color:'gold', icon:'🏆',
-  title:'Zámek 10 – Finále: Objem!',
-  tag:'Objem krychle a kvádru', tagClass:'gold',
+  title:'Zámek 10 – Finále: Objem!', title_en:'Lock 10 – Final: Volume!',
+  tag:'Objem krychle a kvádru', tag_en:'Volume of cube and cuboid', tagClass:'gold',
   tasks:[
-    { title:'🏆 Poslední výzva – Objem',
+    { title:'🏆 Poslední výzva – Objem', title_en:'🏆 Final challenge – Volume',
       body:'<p><b>Objem (V)</b> = kolik místa těleso zaujímá v prostoru.</p><ul><li>Krychle: <b>V = a · a · a = a³</b></li><li>Kvádr: <b>V = a · b · c</b></li></ul><p>Vypočítej:</p><p>a) Objem <b>krychle</b> s hranou <b>a = 4 cm</b></p><p>b) Objem <b>kvádru</b> s rozměry <b>2 × 3 × 4 cm</b></p>',
-      hint:'💡 a) 4 · 4 · 4 = 64. b) 2 · 3 · 4 = 24.' },
-    { title:'🔢 Finální kód',
+      body_en:'<p><b>Volume (V)</b> = how much space a solid takes up.</p><ul><li>Cube: <b>V = a · a · a = a³</b></li><li>Cuboid: <b>V = a · b · c</b></li></ul><p>Calculate:</p><p>a) Volume of a <b>cube</b> with edge <b>a = 4 cm</b></p><p>b) Volume of a <b>cuboid</b> with dimensions <b>2 × 3 × 4 cm</b></p>',
+      hint:'💡 a) 4 · 4 · 4 = 64. b) 2 · 3 · 4 = 24.',
+      hint_en:'💡 a) 4 · 4 · 4 = 64. b) 2 · 3 · 4 = 24.' },
+    { title:'🔢 Finální kód', title_en:'🔢 Final code',
       body:'<p>Sečti oba objemy z předchozí úlohy:</p><p><b>Kód = V<sub>krychle</sub> + V<sub>kvádru</sub></b> (v cm³)</p>',
-      hint:'💡 64 + 24 = ?' }
+      body_en:'<p>Add both volumes from the previous task:</p><p><b>Code = V<sub>cube</sub> + V<sub>cuboid</sub></b> (in cm³)</p>',
+      hint:'💡 64 + 24 = ?',
+      hint_en:'💡 64 + 24 = ?' }
   ],
   code:'88',
-  successMsg:'🏆 BRAVO! 64 + 24 = 88. Všechny zámky tělesa jsou tvé! Poklad geometrie je tvůj!'
+  successMsg:'🏆 BRAVO! 64 + 24 = 88. Všechny zámky tělesa jsou tvé! Poklad geometrie je tvůj!',
+  successMsg_en:'🏆 BRAVO! 64 + 24 = 88. All solid locks are yours! The geometry treasure is yours!'
 }
 ];
 
-/* Progresivní nápověda ke kódu zámku — 3 úrovně */
-const CODE_HINTS = {
+const CODE_HINTS_CS = {
   1: ['Těleso má 3 rozměry (délku, šířku, výšku). Rovinný útvar jen 2.', 'V seznamu: kostka, kniha, obdélník, krabice, kruh, balón. Které jsou 3D?', 'kostka, kniha, krabice, balón = <b>4</b>.'],
   2: ['Krychle má vrcholy (rohy), hrany (úsečky), stěny (plochy). Spočítej je.', 'Vrcholy = 8, hrany = 12, stěny = 6.', '8 + 12 + 6 = <b>26</b>.'],
   3: ['Krychle = všechny hrany stejně dlouhé. Kvádr = různé.', 'Krychle v seznamu: hrací kostka, kostka cukru, kostka ledu, Rubikova kostka.', '<b>4</b> krychle.'],
@@ -429,20 +524,41 @@ const CODE_HINTS = {
   10: ['Objem: krychle V = a³, kvádr V = a·b·c. Spočítej oba a sečti.', 'a) 4³ = 64. b) 2·3·4 = 24.', '64 + 24 = <b>88</b> cm³.'],
 };
 
+const CODE_HINTS_EN = {
+  1: ['A solid has 3 dimensions (length, width, height). A flat shape only has 2.', 'From the list: cube, book, rectangle, box, circle, balloon. Which ones are 3D?', 'cube, book, box, balloon = <b>4</b>.'],
+  2: ['A cube has vertices (corners), edges (line segments), faces (flat surfaces). Count them.', 'Vertices = 8, edges = 12, faces = 6.', '8 + 12 + 6 = <b>26</b>.'],
+  3: ['Cube = all edges equal length. Cuboid = different lengths.', 'Cubes in the list: dice, sugar cube, ice cube, Rubik\'s cube.', '<b>4</b> cubes.'],
+  4: ['Net of a cube = 6 squares. Perimeter of one square = 4 × side.', 'Side = 5 cm. Perimeter = 4 × 5 = ?', '4 × 5 = <b>20</b> cm.'],
+  5: ['Net of a cuboid = 6 rectangles. Area of a rectangle = length × width.', 'Sides 2 × 3 cm. Area = ?', '2 × 3 = <b>6</b> cm².'],
+  6: ['A cube has 12 edges of equal length. Formula: 12 × a.', '12 × 7 = ?', '12 × 7 = <b>84</b> cm.'],
+  7: ['A cuboid has 12 edges in 3 lengths: 4× a, 4× b, 4× c. Formula: 4 × (a + b + c).', '4 × (3 + 5 + 7) = 4 × 15 = ?', '4 × 15 = <b>60</b> cm.'],
+  8: ['Surface area = total area of all faces. Cube = 6 squares. Formula: S = 6 × a².', 'a = 5, so a² = 25. S = 6 × 25.', '6 × 25 = <b>150</b> cm².'],
+  9: ['A cuboid has 3 pairs of faces: a×b, b×c, a×c. Formula: S = 2 × (ab + bc + ac).', '2 × (3·4 + 4·5 + 3·5) = 2 × (12 + 20 + 15).', '2 × 47 = <b>94</b> cm².'],
+  10: ['Volume: cube V = a³, cuboid V = a·b·c. Calculate both and add.', 'a) 4³ = 64. b) 2·3·4 = 24.', '64 + 24 = <b>88</b> cm³.'],
+};
+
 let codeHintLevel = 0;
 
 function advanceCodeHint() {
   if (codeHintLevel >= 3) return;
   codeHintLevel++;
-  const hints = CODE_HINTS[STEPS[cur].id] || ['Přečti si pozorně postup nahoře.', 'Postupně spočítej, co se ptají.', 'Výsledek vyplyne z výpočtu.'];
+  const CODE_HINTS = lang === 'en' ? CODE_HINTS_EN : CODE_HINTS_CS;
+  const hints = CODE_HINTS[STEPS[cur].id] || [
+    i18n('Přečti si pozorně postup nahoře.', 'Read the instructions above carefully.'),
+    i18n('Postupně spočítej, co se ptají.', 'Work through the calculation step by step.'),
+    i18n('Výsledek vyplyne z výpočtu.', 'The answer follows from the calculation.')
+  ];
   const box = document.getElementById('ch-box');
   const btn = document.getElementById('ch-btn');
   const counter = document.getElementById('ch-counter');
   if (!box || !btn) return;
   box.classList.add('show');
   box.dataset.level = codeHintLevel;
-  const labels = ['Nasměrování', 'Vzorec', 'Postup s výsledkem'];
-  box.innerHTML = `<span class="h-label">Nápověda ${codeHintLevel}/3 — ${labels[codeHintLevel-1]}</span>${hints[codeHintLevel - 1]}`;
+  const labels = i18n(
+    ['Nasměrování', 'Vzorec', 'Postup s výsledkem'],
+    ['Direction', 'Formula', 'Solution steps']
+  );
+  box.innerHTML = `<span class="h-label">${i18n('Nápověda','Hint')} ${codeHintLevel}/3 — ${labels[codeHintLevel-1]}</span>${hints[codeHintLevel - 1]}`;
   if (counter) {
     counter.querySelectorAll('.dot').forEach((d, i) => {
       d.classList.toggle('shown', i < codeHintLevel);
@@ -450,18 +566,15 @@ function advanceCodeHint() {
     });
   }
   if (codeHintLevel < 3) {
-    btn.textContent = `💡 Další nápověda ${codeHintLevel+1}/3`;
+    btn.textContent = `💡 ${i18n('Další nápověda','Next hint')} ${codeHintLevel+1}/3`;
   } else {
     btn.disabled = true;
-    btn.textContent = '💡 Všechny nápovědy ukázány';
+    btn.textContent = `💡 ${i18n('Všechny nápovědy ukázány','All hints shown')}`;
   }
 }
 
 let cur = 0;
 let att = new Array(STEPS.length).fill(0);
-
-document.getElementById('btn-start').addEventListener('click', startGame);
-document.getElementById('btn-restart').addEventListener('click', () => location.reload());
 
 function startGame() {
   document.getElementById('intro').classList.remove('active');
@@ -475,7 +588,8 @@ function render(idx) {
   cur = idx;
   codeHintLevel = 0;
   const s = STEPS[idx];
-  document.getElementById('prog-label').textContent = `Zámek ${idx+1} z ${STEPS.length}`;
+  document.getElementById('prog-label').textContent =
+    i18n(`Zámek ${idx+1} z ${STEPS.length}`, `Lock ${idx+1} of ${STEPS.length}`);
   document.getElementById('prog-fill').style.width = `${(idx / STEPS.length) * 100}%`;
   for (let i = 0; i < STEPS.length; i++) {
     const el = document.getElementById(`s${i}`);
@@ -491,30 +605,30 @@ function render(idx) {
 
   const tasksHTML = s.tasks.map(t => `
     <div class="task-card ${s.color}">
-      <span class="tag ${s.tagClass}">${s.tag}</span>
-      <h3>${t.title}</h3>
-      ${t.body}
-      <button class="hint-btn" onclick="toggleHint(this)">💡 Potřebuji nápovědu</button>
-      <div class="hint-box">${t.hint}</div>
+      <span class="tag ${s.tagClass}">${i18n(s.tag, s.tag_en)}</span>
+      <h3>${i18n(t.title, t.title_en)}</h3>
+      ${i18n(t.body, t.body_en)}
+      <button class="hint-btn" onclick="toggleHint(this)">${i18n('💡 Potřebuji nápovědu','💡 I need a hint')}</button>
+      <div class="hint-box">${i18n(t.hint, t.hint_en)}</div>
     </div>
   `).join('');
 
   document.getElementById('step-container').innerHTML = `
     <div class="lock-header">
       <span class="lock-icon-big">${s.icon}</span>
-      <span class="lock-title" style="color:var(${cv})">${s.title}</span>
+      <span class="lock-title" style="color:var(${cv})">${i18n(s.title, s.title_en)}</span>
       <span class="lock-badge">${idx+1}/${STEPS.length}</span>
     </div>
     ${tasksHTML}
     <div class="code-wrap">
-      <label>🔐 Zadej kód zámku ${idx+1}:</label>
+      <label>&#x1F510; ${i18n(`Zadej kód zámku ${idx+1}:`, `Enter lock code ${idx+1}:`)}</label>
       <div class="code-row">
         <input type="number" class="code-input" id="ci" placeholder="???"
           onkeydown="if(event.key==='Enter') chk()">
-        <button class="btn-check" onclick="chk()">Odemknout 🔓</button>
+        <button class="btn-check" onclick="chk()">${i18n('Odemknout 🔓','Unlock 🔓')}</button>
       </div>
       <div class="code-hint-bar">
-        <button class="code-hint-btn" id="ch-btn" onclick="advanceCodeHint()">💡 Nápověda ke kódu 1/3</button>
+        <button class="code-hint-btn" id="ch-btn" onclick="advanceCodeHint()">💡 ${i18n('Nápověda ke kódu 1/3','Code hint 1/3')}</button>
         <span class="code-hint-counter" id="ch-counter">
           <span class="dot"></span><span class="dot"></span><span class="dot"></span>
         </span>
@@ -523,8 +637,8 @@ function render(idx) {
       <div class="feedback" id="fb"></div>
     </div>
     <div class="unlock-anim" id="ua">
-      <div class="big-icon">🔓✨</div>
-      <p>${s.successMsg}</p>
+      <div class="big-icon">&#x1F513;&#x2728;</div>
+      <p>${i18n(s.successMsg, s.successMsg_en)}</p>
     </div>
   `;
   window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -533,7 +647,9 @@ function render(idx) {
 function toggleHint(btn) {
   const h = btn.nextElementSibling;
   h.classList.toggle('show');
-  btn.textContent = h.classList.contains('show') ? '🙈 Skrýt nápovědu' : '💡 Potřebuji nápovědu';
+  btn.textContent = h.classList.contains('show')
+    ? i18n('🙈 Skrýt nápovědu', '🙈 Hide hint')
+    : i18n('💡 Potřebuji nápovědu', '💡 I need a hint');
 }
 
 function chk() {
@@ -554,12 +670,10 @@ function chk() {
     inp.classList.add('error');
     inp.classList.remove('success');
     setTimeout(() => inp.classList.remove('error'), 380);
-    const msgs = [
-      'Hmm, to není ono. Zkontroluj postup!',
-      'Zkus to znovu – možná jiný výpočet?',
-      'Nevzdávej se! Přečti si nápovědu.',
-      'Ještě jednou, jsi blízko!'
-    ];
+    const msgs = i18n(
+      ['Hmm, to není ono. Zkontroluj postup!', 'Zkus to znovu – možná jiný výpočet?', 'Nevzdávej se! Přečti si nápovědu.', 'Ještě jednou, jsi blízko!'],
+      ['Hmm, not quite. Check your working!', 'Try again – maybe a different approach?', "Don't give up! Read the hint.", 'One more time, you\'re close!']
+    );
     fb.className = 'feedback err';
     fb.textContent = msgs[Math.min(att[cur] - 1, msgs.length - 1)];
   }
@@ -568,6 +682,7 @@ function chk() {
 function finish() {
   document.getElementById('game').classList.remove('active');
   document.getElementById('finish').classList.add('active');
+  buildFinish();
   const wrap = document.getElementById('confetti');
   const cols = ['#f5c842','#1a73c8','#1e9e5a','#e74c3c','#7c3aad','#0f8a72','#ff7f50','#b5286e'];
   for (let i = 0; i < 90; i++) {
@@ -584,6 +699,15 @@ function finish() {
     wrap.appendChild(el);
   }
 }
+
+// Init
+document.querySelectorAll('.lang-btn').forEach(b =>
+  b.classList.toggle('active', b.dataset.lang === lang));
+document.querySelectorAll('.tp-back').forEach(el =>
+  el.textContent = i18n('← zpět na projekty', '← back to projects'));
+document.querySelectorAll('.tp-home').forEach(el =>
+  el.textContent = i18n('domů', 'home'));
+buildIntro();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Full bilingual CS/EN support across all interactive educational projects, with a 🇨🇿/🇬🇧 flag toggle bar (fixed bottom-right, persisted in `localStorage`).

### Files changed

- **`unikovka_procenta.html`** — 10 locks, full EN translations (titles, tasks, hints, code hints), `buildIntro`/`buildFinish` dynamic builders
- **`unikovka_telesa.html`** — 10 locks (cubes/cuboids), same bilingual pattern
- **`cesta_penez.html`** — 8-act financial literacy game; `BUILD_EN` object with English scene content for all acts, `buildIntro`/`buildResult` dynamic, i18n'd hub/act/scene rendering, unit labels (Kč↔CZK), decision feedback
- **`projects/index.html`** — removed EN description from `přijímačky-matematika` (CS-only per site convention)

## Test plan

- [ ] Each file: play a section in Czech, switch to EN mid-session — screen re-renders, progress preserved
- [ ] Reload in EN — lang persists via localStorage
- [ ] cesta_penez: hub tiles show English act titles, chapter complete screen in EN, cert screen in EN
- [ ] Navigation links (`← zpět na projekty` / `← back to projects`, `← mapa` / `← map`) update on switch
- [ ] projects/index.html: přijímačky shows only CS description, all other projects show both CS+EN