### PR TITLE
chore: na stránce projektů nechat jen RPG Matematika hub

### DIFF
--- a/projects/index.html
+++ b/projects/index.html
@@ -267,46 +267,6 @@
             <div class="project">
               <div class="line">
                 <span class="perm">-rw-r--r--</span>
-                <a class="filename" href="./rpg-mat-9.html">rpg-mat-9.html</a>
-              </div>
-              <p class="desc-en">EN: NULL_BYTE — cyberpunk hacker RPG for 9th grade math. Breach a megacorp's mainframe through 7 sectors, solve missions, defeat the System Admin AI. Areas: review (percentages, integers), powers & roots & scientific notation & Pythagoras, linear equations, rational expressions, systems of equations (motion/mixtures/work), functions (linear & inverse proportion), similarity & solids (cylinder, cone, sphere). Includes SVG diagrams. Built on the ŠVP for ZŠ s RVJ Husova, Liberec.</p>
-              <p class="desc-cs">CS: NULL_BYTE — cyberpunkové hackerské RPG pro 9. ročník. Pronikni do sítě megakorporace přes 7 sektorů, plň mise a poraz Správce systému (AI). Oblasti: opakování (procenta, celá čísla), mocniny a odmocniny a vědecký zápis a Pythagoras, lineární rovnice, lomené výrazy, soustavy rovnic (pohyb/směsi/práce), funkce (lineární i nepřímá úměrnost), podobnost a tělesa (válec, kužel, koule). Včetně SVG diagramů. Postaveno podle ŠVP ZŠ s RVJ Husova, Liberec.</p>
-              <p class="meta">tags: math · rpg · game · pixel-art · cyberpunk · hacker · null_byte · 9. třída · education · czech · interactive · geometrie</p>
-            </div>
-
-            <div class="project">
-              <div class="line">
-                <span class="perm">-rw-r--r--</span>
-                <a class="filename" href="./rpg-mat-8.html">rpg-mat-8.html</a>
-              </div>
-              <p class="desc-en">EN: Matematická akademie — pixel-art fantasy RPG for 8th grade math. Enroll at the math academy, take on missions and boss battles, level up a character with stats and inventory. Areas: review, Pythagorean theorem, equations, algebra, circles, constructions.</p>
-              <p class="desc-cs">CS: Matematická akademie — pixel-art fantasy RPG pro 8. ročník. Zapiš se do akademie, plň mise a boss souboje, vylepšuj postavu se statistikami a inventářem. Oblasti: opakování, Pythagorova věta, rovnice, algebra, kružnice, konstrukce.</p>
-              <p class="meta">tags: math · rpg · game · pixel-art · akademie · 8. třída · education · czech · interactive</p>
-            </div>
-
-            <div class="project">
-              <div class="line">
-                <span class="perm">-rw-r--r--</span>
-                <a class="filename" href="./rpg-mat-7.html">rpg-mat-7.html</a>
-              </div>
-              <p class="desc-en">EN: Lost-temple archaeology RPG for 7th grade math — explore an ancient temple, solve missions, defeat the Pyramid Guardian. Areas: review, fractions, integers & rational numbers, ratio & proportion (scale, rule of three), percentages, congruence & symmetry, quadrilaterals & prisms. Includes SVG geometry diagrams.</p>
-              <p class="desc-cs">CS: Ztracený chrám — archeologické RPG pro 7. ročník. Prozkoumej starověký chrám, plň mise a poraz Strážce pyramidy. Oblasti: opakování, zlomky, celá a racionální čísla, poměr a úměrnost (měřítko, trojčlenka), procenta, shodnost a souměrnost, čtyřúhelníky a hranoly. Včetně SVG geometrických diagramů.</p>
-              <p class="meta">tags: math · rpg · game · pixel-art · archeologie · 7. třída · education · czech · interactive · geometrie</p>
-            </div>
-
-            <div class="project">
-              <div class="line">
-                <span class="perm">-rw-r--r--</span>
-                <a class="filename" href="./rpg-mat-6.html">rpg-mat-6.html</a>
-              </div>
-              <p class="desc-en">EN: Space-expedition RPG for 6th grade math — travel the galaxy, solve missions, beat boss guardians. Areas: review, decimals & fractions, divisibility, angles (with diagrams), axial symmetry, volume & surface of cubes, triangles. Includes SVG geometry diagrams.</p>
-              <p class="desc-cs">CS: Vesmírná expedice — RPG pro 6. ročník. Cestuj galaxií, plň mise a poraz strážce planet. Oblasti: opakování, desetinná čísla a zlomky, dělitelnost, úhly (s obrázky), osová souměrnost, objem a povrch krychle a kvádru, trojúhelníky. Včetně SVG geometrických diagramů.</p>
-              <p class="meta">tags: math · rpg · game · pixel-art · vesmír · 6. třída · education · czech · interactive · geometrie</p>
-            </div>
-
-            <div class="project">
-              <div class="line">
-                <span class="perm">-rw-r--r--</span>
                 <a class="filename" href="./cesta_penez.html">cesta_penez.html</a>
               </div>
               <p class="desc-en">Financial literacy story game — brigáda, taxes, loans, mortgage, scams — 8 chapters.</p>


### PR DESCRIPTION
Na stránce projektů (`projects/index.html`) zůstává jen karta **RPG Matematika** (hub). Samostatné karty `rpg-mat-6/7/8/9.html` odebrány — hry jsou dostupné přes hub, který je teď jednotný vstupní bod série.

Soubory her zůstávají beze změny.

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_