### PR TITLE
fix: Czech number format in answer inputs (comma, spaces)

### DIFF
--- a/projects/cesta_penez.html
+++ b/projects/cesta_penez.html
@@ -2116,7 +2116,7 @@ function checkMath(content) {
   const fb = document.getElementById('m-fb');
   const raw = inp.value.trim();
   if (raw === '') { inp.focus(); return; }
-  const val = Number(raw);
+  const val = Number(raw.replace(/[\s ]/g, ''));
   const correct = val === content.answer;
   inp.disabled = true; btn.disabled = true;
   const unitLabel = content.unit ? (lang === 'en' ? ' CZK' : ' ' + content.unit) : '';

--- a/projects/goniometrie.html
+++ b/projects/goniometrie.html
@@ -1127,8 +1127,8 @@ function renderMath(data,container) {
   const btnNext=container.querySelector('#btn-next');
   function check() {
     if(answered){ nextScene(); return; }
-    const val=parseFloat(input.value);
-    if(isNaN(val)){ fb.innerHTML=i18n('Zadej číslo.','Enter a number.'); fb.className='feedback err'; return; }
+    const val=parseFloat(input.value.replace(',','.'));
+    if(isNaN(val)){ fb.innerHTML=i18n('Zadej číslo (desetinnou čárku nebo tečku).','Enter a number (use comma or dot for decimals).'); fb.className='feedback err'; return; }
     const ok=Math.abs(val-data.ans)<=(data.tol||0);
     answered=true;
     if(ok) chapterScore.earned+=1;

--- a/projects/procenta_priklady.html
+++ b/projects/procenta_priklady.html
@@ -1337,7 +1337,7 @@ function checkAnswer() {
   const fb = document.getElementById('feedback');
   const raw = inp.value.trim();
   if (raw === '') { inp.focus(); return; }
-  const userVal = Number(raw);
+  const userVal = Number(raw.replace(/[\s ]/g, ''));
   const p = problems[cur];
   const correct = userVal === p.answer;
 


### PR DESCRIPTION
## Summary

Deep audit of all interactive projects. Three files had input parsing bugs where Czech number formatting caused wrong answers to be marked incorrect.

- **goniometrie.html**: `parseFloat(input.value)` didn't handle comma decimal separator. Student typing "7,5" got `NaN` → "Zadej číslo." error. Fixed with `.replace(',','.')` + improved error message.
- **cesta_penez.html**: `Number(raw)` rejected inputs with spaces (Czech thousand separator, e.g. "14 400"). Fixed with `.replace(/\s/g,'')`.
- **procenta_priklady.html**: Same space-stripping fix for consistency.

## Audit results (all other projects clean)

| Project | Locks/Tasks | Result |
|---|---|---|
| unikovka_telesa.html | 10 locks | ✓ all codes correct |
| unikovka_mocniny.html | 10 locks | ✓ all codes correct |
| unikovka_pythagoras.html | 10 locks | ✓ all codes correct |
| unikovka_rovnice.html | 10 locks | ✓ all codes correct |
| unikovka_procenta.html | locks 9–10 | ✓ verified (1–8 done previously) |
| goniometrie.html | 7 chapters | ✓ math correct, comma fix applied |
| cesta_penez.html | 8 acts | ✓ all integer answers, space fix applied |
| procenta_priklady.html | 8 problem types | ✓ (3000-task audit done previously) |

## Test plan
- [ ] goniometrie ch.4–6: type answer with comma (e.g. "7,5") → accepted
- [ ] cesta_penez: type answer with space (e.g. "14 400") → accepted
- [ ] procenta_priklady: type normal integer → still accepted

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_