### PR TITLE
Equal-height cards, tags pinned to bottom, larger text

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -126,8 +126,7 @@
     /* Project grid */
     .project-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-      align-items: start;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
       gap: 1px;
       background: var(--border);
       border: 1px solid var(--border);
@@ -138,7 +137,9 @@
 
     .project {
       background: var(--bg-window);
-      padding: 8px 10px 9px;
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
       transition: background 0.12s;
     }
     .project:hover { background: #121a13; }
@@ -147,32 +148,33 @@
     .project .line {
       display: flex;
       align-items: baseline;
-      gap: 6px;
+      gap: 8px;
       flex-wrap: wrap;
       white-space: normal;
     }
-    .project .perm { color: var(--fg-dim); font-size: 9px; flex-shrink: 0; }
-    .project .filename { color: var(--accent); font-size: 12px; }
+    .project .perm { color: var(--fg-dim); font-size: 10px; flex-shrink: 0; }
+    .project .filename { color: var(--accent); font-size: 14px; }
 
     .project .desc-en, .project .desc-cs {
       color: var(--fg);
-      font-size: 10px;
-      line-height: 1.4;
-      margin: 3px 0 0;
+      font-size: 12px;
+      line-height: 1.5;
+      margin: 6px 0 0;
     }
     .project .desc-en::before, .project .desc-cs::before {
-      font-size: 8px;
+      font-size: 9px;
       font-weight: 700;
       letter-spacing: 0.1em;
-      margin-right: 4px;
+      margin-right: 5px;
     }
     .project .desc-en::before { content: 'EN'; color: var(--fg-dim); }
     .project .desc-cs::before { content: 'CS'; color: var(--amber); }
 
     .project .meta {
       color: var(--fg-dim);
-      font-size: 9px;
-      margin-top: 4px;
+      font-size: 10px;
+      margin-top: auto;
+      padding-top: 8px;
       letter-spacing: 0.02em;
     }
 


### PR DESCRIPTION
## Summary

- Karty teď mají v rámci jednoho řádku stejnou výšku (odstraněno `align-items: start` které způsobovalo světle zelené mezery — pozadí gridu prosvítalo pod kratšími kartami)
- `.project` je flex column, `.meta` přitlačeno dolů přes `margin-top: auto` → volné místo je teď v rámci karty mezi popisem a tagy, ne mezi kartami
- Větší písmo: filename 12→14, desc 10→12, meta 9→10, perm 9→10

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_