### PR TITLE
feat: teacher unlock pro všechny ročníky (6/7/8/9)

### DIFF
--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -1029,10 +1029,11 @@ const ATTR_META = {
 // STATE
 // ══════════════════════════════════════════
 const SAVE_KEY = 'RPG_MAT_6';
-let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{}};
+let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};
+let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{}};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];return true;}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
 
 // ── JUICE: XP award + level-up + floaties + vignette ──
@@ -1121,8 +1122,10 @@ function continueGame(){if(loadS())go('map');}
 // MAP
 // ══════════════════════════════════════════
 function isAreaUnlocked(ar){
+ if(GODMODE)return true;
  if(ar.id===1)return true;
  if(ar.locked)return false;
+ if(S.teacherUnlocked&&ar.missions.some(m=>S.teacherUnlocked.includes(m.id)))return true;
  const prev=AREAS.find(a=>a.id===ar.id-1);
  return prev?isAreaDone(prev):true;
 }
@@ -1188,14 +1191,15 @@ function openArea(aid){
  ml.innerHTML='';
  ar.missions.forEach((m,mi)=>{
  const dn=countDone(m.id,m.tc),tot=m.tc,allDn=dn===tot;
- const avail=mi===0||countDone(ar.missions[mi-1].id,ar.missions[mi-1].tc)===ar.missions[mi-1].tc;
+ const teacherUnlk=GODMODE||(S.teacherUnlocked&&S.teacherUnlocked.includes(m.id));
+ const avail=teacherUnlk||mi===0||countDone(ar.missions[mi-1].id,ar.missions[mi-1].tc)===ar.missions[mi-1].tc;
  const cls=allDn?'done':avail?'avail':'locked';
  const stars=allDn?'⭐⭐⭐':dn>0?'⭐'.repeat(Math.ceil(dn/tot*3))+'☆'.repeat(3-Math.ceil(dn/tot*3)):'☆☆☆';
  const it=document.createElement('div');
  it.className='ms-item '+cls;
  it.innerHTML=`
  <div class="ms-num" style="color:${allDn?'var(--green)':avail?'var(--blue)':'var(--muted)'}">${allDn?'✓':String(mi+1).padStart(2,'0')}</div>
- <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
+ <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${(!allDn&&teacherUnlk&&!GODMODE)?'🔓 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
  <div style="font-size:14px">${stars}</div>`;
  if(avail)it.onclick=()=>launchBattle(ar.id,m.id);
  ml.appendChild(it);
@@ -1956,6 +1960,15 @@ document.addEventListener('keydown',e=>{
 window.addEventListener('load',()=>{
  if(localStorage.getItem(SAVE_KEY)){
  document.getElementById('continue-panel').style.display='block';
+ }
+ const _p=new URLSearchParams(location.search);
+ if(_p.get('preview')==='1'&&_p.get('mid')){
+  GODMODE=true;
+  const _mid=_p.get('mid');
+  const _aid=parseInt(_mid.split('-')[0]);
+  document.getElementById('ni').value='NÁHLED';
+  startGame();
+  launchBattle(_aid,_mid);
  }
 });
 </script>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -1041,10 +1041,11 @@ const ATTR_META = {
 // STATE
 // ══════════════════════════════════════════
 const SAVE_KEY = 'RPG_MAT_7';
-let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{}};
+let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};
+let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{}};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];return true;}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
 
 // ── JUICE: XP award + level-up + floaties + vignette ──
@@ -1133,8 +1134,10 @@ function continueGame(){if(loadS())go('map');}
 // MAP
 // ══════════════════════════════════════════
 function isAreaUnlocked(ar){
+ if(GODMODE)return true;
  if(ar.id===1)return true;
  if(ar.locked)return false;
+ if(S.teacherUnlocked&&ar.missions.some(m=>S.teacherUnlocked.includes(m.id)))return true;
  const prev=AREAS.find(a=>a.id===ar.id-1);
  return prev?isAreaDone(prev):true;
 }
@@ -1200,14 +1203,15 @@ function openArea(aid){
  ml.innerHTML='';
  ar.missions.forEach((m,mi)=>{
  const dn=countDone(m.id,m.tc),tot=m.tc,allDn=dn===tot;
- const avail=mi===0||countDone(ar.missions[mi-1].id,ar.missions[mi-1].tc)===ar.missions[mi-1].tc;
+ const teacherUnlk=GODMODE||(S.teacherUnlocked&&S.teacherUnlocked.includes(m.id));
+ const avail=teacherUnlk||mi===0||countDone(ar.missions[mi-1].id,ar.missions[mi-1].tc)===ar.missions[mi-1].tc;
  const cls=allDn?'done':avail?'avail':'locked';
  const stars=allDn?'⭐⭐⭐':dn>0?'⭐'.repeat(Math.ceil(dn/tot*3))+'☆'.repeat(3-Math.ceil(dn/tot*3)):'☆☆☆';
  const it=document.createElement('div');
  it.className='ms-item '+cls;
  it.innerHTML=`
  <div class="ms-num" style="color:${allDn?'var(--green)':avail?'var(--blue)':'var(--muted)'}">${allDn?'✓':String(mi+1).padStart(2,'0')}</div>
- <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
+ <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${(!allDn&&teacherUnlk&&!GODMODE)?'🔓 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
  <div style="font-size:14px">${stars}</div>`;
  if(avail)it.onclick=()=>launchBattle(ar.id,m.id);
  ml.appendChild(it);
@@ -1965,6 +1969,15 @@ document.addEventListener('keydown',e=>{
 window.addEventListener('load',()=>{
  if(localStorage.getItem(SAVE_KEY)){
  document.getElementById('continue-panel').style.display='block';
+ }
+ const _p=new URLSearchParams(location.search);
+ if(_p.get('preview')==='1'&&_p.get('mid')){
+  GODMODE=true;
+  const _mid=_p.get('mid');
+  const _aid=parseInt(_mid.split('-')[0]);
+  document.getElementById('ni').value='NÁHLED';
+  startGame();
+  launchBattle(_aid,_mid);
  }
 });
 </script>

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -1224,10 +1224,11 @@ const ATTR_META = {
 // STATE
 // ══════════════════════════════════════════
 const SAVE_KEY = 'RPG_MAT_8';
-let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{}};
+let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};
+let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{}};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];return true;}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
 
 // ── JUICE: XP award + level-up + floaties + vignette ──
@@ -1316,8 +1317,10 @@ function continueGame(){if(loadS())go('map');}
 // MAP
 // ══════════════════════════════════════════
 function isAreaUnlocked(ar){
+ if(GODMODE)return true;
  if(ar.id===1)return true;
  if(ar.locked)return false;
+ if(S.teacherUnlocked&&ar.missions.some(m=>S.teacherUnlocked.includes(m.id)))return true;
  const prev=AREAS.find(a=>a.id===ar.id-1);
  return prev?isAreaDone(prev):true;
 }
@@ -1383,14 +1386,15 @@ function openArea(aid){
  ml.innerHTML='';
  ar.missions.forEach((m,mi)=>{
  const dn=countDone(m.id,m.tc),tot=m.tc,allDn=dn===tot;
- const avail=mi===0||countDone(ar.missions[mi-1].id,ar.missions[mi-1].tc)===ar.missions[mi-1].tc;
+ const teacherUnlk=GODMODE||(S.teacherUnlocked&&S.teacherUnlocked.includes(m.id));
+ const avail=teacherUnlk||mi===0||countDone(ar.missions[mi-1].id,ar.missions[mi-1].tc)===ar.missions[mi-1].tc;
  const cls=allDn?'done':avail?'avail':'locked';
  const stars=allDn?'⭐⭐⭐':dn>0?'⭐'.repeat(Math.ceil(dn/tot*3))+'☆'.repeat(3-Math.ceil(dn/tot*3)):'☆☆☆';
  const it=document.createElement('div');
  it.className='ms-item '+cls;
  it.innerHTML=`
  <div class="ms-num" style="color:${allDn?'var(--green)':avail?'var(--blue)':'var(--muted)'}">${allDn?'✓':String(mi+1).padStart(2,'0')}</div>
- <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
+ <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${(!allDn&&teacherUnlk&&!GODMODE)?'🔓 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
  <div style="font-size:14px">${stars}</div>`;
  if(avail)it.onclick=()=>launchBattle(ar.id,m.id);
  ml.appendChild(it);
@@ -2145,6 +2149,15 @@ function trEnd(){renderTrainPicker();}
 window.addEventListener('load',()=>{
  if(localStorage.getItem(SAVE_KEY)){
  document.getElementById('continue-panel').style.display='block';
+ }
+ const _p=new URLSearchParams(location.search);
+ if(_p.get('preview')==='1'&&_p.get('mid')){
+  GODMODE=true;
+  const _mid=_p.get('mid');
+  const _aid=parseInt(_mid.split('-')[0]);
+  document.getElementById('ni').value='NÁHLED';
+  startGame();
+  launchBattle(_aid,_mid);
  }
 });
 </script>

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -356,17 +356,18 @@ function renderTable(){
 
 /* ── teacher unlock ── */
 function buildUnlockHtml(r){
- if(r.game!=='RPG_MAT_9')return'';
+ const missions=missionsFor(r.game);
+ if(!missions.length)return'';
  const d=r.data||{};
  const unlocked=Array.isArray(d.teacherUnlocked)?d.teacherUnlocked:[];
  const i=window.__filtered.indexOf(r);
  let pills='';
  unlocked.forEach(mid=>{
-  const mn=(MISSIONS_9.find(x=>x.id===mid)||{name:mid}).name;
+  const mn=(missions.find(x=>x.id===mid)||{name:mid}).name;
   pills+='<span style="display:inline-flex;align-items:center;gap:4px;font-size:11px;font-weight:700;padding:3px 8px;border-radius:20px;margin:2px;background:var(--panel2);border:1px solid var(--gold);color:var(--gold)">🔓 '+esc(mid)+' '+esc(mn)+' <button onclick="revokeUnlock('+i+',\''+esc(mid)+'\')" style="background:none;border:none;color:var(--red);cursor:pointer;font-size:12px;padding:0 0 0 4px">✕</button></span>';
  });
  let selOpts='<option value="">— vyberte misi —</option>';
- MISSIONS_9.forEach(m=>{
+ missions.forEach(m=>{
   selOpts+='<option value="'+m.id+'">'+m.id+' '+esc(m.name)+'</option>';
  });
  return '<h4>Odemknout misi učitelem</h4>'+

--- a/tests/rpg-teacher.test.cjs
+++ b/tests/rpg-teacher.test.cjs
@@ -283,6 +283,51 @@ async function run(){
       await ctx.close();
     }
 
+    // ── 8) Teacher unlock napříč ročníky 6/7/8/9 ────────────────────────
+    console.log('[ 8 ] Teacher unlock v konzoli pro 6./7./8./9. ročník');
+    {
+      const unlockSaves=[
+        {user_id:'u-ul6', game:'RPG_MAT_6', email:'ul6@husovaliberec.cz', full_name:'Šestka',
+         data:{name:'ASTRO', xp:0, level:1, attrs:{calc:0,geo:0,anal:0,craft:0}, done:{}, inv:[], mastery:{}, xpClaimed:{}, teacherUnlocked:['2-1']},
+         updated_at:new Date().toISOString()},
+        {user_id:'u-ul7', game:'RPG_MAT_7', email:'ul7@husovaliberec.cz', full_name:'Sedmička',
+         data:{name:'INDY', xp:0, level:1, attrs:{calc:0,geo:0,anal:0,craft:0}, done:{}, inv:[], mastery:{}, xpClaimed:{}, teacherUnlocked:[]},
+         updated_at:new Date().toISOString()},
+        {user_id:'u-ul8', game:'RPG_MAT_8', email:'ul8@husovaliberec.cz', full_name:'Osmička',
+         data:{name:'EULER', xp:0, level:1, attrs:{calc:0,geo:0,anal:0,craft:0}, done:{}, inv:[], mastery:{}, xpClaimed:{}, teacherUnlocked:['3-2']},
+         updated_at:new Date().toISOString()},
+        {user_id:'u-ul9', game:'RPG_MAT_9', email:'ul9@husovaliberec.cz', full_name:'Devítka',
+         data:{name:'NEO', xp:0, level:1, attrs:{calc:0,geo:0,anal:0,craft:0}, done:{}, inv:[], mastery:{}, xpClaimed:{}, teacherUnlocked:[]},
+         updated_at:new Date().toISOString()},
+      ];
+      const {ctx,pg}=await page({ session: sess('admin@husovaliberec.cz'),
+        roles:[{email:'admin@husovaliberec.cz',role:'superadmin'}], saves:unlockSaves });
+      await pg.goto(`${BASE}/projects/rpg-ucitel.html`,{waitUntil:'domcontentloaded'});
+      await pg.waitForFunction(()=>document.querySelectorAll('.tbl tbody tr').length>0,{timeout:6000}).catch(()=>{});
+
+      // buildUnlockHtml vrací HTML pro všechny ročníky (ne prázdné)
+      const unlockHtmls=await pg.evaluate(()=>{
+        return ['RPG_MAT_6','RPG_MAT_7','RPG_MAT_8','RPG_MAT_9'].map(game=>{
+          const i=window.__filtered.findIndex(r=>r.game===game);
+          return i>=0?buildUnlockHtml(window.__filtered[i]):'';
+        });
+      });
+      ok('buildUnlockHtml vrací HTML pro 6. ročník', unlockHtmls[0].includes('Odemknout misi'));
+      ok('buildUnlockHtml vrací HTML pro 7. ročník', unlockHtmls[1].includes('Odemknout misi'));
+      ok('buildUnlockHtml vrací HTML pro 8. ročník', unlockHtmls[2].includes('Odemknout misi'));
+      ok('buildUnlockHtml vrací HTML pro 9. ročník', unlockHtmls[3].includes('Odemknout misi'));
+
+      // existující unlock 2-1 v 6.r. se zobrazí jako pill
+      ok('Unlock 2-1 viditelný v 6.r. detailu', unlockHtmls[0].includes('2-1'));
+      // dropdown pro 8.r. obsahuje mise 8. ročníku (nikoli 9.)
+      ok('Dropdown 8.r. obsahuje misi z 8.r. (Celá čísla)', unlockHtmls[2].includes('Celá čísla'));
+      ok('Dropdown 8.r. NEobsahuje mise 9.r. (Bootovací)', !unlockHtmls[2].includes('Bootovací'));
+      // dropdown pro 6.r. obsahuje mise 6. ročníku
+      ok('Dropdown 6.r. obsahuje misi z 6.r. (Obvod a obsah)', unlockHtmls[0].includes('Obvod a obsah'));
+
+      await ctx.close();
+    }
+
   }catch(e){ console.error('\nChyba testu:',e.message,e.stack); fail++; }
 
   await browser.close(); srv.close();


### PR DESCRIPTION
## Souhrn

Teacher unlock byl dosud implementován jen ve hře 9. ročníku a jen v konzoli pro 9. ročník. Teď funguje **ve všech čtyřech hrách** a konzole s ním pracuje pro všechny ročníky.

### Změny v hrách (`rpg-mat-6/7/8.html`)
- Save default: přidáno `teacherUnlocked:[]`
- `loadS` migrace: `if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];`
- Přidán `let GODMODE=false;`
- `isAreaUnlocked`: kontroluje `GODMODE` i `S.teacherUnlocked` (stejný vzor jako grade 9)
- `openArea` — seznam misí: badge 🔓 u odemčených misí (pokud ne GODMODE)
- Boot `window.addEventListener('load')`: reaguje na `?preview=1&mid=X-X` → nastaví GODMODE a spustí misi přímo (god-mode náhled z konzole funguje i pro 6/7/8)

### Změny v konzoli (`rpg-ucitel.html`)
- `buildUnlockHtml(r)`: odstraněna podmínka `if(r.game!=='RPG_MAT_9')return''`
- Dropdown misí teď používá `missionsFor(r.game)` místo hardcoded `MISSIONS_9`
- Pill-y existujících unlocknutých misí ukazují správné názvy pro daný ročník

### Testy
`tests/rpg-teacher.test.cjs` — přidán blok 8 (8 nových kontrol):
- `buildUnlockHtml` vrací HTML pro všechny 4 ročníky
- Existující unlock se zobrazí jako pill
- Dropdown obsahuje mise správného ročníku (ne cizí)

**Výsledek: 35/35 ✅** + **48/48 ✅** (antispam/robustness)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_