### PR TITLE
Fix: replace Fredoka with Lexend in 3 únikovky

### DIFF
--- a/projects/unikovka_procenta.html
+++ b/projects/unikovka_procenta.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Únikovka: Procenta</title>
-<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700;800&family=Fredoka:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700;800&display=swap" rel="stylesheet">
 <style>
 :root {
   --gold-dark:#c89a10; --blue:#1a73c8; --blue-light:#e8f1fb;
@@ -35,8 +35,8 @@ body{
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;
   filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}
-.title-main{font-family:'Fredoka',cursive;font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:700}
-.title-sub{font-family:'Fredoka',cursive;font-size:1.45rem;color:var(--gold-dark);font-weight:600}
+.title-main{font-family:'Lexend',sans-serif;font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:700}
+.title-sub{font-family:'Lexend',sans-serif;font-size:1.45rem;color:var(--gold-dark);font-weight:600}
 .intro-card{background:var(--card);border-radius:var(--radius);padding:22px 26px;
   box-shadow:var(--shadow);border-left:6px solid var(--blue);text-align:left;width:100%}
 .intro-card p{font-size:.97rem;line-height:1.75}
@@ -44,7 +44,7 @@ body{
 .intro-card b{color:var(--blue)}
 .rules{background:var(--card);border-radius:var(--radius);padding:18px 22px;
   box-shadow:var(--shadow);width:100%;border-left:6px solid var(--gold-dark)}
-.rules h3{font-family:'Fredoka',cursive;color:var(--gold-dark);font-size:1.05rem;margin-bottom:10px;font-weight:600}
+.rules h3{font-family:'Lexend',sans-serif;color:var(--gold-dark);font-size:1.05rem;margin-bottom:10px;font-weight:600}
 .rules ul{list-style:none;display:flex;flex-direction:column;gap:8px}
 .rules li{display:flex;align-items:flex-start;gap:10px;font-size:.95rem;line-height:1.55}
 .btn-primary{
@@ -72,7 +72,7 @@ body{
 #game{justify-content:flex-start;gap:0}
 .lock-header{width:100%;display:flex;align-items:center;gap:12px;margin-bottom:16px}
 .lock-icon-big{font-size:2.2rem}
-.lock-title{font-family:'Fredoka',cursive;font-size:1.4rem;font-weight:600}
+.lock-title{font-family:'Lexend',sans-serif;font-size:1.4rem;font-weight:600}
 .lock-badge{margin-left:auto;background:var(--blue);color:#fff;border-radius:50px;
   padding:3px 13px;font-size:.82rem;font-weight:700;white-space:nowrap}
 .task-card{background:var(--card);border-radius:var(--radius);padding:22px 22px 18px;

--- a/projects/unikovka_pythagoras.html
+++ b/projects/unikovka_pythagoras.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Únikovka: Pythagorova věta</title>
 <meta name="description" content="Interaktivní únikovka z matematiky – Pythagorova věta, pravoúhlý trojúhelník, přepona, odvěsny.">
-<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700;800&family=Fredoka:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700;800&display=swap" rel="stylesheet">
 <style>
 :root {
   --gold-dark:#c89a10; --blue:#1a73c8; --blue-light:#e8f1fb;
@@ -36,8 +36,8 @@ body{
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;
   filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}
-.title-main{font-family:'Fredoka',cursive;font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:700}
-.title-sub{font-family:'Fredoka',cursive;font-size:1.45rem;color:var(--gold-dark);font-weight:600}
+.title-main{font-family:'Lexend',sans-serif;font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:700}
+.title-sub{font-family:'Lexend',sans-serif;font-size:1.45rem;color:var(--gold-dark);font-weight:600}
 .intro-card{background:var(--card);border-radius:var(--radius);padding:22px 26px;
   box-shadow:var(--shadow);border-left:6px solid var(--blue);text-align:left;width:100%}
 .intro-card p{font-size:.97rem;line-height:1.75}
@@ -45,7 +45,7 @@ body{
 .intro-card b{color:var(--blue)}
 .rules{background:var(--card);border-radius:var(--radius);padding:18px 22px;
   box-shadow:var(--shadow);width:100%;border-left:6px solid var(--gold-dark)}
-.rules h3{font-family:'Fredoka',cursive;color:var(--gold-dark);font-size:1.05rem;margin-bottom:10px;font-weight:600}
+.rules h3{font-family:'Lexend',sans-serif;color:var(--gold-dark);font-size:1.05rem;margin-bottom:10px;font-weight:600}
 .rules ul{list-style:none;display:flex;flex-direction:column;gap:8px}
 .rules li{display:flex;align-items:flex-start;gap:10px;font-size:.95rem;line-height:1.55}
 .btn-primary{
@@ -73,7 +73,7 @@ body{
 #game{justify-content:flex-start;gap:0}
 .lock-header{width:100%;display:flex;align-items:center;gap:12px;margin-bottom:16px}
 .lock-icon-big{font-size:2.2rem}
-.lock-title{font-family:'Fredoka',cursive;font-size:1.4rem;font-weight:600}
+.lock-title{font-family:'Lexend',sans-serif;font-size:1.4rem;font-weight:600}
 .lock-badge{margin-left:auto;background:var(--blue);color:#fff;border-radius:50px;
   padding:3px 13px;font-size:.82rem;font-weight:700;white-space:nowrap}
 .task-card{background:var(--card);border-radius:var(--radius);padding:22px 22px 18px;

--- a/projects/unikovka_telesa.html
+++ b/projects/unikovka_telesa.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Únikovka: Tělesa (krychle a kvádr)</title>
 <meta name="description" content="Interaktivní únikovka z matematiky pro 6. třídu – krychle, kvádr, povrch, objem.">
-<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700;800&family=Fredoka:wght@400;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;700;800&display=swap" rel="stylesheet">
 <style>
 :root {
   --gold-dark:#c89a10; --blue:#1a73c8; --blue-light:#e8f1fb;
@@ -36,8 +36,8 @@ body{
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;
   filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}
-.title-main{font-family:'Fredoka',cursive;font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:700}
-.title-sub{font-family:'Fredoka',cursive;font-size:1.45rem;color:var(--gold-dark);font-weight:600}
+.title-main{font-family:'Lexend',sans-serif;font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:700}
+.title-sub{font-family:'Lexend',sans-serif;font-size:1.45rem;color:var(--gold-dark);font-weight:600}
 .intro-card{background:var(--card);border-radius:var(--radius);padding:22px 26px;
   box-shadow:var(--shadow);border-left:6px solid var(--blue);text-align:left;width:100%}
 .intro-card p{font-size:.97rem;line-height:1.75}
@@ -45,7 +45,7 @@ body{
 .intro-card b{color:var(--blue)}
 .rules{background:var(--card);border-radius:var(--radius);padding:18px 22px;
   box-shadow:var(--shadow);width:100%;border-left:6px solid var(--gold-dark)}
-.rules h3{font-family:'Fredoka',cursive;color:var(--gold-dark);font-size:1.05rem;margin-bottom:10px;font-weight:600}
+.rules h3{font-family:'Lexend',sans-serif;color:var(--gold-dark);font-size:1.05rem;margin-bottom:10px;font-weight:600}
 .rules ul{list-style:none;display:flex;flex-direction:column;gap:8px}
 .rules li{display:flex;align-items:flex-start;gap:10px;font-size:.95rem;line-height:1.55}
 .btn-primary{
@@ -73,7 +73,7 @@ body{
 #game{justify-content:flex-start;gap:0}
 .lock-header{width:100%;display:flex;align-items:center;gap:12px;margin-bottom:16px}
 .lock-icon-big{font-size:2.2rem}
-.lock-title{font-family:'Fredoka',cursive;font-size:1.4rem;font-weight:600}
+.lock-title{font-family:'Lexend',sans-serif;font-size:1.4rem;font-weight:600}
 .lock-badge{margin-left:auto;background:var(--blue);color:#fff;border-radius:50px;
   padding:3px 13px;font-size:.82rem;font-weight:700;white-space:nowrap}
 .task-card{background:var(--card);border-radius:var(--radius);padding:22px 22px 18px;


### PR DESCRIPTION
## Bug fix

`unikovka_procenta`, `unikovka_telesa` a `unikovka_pythagoras` načítaly a aktivně používaly font **Fredoka** na nadpisech a titulcích. Dle CLAUDE.md: *"Avoid Fredoka (broken Czech diacritics for some users)"* — u části uživatelů se nezobrazují správně háčky a čárky.

Nahrazeno fontem **Lexend** (plná podpora Latin Extended-A).

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_