### PR TITLE
fix: role race condition v konzoli (isAdmin() vracel false)

### DIFF
--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -44,8 +44,8 @@ window.RPGCloud = (function () {
       client.auth.onAuthStateChange(async (_event, s) => {
         const nu = s ? s.user : null;
         if (nu && !emailOK(nu)) { client.auth.signOut(); return; }
-        user = nu; role = null;
-        if (user) await fetchRole();
+        user = nu;
+        if (user) await fetchRole(); else role = null;
         emit();
       });
       emit();

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -185,9 +185,6 @@ function toast(msg,err){const t=document.getElementById('toast');t.textContent=m
 
 /* ── brána ── */
 async function boot(){
- if(!RPGCloud.configured()){
-  await RPGCloud.init();
- }
  await RPGCloud.init();
  paintGate();
  RPGCloud.onChange(()=>paintGate());


### PR DESCRIPTION
Oprava chyby: přidávání učitelů v konzoli hlásilo „Nemáš oprávnění" i přihlášenému superadminovi.

**Příčina:** `rpg-ucitel.html` volal `RPGCloud.init()` dvakrát → dva `onAuthStateChange` listenery. Každý při aktivaci nastavil `role = null` a čekal na async `fetchRole()`. Pokud uživatel kliknul na „+ Přidat" během tohoto okna, `isAdmin()` vrátilo `false`.

**Opravy:**
- `onAuthStateChange` nyní neresetuje `role = null` dokud `fetchRole()` neskončí — role se nuluje jen při odhlášení.
- `boot()` nevolá `init()` dvakrát.

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_