### PR TITLE
feat: Teorie screen pro 8. a 9. ročník (learning content)

### DIFF
--- a/projects/rpg-learn-8.js
+++ b/projects/rpg-learn-8.js
@@ -1,0 +1,453 @@
+/* ══════════════════════════════════════════════════════════════════
+   RPG Matematika 8 — Teorie ke všem 21 misím (Citadela arcimága 🏛️)
+   Zdroje: RVP ZV, učebnice Odvárko/Kadleček, CERMAT, MŠMT
+   Videa: kanál @matematikajednoduse (Lucie Straková)
+   ══════════════════════════════════════════════════════════════════ */
+(function(){
+'use strict';
+window.RPG_LEARN_8 = {
+
+/* ─── Oblast 1: ÚDOLÍ OPAKOVÁNÍ ───────────────────────────────── */
+
+'1-1': {
+ intro: '🏔️ Strážce údolí tě nepustí dál, dokud neovládneš celá čísla a jejich znaménka.',
+ sections: [
+  { h: 'Celá čísla a osa',
+    p: ['Celá čísla jsou …, −3, −2, −1, 0, 1, 2, 3, … Záporná leží vlevo od nuly, kladná vpravo.',
+        'Absolutní hodnota |a| je vzdálenost čísla od nuly — vždy nezáporná: |−5| = 5.'] },
+  { h: 'Sčítání a odčítání',
+    p: ['Stejná znaménka: sečti a ponech znaménko. Různá znaménka: odečti menší od většího a vezmi znaménko většího.',
+        'Odčítání = přičtení opačného čísla: 5 − (−3) = 5 + 3 = 8.'] },
+  { h: 'Násobení a dělení',
+    p: ['Stejná znaménka → výsledek kladný. Různá znaménka → výsledek záporný.',
+        '(−4) · (−3) = 12; (−4) · 3 = −12.'] },
+ ],
+ formulas: [
+  '<b>− · − = +</b> · <b>+ · − = −</b>',
+  '<b>a − (−b) = a + b</b>',
+ ],
+ examples: [
+  { q: 'Spočítej: −7 + 12', s: ['Různá znaménka: 12 − 7 = 5, znaménko většího (+)', 'Výsledek: <b>5</b>'] },
+  { q: 'Spočítej: (−6) · (−5)', s: ['Stejná znaménka → kladně', '6 · 5 = <b>30</b>'] },
+ ],
+ video: null,
+},
+
+'1-2': {
+ intro: '🗻 Mlžný duch testuje tvou znalost racionálních čísel — zlomků i desetinných.',
+ sections: [
+  { h: 'Racionální čísla',
+    p: ['Racionální číslo lze zapsat jako zlomek a/b (b ≠ 0). Patří sem celá čísla, zlomky i konečná a periodická desetinná čísla.'] },
+  { h: 'Operace se zlomky',
+    p: ['Sčítání/odčítání: převeď na společný jmenovatel, pak sčítej čitatele.',
+        'Násobení: čitatel × čitatel, jmenovatel × jmenovatel. Dělení: násob převrácenou hodnotou.'] },
+  { h: 'Převody zlomek ↔ desetinné',
+    p: ['Zlomek na desetinné: vyděl čitatele jmenovatelem. 3/4 = 3 ÷ 4 = 0,75.',
+        'Desetinné na zlomek: zapiš podle řádu a zkrať. 0,6 = 6/10 = 3/5.'] },
+ ],
+ formulas: [
+  '<b>a/b · c/d = (a·c)/(b·d)</b>',
+  '<b>a/b ÷ c/d = a/b · d/c</b>',
+ ],
+ examples: [
+  { q: 'Spočítej: 2/3 + 1/6', s: ['Společný jmenovatel 6: 4/6 + 1/6 = 5/6', 'Výsledek: <b>5/6</b>'] },
+  { q: 'Spočítej: 3/5 · 10/9', s: ['(3·10)/(5·9) = 30/45 = <b>2/3</b>'] },
+ ],
+ video: null,
+},
+
+'1-3': {
+ intro: '⚗️ Alchymista počítá poměry lektvarů. Bez procent ti recept nevydá.',
+ sections: [
+  { h: 'Co jsou procenta',
+    p: ['1 % = jedna setina celku = 0,01. Základ je celek (100 %), procentová část je úsek a počet procent je kolik setin bereme.'] },
+  { h: 'Tři typy úloh',
+    p: ['Procentová část: část = základ · (počet % ÷ 100).',
+        'Počet procent: % = (část ÷ základ) · 100.',
+        'Základ: základ = část ÷ (počet % ÷ 100).'] },
+  { h: 'Sleva, zdražení, daň',
+    p: ['Sleva 20 % → platíš 80 % původní ceny. Zdražení o 15 % → platíš 115 %.'] },
+ ],
+ formulas: [
+  '<b>část = základ · p/100</b>',
+  '<b>p % = (část/základ) · 100</b>',
+  '<b>základ = část · 100/p</b>',
+ ],
+ examples: [
+  { q: 'Kolik je 35 % z 240?', s: ['240 · 35/100 = 240 · 0,35 = <b>84</b>'] },
+  { q: 'Kabát za 1 200 Kč zlevnili o 25 %. Nová cena?', s: ['Sleva: 1 200 · 0,25 = 300 Kč', '1 200 − 300 = <b>900 Kč</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 2: HORA PYTHAGOROVA ──────────────────────────────── */
+
+'2-1': {
+ intro: '⛰️ U paty hory tě zkouší duch čísel: ovládáš mocniny a odmocniny?',
+ sections: [
+  { h: 'Druhá mocnina a odmocnina',
+    p: ['Druhá mocnina: a² = a · a (5² = 25). Druhá odmocnina √ je opačná operace: √25 = 5.',
+        'Mocnina s exponentem n: aⁿ = a · a · … · a (n-krát).'] },
+  { h: 'Mocniny deseti',
+    p: ['10² = 100, 10³ = 1 000. Počet nul = exponent. Hodí se pro velká čísla a vědecký zápis.'] },
+  { h: 'Odmocňování zpaměti',
+    p: ['Znej druhé mocniny do 15²: 11²=121, 12²=144, 13²=169, 14²=196, 15²=225.'] },
+ ],
+ formulas: [
+  '<b>a² = a · a</b> · <b>√(a²) = a</b> (pro a ≥ 0)',
+  '<b>10ⁿ</b> = 1 a n nul',
+ ],
+ examples: [
+  { q: 'Spočítej: 13²', s: ['13 · 13 = <b>169</b>'] },
+  { q: 'Spočítej: √144', s: ['12 · 12 = 144 → <b>12</b>'] },
+ ],
+ video: { id: 'DVQl6pLx8qI', title: 'Druhá mocnina a odmocnina' },
+},
+
+'2-2': {
+ intro: '🧗 Na svahu hory ti chybí délka lana. Spočítej přeponu Pythagorovou větou!',
+ sections: [
+  { h: 'Pythagorova věta',
+    p: ['V pravoúhlém trojúhelníku platí: obsah čtverce nad přeponou = součet obsahů čtverců nad odvěsnami.',
+        'Přepona c je nejdelší strana, leží naproti pravému úhlu. Odvěsny a, b svírají pravý úhel.'] },
+  { h: 'Výpočet přepony',
+    p: ['Známe obě odvěsny → c² = a² + b², pak c = √(a² + b²).',
+        'Postup: umocni odvěsny, sečti, odmocni.'] },
+ ],
+ formulas: [
+  '<b>c² = a² + b²</b>',
+  '<b>c = √(a² + b²)</b>',
+ ],
+ examples: [
+  { q: 'Odvěsny 3 cm a 4 cm. Přepona?', s: ['c² = 3² + 4² = 9 + 16 = 25', 'c = √25 = <b>5 cm</b>'] },
+  { q: 'Odvěsny 6 cm a 8 cm. Přepona?', s: ['c² = 36 + 64 = 100', 'c = √100 = <b>10 cm</b>'] },
+ ],
+ video: { id: 'ssvz3u8imgk', title: 'Pythagorova věta' },
+},
+
+'2-3': {
+ intro: '🪨 Skála se sesula a znáš jen přeponu a jednu odvěsnu. Dopočítej druhou odvěsnu.',
+ sections: [
+  { h: 'Výpočet odvěsny',
+    p: ['Známe přeponu c a jednu odvěsnu → druhou odvěsnu vyjádříme z věty: a² = c² − b².',
+        'Pozor: od čtverce přepony odečítáme čtverec známé odvěsny (ne naopak).'] },
+  { h: 'Užití v praxi',
+    p: ['Pythagorova věta řeší žebřík opřený o zeď, úhlopříčku obdélníku, výšku ve trojúhelníku.'] },
+ ],
+ formulas: [
+  '<b>a² = c² − b²</b>',
+  '<b>a = √(c² − b²)</b>',
+ ],
+ examples: [
+  { q: 'Přepona 13 cm, odvěsna 5 cm. Druhá odvěsna?', s: ['a² = 13² − 5² = 169 − 25 = 144', 'a = √144 = <b>12 cm</b>'] },
+  { q: 'Úhlopříčka obdélníku 10 cm, jedna strana 6 cm. Druhá strana?', s: ['√(10² − 6²) = √(100−36) = √64 = <b>8 cm</b>'] },
+ ],
+ video: { id: 'ssvz3u8imgk', title: 'Pythagorova věta' },
+},
+
+/* ─── Oblast 3: BAŽINY ROVNIC ─────────────────────────────────── */
+
+'3-1': {
+ intro: '🌿 Bahno tě stahuje dolů. Jen vyřešená rovnice ti ukáže pevnou cestu.',
+ sections: [
+  { h: 'Co je rovnice',
+    p: ['Rovnice je rovnost dvou výrazů s neznámou (x). Řešit = najít hodnotu x, pro kterou rovnost platí.',
+        'Co uděláme na jedné straně, musíme udělat i na druhé — rovnováha „vah".'] },
+  { h: 'Základní úpravy',
+    p: ['K oběma stranám můžeme přičíst/odečíst stejné číslo a obě strany vynásobit/vydělit stejným nenulovým číslem.',
+        'Cíl: osamostatnit x na jedné straně.'] },
+  { h: 'Zkouška',
+    p: ['Dosaď výsledek zpět do původní rovnice — levá strana se musí rovnat pravé.'] },
+ ],
+ formulas: [
+  '<b>x + a = b → x = b − a</b>',
+  '<b>a · x = b → x = b / a</b>',
+ ],
+ examples: [
+  { q: 'Vyřeš: x + 7 = 12', s: ['x = 12 − 7 = <b>5</b>'] },
+  { q: 'Vyřeš: 4x = 20', s: ['x = 20 ÷ 4 = <b>5</b>'] },
+ ],
+ video: null,
+},
+
+'3-2': {
+ intro: '🐸 Strážce bažin zadává rovnice na víc kroků. Ovládni je a projdeš.',
+ sections: [
+  { h: 'Rovnice na více kroků',
+    p: ['Nejdřív převeď členy s x na jednu stranu a čísla na druhou. Pak vyděl koeficientem u x.',
+        'Příklad: 3x + 5 = 20 → 3x = 15 → x = 5.'] },
+  { h: 'Neznámá na obou stranách',
+    p: ['Členy s x dej vlevo, čísla vpravo: 5x − 2 = 2x + 7 → 5x − 2x = 7 + 2 → 3x = 9 → x = 3.'] },
+ ],
+ formulas: [
+  '<b>Postup:</b> x vlevo, čísla vpravo, pak ÷ koeficient',
+ ],
+ examples: [
+  { q: 'Vyřeš: 3x + 5 = 20', s: ['3x = 20 − 5 = 15', 'x = 15 ÷ 3 = <b>5</b>'] },
+  { q: 'Vyřeš: 5x − 2 = 2x + 7', s: ['5x − 2x = 7 + 2', '3x = 9 → x = <b>3</b>'] },
+ ],
+ video: null,
+},
+
+'3-3': {
+ intro: '🗺️ Ztracený poutník popíše svůj problém slovy. Přelož ho do rovnice a vyřeš.',
+ sections: [
+  { h: 'Od slov k rovnici',
+    p: ['1) Označ neznámou x. 2) Vyjádři ostatní veličiny pomocí x. 3) Sestav rovnici podle vztahu ze zadání. 4) Vyřeš a napiš odpověď.'] },
+  { h: 'Typické formulace',
+    p: ['„O 5 více" → +5. „Třikrát tolik" → ·3. „Dohromady" → součet se rovná celku.'] },
+ ],
+ formulas: [
+  '<b>Postup:</b> neznámá → vztah → rovnice → řešení → odpověď',
+ ],
+ examples: [
+  { q: 'Myslím si číslo. Jeho trojnásobek zvětšený o 4 je 19. Které?', s: ['3x + 4 = 19', '3x = 15 → x = <b>5</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 4: VĚŽE ALGEBRY ──────────────────────────────────── */
+
+'4-1': {
+ intro: '🏰 Strážce věží ti dá výraz a hodnotu. Dosaď a vypočítej.',
+ sections: [
+  { h: 'Algebraický výraz',
+    p: ['Výraz obsahuje čísla, proměnné a operace, ale nemá znaménko rovná se (na rozdíl od rovnice).',
+        'Dosazení = nahrazení proměnné konkrétním číslem a výpočet.'] },
+  { h: 'Pozor na pořadí a znaménka',
+    p: ['Dodržuj pořadí operací. U záporných hodnot dej proměnnou do závorky: pro x = −2 je x² = (−2)² = 4.'] },
+ ],
+ formulas: [
+  '<b>Dosazení:</b> nahraď proměnnou číslem, dodrž pořadí operací',
+ ],
+ examples: [
+  { q: 'Urči hodnotu 2x + 3 pro x = 4', s: ['2 · 4 + 3 = 8 + 3 = <b>11</b>'] },
+  { q: 'Urči hodnotu x² − 1 pro x = −3', s: ['(−3)² − 1 = 9 − 1 = <b>8</b>'] },
+ ],
+ video: null,
+},
+
+'4-2': {
+ intro: '✨ Kouzelná formule se skrývá ve vzorcích. Ovládni druhou mocninu součtu a rozdílu.',
+ sections: [
+  { h: 'Roznásobení závorek',
+    p: ['(a + b)(c + d) = ac + ad + bc + bd — každý člen s každým.',
+        'Jednočlen před závorkou: a(b + c) = ab + ac.'] },
+  { h: 'Vzorce',
+    p: ['Druhá mocnina součtu: (a + b)² = a² + 2ab + b².',
+        'Druhá mocnina rozdílu: (a − b)² = a² − 2ab + b².',
+        'Rozdíl čtverců: (a + b)(a − b) = a² − b².'] },
+ ],
+ formulas: [
+  '<b>(a + b)² = a² + 2ab + b²</b>',
+  '<b>(a − b)² = a² − 2ab + b²</b>',
+  '<b>(a + b)(a − b) = a² − b²</b>',
+ ],
+ examples: [
+  { q: 'Rozepiš (x + 3)²', s: ['x² + 2·x·3 + 3² = <b>x² + 6x + 9</b>'] },
+  { q: 'Rozepiš (x − 5)(x + 5)', s: ['Rozdíl čtverců: x² − 25', 'Výsledek: <b>x² − 25</b>'] },
+ ],
+ video: { id: 'nD2ZY0V5aPE', title: 'Výrazy – vzorce' },
+},
+
+'4-3': {
+ intro: '🔮 Mistr algebry žádá zjednodušení. Vytkni společného činitele před závorku.',
+ sections: [
+  { h: 'Vytýkání',
+    p: ['Vytýkání je opak roznásobení: najdeme společného činitele všech členů a dáme ho před závorku.',
+        '6x + 9 = 3·(2x + 3), protože 3 dělí 6 i 9.'] },
+  { h: 'Společný činitel',
+    p: ['Vytýkáme největší společný dělitel čísel a nejnižší mocninu společné proměnné.',
+        '4x² + 8x = 4x·(x + 2).'] },
+ ],
+ formulas: [
+  '<b>ab + ac = a(b + c)</b>',
+ ],
+ examples: [
+  { q: 'Vytkni: 6x + 9', s: ['Společný činitel 3', '3·(2x + 3) → <b>3(2x + 3)</b>'] },
+  { q: 'Vytkni: 4x² + 8x', s: ['Společný činitel 4x', '<b>4x(x + 2)</b>'] },
+ ],
+ video: { id: 'LOuVE-8-3xs', title: 'Vytýkání' },
+},
+
+/* ─── Oblast 5: JEZERO KRUŽNIC ────────────────────────────────── */
+
+'5-1': {
+ intro: '🌊 Hladina jezera tvoří dokonalý kruh. Spočítej jeho obvod a obsah.',
+ sections: [
+  { h: 'Kruh a kružnice',
+    p: ['Kružnice je čára, kruh je plocha uvnitř. Poloměr r je vzdálenost od středu k okraji, průměr d = 2r.',
+        'Konstanta π (pí) ≈ 3,14 vyjadřuje poměr obvodu k průměru.'] },
+  { h: 'Obvod a obsah',
+    p: ['Obvod kruhu: o = 2 · π · r = π · d.',
+        'Obsah kruhu: S = π · r².'] },
+ ],
+ formulas: [
+  '<b>Obvod:</b> o = 2 · π · r',
+  '<b>Obsah:</b> S = π · r²',
+  '<b>π ≈ 3,14</b>',
+ ],
+ examples: [
+  { q: 'Kruh s r = 5 cm. Obvod? (π ≈ 3,14)', s: ['o = 2 · 3,14 · 5 = <b>31,4 cm</b>'] },
+  { q: 'Kruh s r = 5 cm. Obsah?', s: ['S = 3,14 · 5² = 3,14 · 25 = <b>78,5 cm²</b>'] },
+ ],
+ video: { id: 'Cj3fwDlrpPM', title: 'Obvod a obsah kruhu' },
+},
+
+'5-2': {
+ intro: '🛢️ Ze dna jezera vyčnívá válcová věž. Spočítej její povrch a objem.',
+ sections: [
+  { h: 'Válec',
+    p: ['Válec má dvě kruhové podstavy (poloměr r) a plášť o výšce v. Plášť rozvinutý je obdélník o stranách 2πr a v.'] },
+  { h: 'Povrch a objem',
+    p: ['Objem: V = π · r² · v (obsah podstavy × výška).',
+        'Povrch: S = 2 · π · r² + 2 · π · r · v (dvě podstavy + plášť).'] },
+ ],
+ formulas: [
+  '<b>Objem válce:</b> V = π · r² · v',
+  '<b>Povrch válce:</b> S = 2πr² + 2πrv = 2πr(r + v)',
+ ],
+ examples: [
+  { q: 'Válec r = 3 cm, v = 10 cm. Objem? (π ≈ 3,14)', s: ['V = 3,14 · 3² · 10 = 3,14 · 90 = <b>282,6 cm³</b>'] },
+  { q: 'Tentýž válec. Povrch?', s: ['S = 2·3,14·3·(3+10) = 6,28·3·13 = <b>244,92 cm²</b>'] },
+ ],
+ video: { id: 'GG9WF955El4', title: 'Objem a povrch válce' },
+},
+
+'5-3': {
+ intro: '🎣 Rybář u jezera má praktické úlohy. Použij obvod, obsah i válec ve slovních úlohách.',
+ sections: [
+  { h: 'Řešení slovních úloh',
+    p: ['Rozpoznej, zda jde o obvod (délka okraje), obsah (plocha) nebo objem (kolik se vejde).',
+        'Hlídej jednotky a zaokrouhlení podle zadání.'] },
+  { h: 'Typické situace',
+    p: ['Plot kolem kruhového záhonu → obvod. Trávník v kruhu → obsah. Voda v sudu (válci) → objem.'] },
+ ],
+ formulas: [
+  '<b>Obvod:</b> o = 2πr · <b>Obsah:</b> S = πr² · <b>Objem válce:</b> V = πr²v',
+ ],
+ examples: [
+  { q: 'Kruhový bazén r = 2 m. Kolik m² plachty na zakrytí? (π ≈ 3,14)', s: ['S = 3,14 · 2² = 3,14 · 4 = <b>12,56 m²</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 6: DÍLNA KONSTRUKCÍ ──────────────────────────────── */
+
+'6-1': {
+ intro: '🔧 V dílně se rýsuje. Pochop množiny bodů dané vlastnosti — základ konstrukcí.',
+ sections: [
+  { h: 'Množina bodů dané vlastnosti',
+    p: ['Je to soubor všech bodů, které splňují nějakou podmínku. Často je to čára (přímka, kružnice).'] },
+  { h: 'Důležité množiny',
+    p: ['Body ve stejné vzdálenosti od daného bodu → kružnice.',
+        'Body ve stejné vzdálenosti od dvou bodů → osa úsečky.',
+        'Body ve stejné vzdálenosti od ramen úhlu → osa úhlu.'] },
+ ],
+ formulas: [
+  '<b>Stejná vzdálenost od bodu:</b> kružnice',
+  '<b>Stejná vzdálenost od 2 bodů:</b> osa úsečky',
+ ],
+ examples: [
+  { q: 'Jaká množina jsou body vzdálené 3 cm od bodu S?', s: ['Všechny ve vzdálenosti 3 cm → <b>kružnice se středem S a r = 3 cm</b>'] },
+ ],
+ video: null,
+},
+
+'6-2': {
+ intro: '⚙️ Mistr konstruktér tě učí Thaletovu kružnici — klíč k pravým úhlům.',
+ sections: [
+  { h: 'Thaletova věta',
+    p: ['Každý bod kružnice (kromě krajních) „vidí" průměr pod pravým úhlem.',
+        'Trojúhelník s vrcholem na Thaletově kružnici a s přeponou rovnou průměru je pravoúhlý.'] },
+  { h: 'Užití',
+    p: ['Thaletovu kružnici používáme ke konstrukci pravého úhlu nebo tečny z bodu ke kružnici.'] },
+ ],
+ formulas: [
+  '<b>Thaletova věta:</b> bod na kružnici nad průměrem → pravý úhel',
+ ],
+ examples: [
+  { q: 'Trojúhelník ABC má přeponu AB rovnou průměru kružnice, C leží na kružnici. Jaký je úhel u C?', s: ['Podle Thaletovy věty → <b>90° (pravý)</b>'] },
+ ],
+ video: null,
+},
+
+'6-3': {
+ intro: '📐 Závěrečná zkouška dílny: osy a souměrnosti v praktických konstrukcích.',
+ sections: [
+  { h: 'Osa úsečky a osa úhlu',
+    p: ['Osa úsečky je kolmá k úsečce a prochází jejím středem. Osa úhlu dělí úhel na dvě shodné poloviny.'] },
+  { h: 'Souměrnosti v konstrukcích',
+    p: ['Osová a středová souměrnost pomáhají sestrojit obraz útvaru a řešit konstrukční úlohy.',
+        'Postup konstrukce vždy popisujeme kroky a ověřujeme, zda splňuje zadání.'] },
+ ],
+ formulas: [
+  '<b>Osa úsečky:</b> kolmá, prochází středem',
+  '<b>Osa úhlu:</b> dělí úhel na dvě shodné poloviny',
+ ],
+ examples: [
+  { q: 'Co tvoří osa úsečky AB?', s: ['Body stejně vzdálené od A i B', 'Je <b>kolmá k AB a prochází jejím středem</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 7: CITADELA ARCIMÁGA ─────────────────────────────── */
+
+'7-1': {
+ intro: '🏛️ Brána citadely. Zkouška ohněm kombinuje všechna témata 8. ročníku.',
+ sections: [
+  { h: 'Co tě čeká',
+    p: ['Mix celých a racionálních čísel, procent, mocnin, Pythagorovy věty, rovnic, výrazů a kružnic.',
+        'Projdi si teorii misí, kde si nejsi jistý.'] },
+  { h: 'Strategie',
+    p: ['Čti pozorně, načrtni obrázek u geometrie, dělej zkoušku u rovnic, hlídej jednotky.'] },
+ ],
+ formulas: [
+  '<b>Pythagoras:</b> c² = a² + b² · <b>Kruh:</b> S = πr²',
+  '<b>(a ± b)² = a² ± 2ab + b²</b>',
+ ],
+ examples: [
+  { q: 'Rozcvička: 25 % z 80 + √49', s: ['25 % z 80 = 20', '√49 = 7', '20 + 7 = <b>27</b>'] },
+ ],
+ video: null,
+},
+
+'7-2': {
+ intro: '📜 Přijímačkový trénink — úlohy ve stylu CERMAT. Připrav se na přijímačky!',
+ sections: [
+  { h: 'Jak na přijímačkové úlohy',
+    p: ['Čti zadání dvakrát. Rozlož složenou úlohu na kroky. Hlídej čas — lehčí úlohy nejdřív.',
+        'U výběru ze 4 můžeš dosadit nabízené možnosti a ověřit.'] },
+  { h: 'Časté typy',
+    p: ['Procenta, poměry, rovnice ze slovní úlohy, obsahy a obvody, Pythagorova věta, čtení z grafu a tabulky.'] },
+ ],
+ formulas: [
+  '<b>Tip:</b> u výběru ze 4 dosaď možnosti zpět do zadání',
+ ],
+ examples: [
+  { q: 'Vlak ujede 240 km za 3 h. Průměrná rychlost?', s: ['v = s ÷ t = 240 ÷ 3 = <b>80 km/h</b>'] },
+ ],
+ video: null,
+},
+
+'7-3': {
+ intro: '🔥 Finální duel s Arcimágem — nejtěžší výzva. Dokaž, že 8. ročník ovládáš!',
+ sections: [
+  { h: 'Před soubojem',
+    p: ['Toto je vrchol — kombinace nejnáročnějších úloh z celého ročníku.',
+        'Zopakuj si vzorce a postupy, ničeho se neboj a počítej s rozvahou.'] },
+  { h: 'Klíčové vzorce na závěr',
+    p: ['Měj v hlavě Pythagorovu větu, vzorce pro kruh a válec, algebraické vzorce a postup řešení rovnic.'] },
+ ],
+ formulas: [
+  '<b>c = √(a² + b²)</b> · <b>V válce = πr²v</b>',
+  '<b>(a + b)(a − b) = a² − b²</b>',
+ ],
+ examples: [
+  { q: 'Vyřeš: 2(x − 3) = x + 4', s: ['2x − 6 = x + 4', '2x − x = 4 + 6', 'x = <b>10</b>'] },
+ ],
+ video: null,
+},
+
+};
+})();

--- a/projects/rpg-learn-9.js
+++ b/projects/rpg-learn-9.js
@@ -1,0 +1,434 @@
+/* ══════════════════════════════════════════════════════════════════
+   RPG Matematika 9 — Teorie ke všem 21 misím (NULL_BYTE 💻 cyberpunk)
+   Zdroje: RVP ZV, učebnice Odvárko/Kadleček, CERMAT, MŠMT
+   Videa: kanál @matematikajednoduse (Lucie Straková)
+   ══════════════════════════════════════════════════════════════════ */
+(function(){
+'use strict';
+window.RPG_LEARN_9 = {
+
+/* ─── Oblast 1: VSTUPNÍ TERMINÁL ──────────────────────────────── */
+
+'1-1': {
+ intro: '🔓 [BOOT] Vstupní terminál vyžaduje ověření základů. Zopakuj početní operace a pořadí.',
+ sections: [
+  { h: 'Obor čísel',
+    p: ['Pracujeme s racionálními čísly: celá, zlomky, desetinná (konečná i periodická). Lze je zapsat jako zlomek a/b.'] },
+  { h: 'Pořadí operací',
+    p: ['Závorky → mocniny a odmocniny → násobení a dělení → sčítání a odčítání.',
+        'Operace stejné úrovně počítej zleva doprava.'] },
+  { h: 'Znaménka',
+    p: ['Stejná znaménka při násobení/dělení → kladně, různá → záporně. Odčítání = přičtení opačného.'] },
+ ],
+ formulas: [
+  '<b>Pořadí:</b> ( ) → ^ √ → × ÷ → + −',
+  '<b>− · − = +</b>',
+ ],
+ examples: [
+  { q: 'Spočítej: 2 + 3 · 4²', s: ['Mocnina: 4² = 16', 'Násobení: 3 · 16 = 48', '2 + 48 = <b>50</b>'] },
+ ],
+ video: null,
+},
+
+'1-2': {
+ intro: '📊 [SCAN] Procentní skener čte data v procentech a promile. Ovládni je a projdeš firewallem.',
+ sections: [
+  { h: 'Procenta a promile',
+    p: ['1 % = 1/100 = 0,01. 1 ‰ (promile) = 1/1000 = 0,001. Promile se hodí pro malé podíly (alkohol v krvi, solnost).'] },
+  { h: 'Tři základní úlohy',
+    p: ['Část = základ · p/100. Počet procent = (část/základ)·100. Základ = část · 100/p.'] },
+  { h: 'Změny v procentech',
+    p: ['Zdražení o p % → násob (1 + p/100). Zlevnění o p % → násob (1 − p/100).'] },
+ ],
+ formulas: [
+  '<b>část = základ · p/100</b>',
+  '<b>1 ‰ = 0,001</b>',
+ ],
+ examples: [
+  { q: 'Kolik je 8 % z 1 500 Kč?', s: ['1 500 · 0,08 = <b>120 Kč</b>'] },
+  { q: 'Cena 600 Kč vzroste o 20 %. Nová cena?', s: ['600 · 1,20 = <b>720 Kč</b>'] },
+ ],
+ video: null,
+},
+
+'1-3': {
+ intro: '⚠️ [WARN] Záporná zóna — datové toky se znaménky. Spočítej je správně, jinak crash.',
+ sections: [
+  { h: 'Celá čísla a absolutní hodnota',
+    p: ['|a| je vzdálenost od nuly, vždy nezáporná. |−7| = 7, |7| = 7.'] },
+  { h: 'Operace se znaménky',
+    p: ['Sčítání různých znamének: odečti menší od většího, vezmi znaménko většího.',
+        'Násobení/dělení: stejná znaménka → +, různá → −.'] },
+ ],
+ formulas: [
+  '<b>a − (−b) = a + b</b>',
+  '<b>(−)·(−) = (+)</b>, <b>(−)·(+) = (−)</b>',
+ ],
+ examples: [
+  { q: 'Spočítej: −8 − (−15)', s: ['−8 + 15 = <b>7</b>'] },
+  { q: 'Spočítej: (−12) ÷ (−4)', s: ['Stejná znaménka → kladně', '12 ÷ 4 = <b>3</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 2: MOCNINOVÝ REAKTOR ─────────────────────────────── */
+
+'2-1': {
+ intro: '⚡ [CORE] Energetické články běží na mocninách a odmocninách. Nabij je správně.',
+ sections: [
+  { h: 'Mocniny a odmocniny',
+    p: ['aⁿ = a · a · … · a (n-krát). √a je číslo, jehož druhá mocnina je a (pro a ≥ 0).',
+        'a⁰ = 1 (pro a ≠ 0). a¹ = a.'] },
+  { h: 'Odmocniny zpaměti',
+    p: ['Znej druhé mocniny do 20² a odpovídající odmocniny. √169 = 13, √225 = 15, √400 = 20.'] },
+ ],
+ formulas: [
+  '<b>aⁿ = a · a · … · a</b> (n-krát)',
+  '<b>a⁰ = 1</b> (a ≠ 0)',
+ ],
+ examples: [
+  { q: 'Spočítej: 2⁵', s: ['2·2·2·2·2 = <b>32</b>'] },
+  { q: 'Spočítej: √196', s: ['14 · 14 = 196 → <b>14</b>'] },
+ ],
+ video: { id: 'DVQl6pLx8qI', title: 'Druhá mocnina a odmocnina' },
+},
+
+'2-2': {
+ intro: '🔋 [RULES] Reaktor vyžaduje pravidla pro počítání s mocninami. Sjednoť exponenty.',
+ sections: [
+  { h: 'Pravidla pro mocniny se stejným základem',
+    p: ['Násobení: exponenty sčítáme. Dělení: exponenty odečítáme. Mocnina mocniny: exponenty násobíme.'] },
+  { h: 'Mocnina součinu a podílu',
+    p: ['(a · b)ⁿ = aⁿ · bⁿ. (a/b)ⁿ = aⁿ/bⁿ.'] },
+ ],
+ formulas: [
+  '<b>aᵐ · aⁿ = aᵐ⁺ⁿ</b>',
+  '<b>aᵐ ÷ aⁿ = aᵐ⁻ⁿ</b>',
+  '<b>(aᵐ)ⁿ = aᵐ·ⁿ</b>',
+ ],
+ examples: [
+  { q: 'Zjednoduš: 2³ · 2⁴', s: ['Sčítáme exponenty: 2³⁺⁴ = 2⁷ = <b>128</b>'] },
+  { q: 'Zjednoduš: (3²)³', s: ['Násobíme exponenty: 3⁶ = <b>729</b>'] },
+ ],
+ video: { id: 'x0Yv5r2NjTU', title: 'Součin mocnin' },
+},
+
+'2-3': {
+ intro: '🛰️ [SIGNAL] Vědecký zápis komprimuje obří čísla. A Pythagoras hlídá geometrii sítě.',
+ sections: [
+  { h: 'Vědecký (semilogaritmický) zápis',
+    p: ['Číslo zapíšeme jako a · 10ⁿ, kde 1 ≤ a < 10. Velká čísla mají kladné n, malá záporné.',
+        '6 500 = 6,5 · 10³. 0,0042 = 4,2 · 10⁻³.'] },
+  { h: 'Pythagorova věta',
+    p: ['V pravoúhlém trojúhelníku c² = a² + b² (c je přepona naproti pravému úhlu).',
+        'Přepona: c = √(a²+b²). Odvěsna: a = √(c²−b²).'] },
+ ],
+ formulas: [
+  '<b>Vědecký zápis:</b> a · 10ⁿ, 1 ≤ a < 10',
+  '<b>c² = a² + b²</b>',
+ ],
+ examples: [
+  { q: 'Zapiš vědecky: 73 000', s: ['7,3 · 10⁴ → <b>7,3 · 10⁴</b>'] },
+  { q: 'Odvěsny 9 a 12. Přepona?', s: ['c² = 81 + 144 = 225', 'c = <b>15</b>'] },
+ ],
+ video: { id: 'ssvz3u8imgk', title: 'Pythagorova věta' },
+},
+
+/* ─── Oblast 3: ROVNICOVÝ PROCESOR ────────────────────────────── */
+
+'3-1': {
+ intro: '🧮 [SOLVE] Procesor čeká na hodnotu x. Vyřeš základní rovnici a odemkni jádro.',
+ sections: [
+  { h: 'Lineární rovnice',
+    p: ['Rovnice s neznámou x v první mocnině. Cíl: osamostatnit x ekvivalentními úpravami.',
+        'Co uděláš jedné straně, udělej i druhé.'] },
+  { h: 'Postup a zkouška',
+    p: ['Členy s x na jednu stranu, čísla na druhou, pak vyděl koeficientem. Výsledek ověř dosazením.'] },
+ ],
+ formulas: [
+  '<b>ax + b = c → x = (c − b)/a</b>',
+ ],
+ examples: [
+  { q: 'Vyřeš: 5x − 8 = 17', s: ['5x = 25', 'x = <b>5</b>'] },
+ ],
+ video: null,
+},
+
+'3-2': {
+ intro: '🔁 [PARSE] Rovnice se závorkami a neznámou na obou stranách. Rozparsuj je.',
+ sections: [
+  { h: 'Odstranění závorek',
+    p: ['Roznásob závorky (pozor na znaménko před závorkou): −(x − 3) = −x + 3.'] },
+  { h: 'Neznámá na obou stranách',
+    p: ['Členy s x dej vlevo, čísla vpravo, sečti a vyděl koeficientem.'] },
+ ],
+ formulas: [
+  '<b>−(a − b) = −a + b</b>',
+  '<b>Postup:</b> roznásob → x vlevo → ÷ koeficient',
+ ],
+ examples: [
+  { q: 'Vyřeš: 3(x − 2) = x + 4', s: ['3x − 6 = x + 4', '3x − x = 4 + 6', '2x = 10 → x = <b>5</b>'] },
+ ],
+ video: null,
+},
+
+'3-3': {
+ intro: '📐 [EXTRACT] Vyjádři neznámou ze vzorce a vyřeš slovní rovnici. Datová extrakce.',
+ sections: [
+  { h: 'Vyjádření neznámé ze vzorce',
+    p: ['Se vzorcem zacházíme jako s rovnicí — osamostatníme hledanou veličinu ekvivalentními úpravami.',
+        'Z S = a · b vyjádříme a = S / b.'] },
+  { h: 'Slovní rovnice',
+    p: ['Označ neznámou, vyjádři vztahy, sestav rovnici, vyřeš a napiš odpověď.'] },
+ ],
+ formulas: [
+  '<b>S = a·b → a = S/b</b>',
+  '<b>o = 2(a+b) → a = o/2 − b</b>',
+ ],
+ examples: [
+  { q: 'Ze vzorce V = a³ vyjádři a', s: ['Odmocni obě strany (třetí odmocnina)', 'a = <b>³√V</b>'] },
+  { q: 'Obdélník: o = 30 cm, b = 7 cm. Strana a?', s: ['a = o/2 − b = 15 − 7 = <b>8 cm</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 4: SEKTOR LOMENÉHO KÓDU ──────────────────────────── */
+
+'4-1': {
+ intro: '🧬 [VALIDATE] Lomené výrazy mají podmínky. Zjisti, kdy jmenovatel nesmí být nula.',
+ sections: [
+  { h: 'Lomený výraz',
+    p: ['Lomený výraz má proměnnou ve jmenovateli. Jmenovatel nikdy nesmí být roven nule (dělení nulou není definováno).'] },
+  { h: 'Podmínky řešitelnosti',
+    p: ['Najdi hodnoty, pro které je jmenovatel nula, a vyluč je. Pro 1/(x−3) platí podmínka x ≠ 3.'] },
+ ],
+ formulas: [
+  '<b>Jmenovatel ≠ 0</b>',
+  '<b>x − a ≠ 0 → x ≠ a</b>',
+ ],
+ examples: [
+  { q: 'Urči podmínku pro 5/(x − 2)', s: ['Jmenovatel x − 2 ≠ 0', 'Podmínka: <b>x ≠ 2</b>'] },
+  { q: 'Urči podmínku pro x/(x + 4)', s: ['x + 4 ≠ 0', '<b>x ≠ −4</b>'] },
+ ],
+ video: null,
+},
+
+'4-2': {
+ intro: '🔢 [EVAL] Vyhodnoť hodnotu lomeného výrazu — dosaď a zkrať.',
+ sections: [
+  { h: 'Hodnota výrazu',
+    p: ['Dosaď číslo za proměnnou (musí splňovat podmínku) a vypočítej. Pozor na pořadí operací.'] },
+  { h: 'Krácení lomených výrazů',
+    p: ['Čitatel i jmenovatel rozlož na součin a zkrať společné činitele. (x²−9)/(x−3) = (x−3)(x+3)/(x−3) = x+3.'] },
+ ],
+ formulas: [
+  '<b>Krácení:</b> rozlož na součin, zkrať společné',
+  '<b>x² − a² = (x − a)(x + a)</b>',
+ ],
+ examples: [
+  { q: 'Hodnota (x + 1)/(x − 1) pro x = 3', s: ['(3+1)/(3−1) = 4/2 = <b>2</b>'] },
+  { q: 'Zkrať: (x² − 4)/(x − 2)', s: ['(x−2)(x+2)/(x−2) = <b>x + 2</b> (x ≠ 2)'] },
+ ],
+ video: null,
+},
+
+'4-3': {
+ intro: '🧩 [DECODE] Rovnice s neznámou ve jmenovateli. Dekóduj ji opatrně — nezapomeň podmínky.',
+ sections: [
+  { h: 'Rovnice s neznámou ve jmenovateli',
+    p: ['Nejdřív urči podmínky (jmenovatel ≠ 0). Pak vynásob rovnici společným jmenovatelem a vyřeš lineární rovnici.',
+        'Výsledek nesmí porušit podmínku — jinak je řešení nepřípustné.'] },
+ ],
+ formulas: [
+  '<b>Postup:</b> podmínky → vynásob jmenovatelem → vyřeš → ověř podmínku',
+ ],
+ examples: [
+  { q: 'Vyřeš: 6/x = 2  (x ≠ 0)', s: ['Vynásob x: 6 = 2x', 'x = <b>3</b> (splňuje x ≠ 0)'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 5: SÍŤOVÝ UZEL ───────────────────────────────────── */
+
+'5-1': {
+ intro: '🔗 [LINK] Dvě rovnice, dvě neznámé. Propoj uzel řešením soustavy.',
+ sections: [
+  { h: 'Soustava dvou rovnic',
+    p: ['Hledáme dvojici (x, y), která vyhovuje oběma rovnicím současně.'] },
+  { h: 'Metoda dosazovací a sčítací',
+    p: ['Dosazovací: z jedné rovnice vyjádři jednu neznámou a dosaď do druhé.',
+        'Sčítací: rovnice sečti/odečti tak, aby jedna neznámá vypadla.'] },
+ ],
+ formulas: [
+  '<b>Dosazovací:</b> vyjádři x → dosaď do 2. rovnice',
+  '<b>Sčítací:</b> uprav koeficienty → sečti → 1 neznámá vypadne',
+ ],
+ examples: [
+  { q: 'Vyřeš: x + y = 10, x − y = 4', s: ['Sečti rovnice: 2x = 14 → x = 7', 'y = 10 − 7 = 3', 'Řešení: <b>x = 7, y = 3</b>'] },
+ ],
+ video: null,
+},
+
+'5-2': {
+ intro: '⚗️ [MIX] Roztoky, slitiny a výkon. Sestav rovnice pro směsi a práci.',
+ sections: [
+  { h: 'Úlohy o směsích',
+    p: ['Hlídej množství „čisté" složky: koncentrace × množství. Součet složek = výsledná směs.',
+        'Příklad roztoku: 2 l 10% + 3 l 20% → čistá látka 0,2 + 0,6 = 0,8 l v 5 l → 16 %.'] },
+  { h: 'Úlohy o společné práci',
+    p: ['Pracuj s výkonem za jednotku času. Kdo udělá práci za a hodin, zvládne za hodinu 1/a práce.'] },
+ ],
+ formulas: [
+  '<b>Směs:</b> Σ(koncentrace · množství) = výsledná látka',
+  '<b>Práce:</b> výkon = 1/čas',
+ ],
+ examples: [
+  { q: 'Smícháme 2 kg za 50 Kč/kg a 3 kg za 100 Kč/kg. Cena za kg směsi?', s: ['Celkem: 2·50 + 3·100 = 100 + 300 = 400 Kč', '400 ÷ 5 kg = <b>80 Kč/kg</b>'] },
+ ],
+ video: null,
+},
+
+'5-3': {
+ intro: '🚀 [MOVE] Dráha, rychlost, čas. Vyřeš úlohy o pohybu napříč sítí.',
+ sections: [
+  { h: 'Vztah dráhy, rychlosti a času',
+    p: ['Dráha = rychlost × čas. Z toho rychlost = dráha ÷ čas a čas = dráha ÷ rychlost.'] },
+  { h: 'Pohyb proti sobě a za sebou',
+    p: ['Proti sobě: rychlosti se sčítají (sbližují se). Za sebou stejným směrem: rychlosti se odečítají.'] },
+ ],
+ formulas: [
+  '<b>s = v · t</b>',
+  '<b>v = s / t</b>, <b>t = s / v</b>',
+ ],
+ examples: [
+  { q: 'Auto jede 90 km/h. Jakou dráhu ujede za 2,5 h?', s: ['s = 90 · 2,5 = <b>225 km</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 6: GRAFOVÝ MONITOR ───────────────────────────────── */
+
+'6-1': {
+ intro: '📈 [PLOT] Monitor vykresluje lineární funkce. Pochop tvar y = kx + q.',
+ sections: [
+  { h: 'Lineární funkce',
+    p: ['Funkce y = kx + q. Grafem je přímka. k je směrnice (sklon), q je úsek na ose y (kde přímka protne osu y).'] },
+  { h: 'Smysl k a q',
+    p: ['k > 0 → rostoucí, k < 0 → klesající, k = 0 → konstantní (vodorovná).',
+        'q je hodnota y pro x = 0.'] },
+ ],
+ formulas: [
+  '<b>y = kx + q</b>',
+  '<b>k</b> = sklon · <b>q</b> = úsek na ose y',
+ ],
+ examples: [
+  { q: 'Urči y pro funkci y = 2x + 3 při x = 4', s: ['y = 2·4 + 3 = 8 + 3 = <b>11</b>'] },
+  { q: 'Kde protne y = 2x + 3 osu y?', s: ['Pro x = 0: y = 3', 'Bod <b>[0; 3]</b>'] },
+ ],
+ video: null,
+},
+
+'6-2': {
+ intro: '🔍 [ANALYZE] Vlastnosti funkcí — rostoucí, klesající, průsečíky. Analyzuj graf.',
+ sections: [
+  { h: 'Rostoucí a klesající',
+    p: ['Rostoucí: s rostoucím x roste i y (k > 0). Klesající: s rostoucím x klesá y (k < 0).'] },
+  { h: 'Průsečíky s osami',
+    p: ['S osou y: dosaď x = 0. S osou x: polož y = 0 a vyřeš rovnici pro x.'] },
+ ],
+ formulas: [
+  '<b>Průsečík s osou x:</b> y = 0 → vyřeš pro x',
+  '<b>Průsečík s osou y:</b> x = 0 → y = q',
+ ],
+ examples: [
+  { q: 'Je y = −3x + 6 rostoucí, nebo klesající?', s: ['k = −3 < 0 → <b>klesající</b>'] },
+  { q: 'Kde protne y = −3x + 6 osu x?', s: ['y = 0: 0 = −3x + 6 → x = 2', 'Bod <b>[2; 0]</b>'] },
+ ],
+ video: null,
+},
+
+'6-3': {
+ intro: '〽️ [INVERSE] Lomená funkce a nepřímá úměrnost y = k/x. Křivka v monitoru.',
+ sections: [
+  { h: 'Nepřímá úměrnost',
+    p: ['y = k/x (x ≠ 0). Když x roste, y klesá a naopak. Součin x · y = k je stálý.',
+        'Grafem je hyperbola (dvě větve).'] },
+  { h: 'Užití',
+    p: ['Čím víc dělníků, tím kratší čas. Čím vyšší rychlost, tím kratší čas na danou dráhu.'] },
+ ],
+ formulas: [
+  '<b>y = k/x</b> (x ≠ 0)',
+  '<b>x · y = k</b> (konstantní)',
+ ],
+ examples: [
+  { q: 'Pro y = 12/x urči y při x = 3', s: ['y = 12/3 = <b>4</b>'] },
+  { q: '6 dělníků udělá práci za 8 dní. Za kolik dní 4 dělníci?', s: ['Součin stálý: 6·8 = 48', '48 ÷ 4 = <b>12 dní</b>'] },
+ ],
+ video: null,
+},
+
+/* ─── Oblast 7: JÁDRO SYSTÉMU ─────────────────────────────────── */
+
+'7-1': {
+ intro: '🏛️ [SCALE] Podobnost a měřítko — klíč k jádru. Urči koeficient podobnosti.',
+ sections: [
+  { h: 'Podobnost útvarů',
+    p: ['Podobné útvary mají stejný tvar, ale jinou velikost. Odpovídající strany jsou ve stejném poměru — koeficient podobnosti k.',
+        'Úhly se při podobnosti zachovávají.'] },
+  { h: 'Měřítko',
+    p: ['Měřítko 1 : 50 000 znamená, že 1 cm na mapě = 50 000 cm = 500 m ve skutečnosti.'] },
+ ],
+ formulas: [
+  '<b>k</b> = poměr odpovídajících stran',
+  '<b>Měřítko 1 : m</b> → skutečnost = mapa · m',
+ ],
+ examples: [
+  { q: 'Trojúhelníky podobné, k = 3. Strana originálu 4 cm. Odpovídající strana obrazu?', s: ['4 · 3 = <b>12 cm</b>'] },
+  { q: 'Mapa 1 : 100 000. Úsečka 3 cm = kolik km?', s: ['3 · 100 000 = 300 000 cm = 3 000 m = <b>3 km</b>'] },
+ ],
+ video: { id: 'XFIg5VJ2Ujc', title: 'Podobnost trojúhelníků' },
+},
+
+'7-2': {
+ intro: '🧊 [VOLUME] Objem a povrch těles — válec, kužel, koule. Naplň jádro daty.',
+ sections: [
+  { h: 'Válec',
+    p: ['Objem V = π·r²·v. Povrch S = 2πr² + 2πrv.'] },
+  { h: 'Kužel',
+    p: ['Objem V = ⅓·π·r²·v. Povrch S = πr² + πrs (s je strana kužele).'] },
+  { h: 'Koule',
+    p: ['Objem V = ⁴⁄₃·π·r³. Povrch S = 4πr².'] },
+ ],
+ formulas: [
+  '<b>Válec:</b> V = πr²v',
+  '<b>Kužel:</b> V = ⅓πr²v',
+  '<b>Koule:</b> V = ⁴⁄₃πr³, S = 4πr²',
+ ],
+ examples: [
+  { q: 'Koule r = 3 cm. Povrch? (π ≈ 3,14)', s: ['S = 4·3,14·3² = 4·3,14·9 = <b>113,04 cm²</b>'] },
+  { q: 'Kužel r = 3 cm, v = 4 cm. Objem? (π ≈ 3,14)', s: ['V = ⅓·3,14·9·4 = ⅓·113,04 = <b>37,68 cm³</b>'] },
+ ],
+ video: { id: 'GG9WF955El4', title: 'Objem a povrch válce' },
+},
+
+'7-3': {
+ intro: '💥 [BREACH] Finální průlom do systémového jádra. Mix všech témat 9. ročníku — všechno se počítá.',
+ sections: [
+  { h: 'Co tě čeká',
+    p: ['Procenta, mocniny, rovnice, lomené výrazy, soustavy, funkce, podobnost i tělesa — vše dohromady.',
+        'Toto je příprava na přijímačky i na konec ZŠ.'] },
+  { h: 'Strategie závěru',
+    p: ['Čti zadání pozorně, dělej zkoušku u rovnic, hlídej podmínky u lomených výrazů a jednotky u geometrie.'] },
+ ],
+ formulas: [
+  '<b>c² = a² + b²</b> · <b>y = kx + q</b>',
+  '<b>Koule:</b> V = ⁴⁄₃πr³ · <b>Válec:</b> V = πr²v',
+ ],
+ examples: [
+  { q: 'Vyřeš: 4/(x − 1) = 2  (x ≠ 1)', s: ['Vynásob (x−1): 4 = 2(x−1)', '4 = 2x − 2 → 2x = 6 → x = <b>3</b>'] },
+ ],
+ video: null,
+},
+
+};
+})();

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -123,6 +123,20 @@ body::before{
 .ms-item.avail{border-color:var(--blue)}
 .ms-item.locked{opacity:.35;cursor:not-allowed}
 .ms-item:not(.locked):hover{border-color:var(--gold)}
+.learn-section{margin-bottom:18px}
+.learn-section h3{font-family:var(--px);font-weight:700;font-size:13px;color:var(--blue);letter-spacing:1px;text-transform:uppercase;margin-bottom:8px;border-bottom:1px solid var(--gold);padding-bottom:4px}
+.learn-section p{font-family:var(--vt);font-size:19px;color:var(--text);line-height:1.55;margin-bottom:8px}
+.learn-formula{background:#0f1a2f;border:2px solid var(--blue);border-radius:4px;padding:12px 16px;margin:10px 0;font-family:var(--px);font-size:13px;color:var(--blue);line-height:1.8}
+.learn-formula b{color:#fff}
+.learn-example{background:var(--panel);border-left:4px solid var(--gold);padding:12px 16px;margin:10px 0;border-radius:0 6px 6px 0}
+.learn-example .ex-q{font-family:var(--px);font-weight:700;font-size:13px;color:var(--gold);margin-bottom:6px}
+.learn-example .ex-s{font-family:var(--vt);font-size:18px;color:var(--text);line-height:1.6}
+.learn-example .ex-s b{color:var(--green)}
+.learn-video{display:inline-flex;align-items:center;gap:8px;font-family:var(--px);font-weight:700;font-size:13px;padding:10px 16px;border:2px solid var(--red);color:var(--red);text-decoration:none;margin-top:6px;cursor:pointer;background:none;letter-spacing:.5px}
+.learn-video:hover{background:var(--red);color:#fff}
+.learn-intro{font-family:var(--vt);font-size:22px;color:var(--muted);line-height:1.5;padding:10px 14px;background:#1a1540;border:2px dashed #4a3f8a;margin-bottom:18px}
+.learn-btn{background:none;border:2px solid var(--blue);color:var(--blue);font-family:var(--px);font-size:11px;font-weight:700;padding:4px 8px;cursor:pointer;margin-left:6px;flex-shrink:0}
+.learn-btn:hover{background:var(--blue);color:#06101e}
 .ms-num{font-family:var(--px);font-weight:700;font-size:16px;min-width:34px;text-align:center}
 .ms-name{font-family:var(--px);font-weight:700;font-size:16px;line-height:1.1;color:var(--text)}
 .ms-sub{font-family:var(--vt);font-size:18px;color:var(--muted);margin-top:2px;line-height:1}
@@ -468,6 +482,22 @@ body::before{
 </div>
 
 <!-- ══════════════ AREA ══════════════ -->
+<!-- ══════════════ TEORIE ══════════════ -->
+<div id="s-learn" class="screen">
+<div class="wrap">
+ <div class="topnav">
+ <button class="btn sm" id="learn-back-btn" onclick="go('area')">← ZPĚT</button>
+ <span style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--blue)">📖 TEORIE</span>
+ <span style="min-width:60px"></span>
+ </div>
+ <div id="learn-content"></div>
+ <div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:18px">
+  <button class="btn b" id="learn-battle-btn" onclick="launchLearnBattle()">⚔️ BOJOVAT NYNÍ</button>
+  <button class="btn sm" onclick="go('train')">🎯 TRÉNOVAT</button>
+ </div>
+</div>
+</div>
+
 <div id="s-area" class="screen">
 <div class="wrap">
  <div class="topnav">
@@ -1392,15 +1422,66 @@ function openArea(aid){
  const stars=allDn?'⭐⭐⭐':dn>0?'⭐'.repeat(Math.ceil(dn/tot*3))+'☆'.repeat(3-Math.ceil(dn/tot*3)):'☆☆☆';
  const it=document.createElement('div');
  it.className='ms-item '+cls;
+ const hasLearn=window.RPG_LEARN_8&&window.RPG_LEARN_8[m.id];
  it.innerHTML=`
  <div class="ms-num" style="color:${allDn?'var(--green)':avail?'var(--blue)':'var(--muted)'}">${allDn?'✓':String(mi+1).padStart(2,'0')}</div>
  <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${(!allDn&&teacherUnlk&&!GODMODE)?'🔓 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
+ ${hasLearn?`<button class="learn-btn" onclick="startLearn('${m.id}');event.stopPropagation()">📖 Teorie</button>`:''}
  <div style="font-size:14px">${stars}</div>`;
  if(avail)it.onclick=()=>launchBattle(ar.id,m.id);
  ml.appendChild(it);
  });
  go('area');
 }
+
+// ══════════════════════════════════════════
+// TEORIE
+// ══════════════════════════════════════════
+let LEARN_MID=null;
+
+function startLearn(mid){
+ LEARN_MID=mid;
+ const ar=AREAS.find(a=>a.missions.some(m=>m.id===mid));
+ const m=ar?ar.missions.find(x=>x.id===mid):null;
+ renderLearn(mid,m);
+ go('learn');
+}
+function launchLearnBattle(){
+ if(!LEARN_MID)return;
+ const ar=AREAS.find(a=>a.missions.some(m=>m.id===LEARN_MID));
+ if(ar)launchBattle(ar.id,LEARN_MID);
+}
+function renderLearn(mid,m){
+ const L=window.RPG_LEARN_8&&window.RPG_LEARN_8[mid];
+ const el=document.getElementById('learn-content');
+ if(!L){el.innerHTML='<div style="font-family:var(--vt);font-size:20px;color:var(--muted);padding:20px">Teorie pro tuto misi není dostupná.</div>';return;}
+ let html=`<div class="panel b" style="margin-bottom:14px">
+  <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--blue);letter-spacing:.5px">${esc2(m?m.name:mid)}</div>
+  <div style="font-family:var(--vt);font-size:18px;color:var(--muted);margin-top:4px">${esc2(m?m.sub:'')}</div>
+ </div>`;
+ if(L.intro)html+=`<div class="learn-intro">${esc2(L.intro)}</div>`;
+ (L.sections||[]).forEach(s=>{
+  html+=`<div class="learn-section"><h3>${esc2(s.h)}</h3>`;
+  (Array.isArray(s.p)?s.p:[s.p]).forEach(p=>{html+=`<p>${p}</p>`;});
+  html+='</div>';
+ });
+ if(L.formulas&&L.formulas.length){
+  html+='<div class="learn-formula">';
+  L.formulas.forEach(f=>{html+=f+'<br>';});
+  html+='</div>';
+ }
+ (L.examples||[]).forEach(ex=>{
+  html+=`<div class="learn-example"><div class="ex-q">📝 ${esc2(ex.q)}</div><div class="ex-s">`;
+  (Array.isArray(ex.s)?ex.s:[ex.s]).forEach(step=>{html+=step+'<br>';});
+  html+='</div></div>';
+ });
+ if(L.video){
+  html+=`<div style="margin-top:16px"><a class="learn-video" href="https://www.youtube.com/watch?v=${L.video.id}" target="_blank" rel="noopener">▶ VIDEO: ${esc2(L.video.title)}</a></div>`;
+ }
+ el.innerHTML=html;
+ document.getElementById('learn-battle-btn').onclick=launchLearnBattle;
+}
+function esc2(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 
 // ══════════════════════════════════════════
 // BATTLE
@@ -1979,6 +2060,7 @@ document.addEventListener('keydown',e=>{
  if(nxt.style.display!=='none')trNext();
  else if(!TR.m||!TR.m.mc)trSubmit();
  }
+ if(active.id==='s-learn'){launchLearnBattle();}
 });
 
 // ══════════════════════════════════════════
@@ -2162,6 +2244,7 @@ window.addEventListener('load',()=>{
 });
 </script>
 <script src="./rpg-tasks-8.js"></script>
+<script src="./rpg-learn-8.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="./rpg-cloud.js"></script>
 <script>RPGCloud.attachGame(SAVE_KEY);</script>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -123,6 +123,20 @@ body::before{
 .ms-item.avail{border-color:var(--blue)}
 .ms-item.locked{opacity:.35;cursor:not-allowed}
 .ms-item:not(.locked):hover{border-color:var(--gold)}
+.learn-section{margin-bottom:18px}
+.learn-section h3{font-family:var(--px);font-weight:700;font-size:13px;color:var(--blue);letter-spacing:1px;text-transform:uppercase;margin-bottom:8px;border-bottom:1px solid var(--gold);padding-bottom:4px}
+.learn-section p{font-family:var(--vt);font-size:19px;color:var(--text);line-height:1.55;margin-bottom:8px}
+.learn-formula{background:#0f1a2f;border:2px solid var(--blue);border-radius:4px;padding:12px 16px;margin:10px 0;font-family:var(--px);font-size:13px;color:var(--blue);line-height:1.8}
+.learn-formula b{color:#fff}
+.learn-example{background:var(--panel);border-left:4px solid var(--gold);padding:12px 16px;margin:10px 0;border-radius:0 6px 6px 0}
+.learn-example .ex-q{font-family:var(--px);font-weight:700;font-size:13px;color:var(--gold);margin-bottom:6px}
+.learn-example .ex-s{font-family:var(--vt);font-size:18px;color:var(--text);line-height:1.6}
+.learn-example .ex-s b{color:var(--green)}
+.learn-video{display:inline-flex;align-items:center;gap:8px;font-family:var(--px);font-weight:700;font-size:13px;padding:10px 16px;border:2px solid var(--red);color:var(--red);text-decoration:none;margin-top:6px;cursor:pointer;background:none;letter-spacing:.5px}
+.learn-video:hover{background:var(--red);color:#fff}
+.learn-intro{font-family:var(--vt);font-size:22px;color:var(--muted);line-height:1.5;padding:10px 14px;background:#1a1540;border:2px dashed #4a3f8a;margin-bottom:18px}
+.learn-btn{background:none;border:2px solid var(--blue);color:var(--blue);font-family:var(--px);font-size:11px;font-weight:700;padding:4px 8px;cursor:pointer;margin-left:6px;flex-shrink:0}
+.learn-btn:hover{background:var(--blue);color:#06101e}
 .ms-num{font-family:var(--px);font-weight:700;font-size:16px;min-width:34px;text-align:center}
 .ms-name{font-family:var(--px);font-weight:700;font-size:16px;line-height:1.1;color:var(--text)}
 .ms-sub{font-family:var(--vt);font-size:18px;color:var(--muted);margin-top:2px;line-height:1}
@@ -422,6 +436,22 @@ body::before{
 </div>
 
 <!-- ══════════════ AREA ══════════════ -->
+<!-- ══════════════ TEORIE ══════════════ -->
+<div id="s-learn" class="screen">
+<div class="wrap">
+ <div class="topnav">
+ <button class="btn sm" id="learn-back-btn" onclick="go('area')">← ZPĚT</button>
+ <span style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--blue)">📖 TEORIE</span>
+ <span style="min-width:60px"></span>
+ </div>
+ <div id="learn-content"></div>
+ <div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:18px">
+  <button class="btn b" id="learn-battle-btn" onclick="launchLearnBattle()">⚔️ BOJOVAT NYNÍ</button>
+  <button class="btn sm" onclick="go('train')">🎯 TRÉNOVAT</button>
+ </div>
+</div>
+</div>
+
 <div id="s-area" class="screen">
 <div class="wrap">
  <div class="topnav">
@@ -590,6 +620,7 @@ body::before{
 
 <!-- rozšiřující banka úloh (nepovinná; bez ní hra běží na základním poolu) -->
 <script src="./rpg-tasks-9.js"></script>
+<script src="./rpg-learn-9.js"></script>
 <script>
 // ══════════════════════════════════════════
 // HELPERS
@@ -1246,15 +1277,66 @@ function openArea(aid){
  const stars=allDn?'⭐⭐⭐':dn>0?'⭐'.repeat(Math.ceil(dn/tot*3))+'☆'.repeat(3-Math.ceil(dn/tot*3)):'☆☆☆';
  const it=document.createElement('div');
  it.className='ms-item '+cls;
+ const hasLearn=window.RPG_LEARN_9&&window.RPG_LEARN_9[m.id];
  it.innerHTML=`
  <div class="ms-num" style="color:${allDn?'var(--green)':avail?'var(--blue)':'var(--muted)'}">${allDn?'✓':String(mi+1).padStart(2,'0')}</div>
  <div style="flex:1"><div class="ms-name">${masteryOf(m.id).mastered?'🏅 ':''}${(!allDn&&teacherUnlk&&!GODMODE)?'🔓 ':''}${m.name}</div><div class="ms-sub">${m.sub} · ${dn}/${tot}</div></div>
+ ${hasLearn?`<button class="learn-btn" onclick="startLearn('${m.id}');event.stopPropagation()">📖 Teorie</button>`:''}
  <div style="font-size:14px">${stars}</div>`;
  if(avail)it.onclick=()=>launchBattle(ar.id,m.id);
  ml.appendChild(it);
  });
  go('area');
 }
+
+// ══════════════════════════════════════════
+// TEORIE
+// ══════════════════════════════════════════
+let LEARN_MID=null;
+
+function startLearn(mid){
+ LEARN_MID=mid;
+ const ar=AREAS.find(a=>a.missions.some(m=>m.id===mid));
+ const m=ar?ar.missions.find(x=>x.id===mid):null;
+ renderLearn(mid,m);
+ go('learn');
+}
+function launchLearnBattle(){
+ if(!LEARN_MID)return;
+ const ar=AREAS.find(a=>a.missions.some(m=>m.id===LEARN_MID));
+ if(ar)launchBattle(ar.id,LEARN_MID);
+}
+function renderLearn(mid,m){
+ const L=window.RPG_LEARN_9&&window.RPG_LEARN_9[mid];
+ const el=document.getElementById('learn-content');
+ if(!L){el.innerHTML='<div style="font-family:var(--vt);font-size:20px;color:var(--muted);padding:20px">Teorie pro tuto misi není dostupná.</div>';return;}
+ let html=`<div class="panel b" style="margin-bottom:14px">
+  <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--blue);letter-spacing:.5px">${esc2(m?m.name:mid)}</div>
+  <div style="font-family:var(--vt);font-size:18px;color:var(--muted);margin-top:4px">${esc2(m?m.sub:'')}</div>
+ </div>`;
+ if(L.intro)html+=`<div class="learn-intro">${esc2(L.intro)}</div>`;
+ (L.sections||[]).forEach(s=>{
+  html+=`<div class="learn-section"><h3>${esc2(s.h)}</h3>`;
+  (Array.isArray(s.p)?s.p:[s.p]).forEach(p=>{html+=`<p>${p}</p>`;});
+  html+='</div>';
+ });
+ if(L.formulas&&L.formulas.length){
+  html+='<div class="learn-formula">';
+  L.formulas.forEach(f=>{html+=f+'<br>';});
+  html+='</div>';
+ }
+ (L.examples||[]).forEach(ex=>{
+  html+=`<div class="learn-example"><div class="ex-q">📝 ${esc2(ex.q)}</div><div class="ex-s">`;
+  (Array.isArray(ex.s)?ex.s:[ex.s]).forEach(step=>{html+=step+'<br>';});
+  html+='</div></div>';
+ });
+ if(L.video){
+  html+=`<div style="margin-top:16px"><a class="learn-video" href="https://www.youtube.com/watch?v=${L.video.id}" target="_blank" rel="noopener">▶ VIDEO: ${esc2(L.video.title)}</a></div>`;
+ }
+ el.innerHTML=html;
+ document.getElementById('learn-battle-btn').onclick=launchLearnBattle;
+}
+function esc2(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
 
 // ══════════════════════════════════════════
 // BATTLE
@@ -2001,6 +2083,7 @@ document.addEventListener('keydown',e=>{
  if(nxt.style.display!=='none')trNext();
  else if(!TR.m||!TR.m.mc)trSubmit();
  }
+ if(active.id==='s-learn'){launchLearnBattle();}
 });
 
 // ══════════════════════════════════════════

--- a/tests/rpg-learn.test.cjs
+++ b/tests/rpg-learn.test.cjs
@@ -1,0 +1,63 @@
+/* ══════════════════════════════════════════════════════════════════
+   Test: learning content (Teorie) pro ročníky 6/7/8/9
+   Ověřuje moduly rpg-learn-N.js + zapojení s-learn v rpg-mat-N.html
+   ══════════════════════════════════════════════════════════════════ */
+const fs = require('fs');
+const path = require('path');
+
+const PROJ = path.join(__dirname, '..', 'projects');
+let pass = 0, fail = 0;
+function ok(cond, msg){ if(cond){pass++; console.log('  ✅ '+msg);} else {fail++; console.log('  ❌ '+msg);} }
+
+const GRADES = [6, 7, 8, 9];
+
+for (const g of GRADES) {
+  console.log(`\n── ${g}. ročník ──`);
+
+  // 1) modul rpg-learn-N.js
+  const modPath = path.join(PROJ, `rpg-learn-${g}.js`);
+  ok(fs.existsSync(modPath), `rpg-learn-${g}.js existuje`);
+  const sandbox = { window: {} };
+  const code = fs.readFileSync(modPath, 'utf8');
+  new Function('window', code)(sandbox.window);
+  const L = sandbox.window[`RPG_LEARN_${g}`];
+  ok(L && typeof L === 'object', `window.RPG_LEARN_${g} je objekt`);
+  const keys = Object.keys(L || {});
+  ok(keys.length === 21, `obsahuje 21 misí (má ${keys.length})`);
+
+  // každá mise má intro a aspoň jednu sekci; video je null nebo {id,title}
+  let structOK = true, videoOK = true, vids = 0;
+  for (const k of keys) {
+    const e = L[k];
+    if (!e.intro || !Array.isArray(e.sections) || e.sections.length === 0) structOK = false;
+    if (e.video !== null) {
+      if (!e.video || typeof e.video.id !== 'string' || typeof e.video.title !== 'string') videoOK = false;
+      else vids++;
+    }
+  }
+  ok(structOK, 'každá mise má intro + alespoň jednu sekci');
+  ok(videoOK, 'video je všude buď null, nebo {id,title}');
+  console.log(`     (misí s videem: ${vids})`);
+
+  // mise odpovídají vzoru oblast-mise 1-1 … 7-3
+  const expected = [];
+  for (let a = 1; a <= 7; a++) for (let m = 1; m <= 3; m++) expected.push(`${a}-${m}`);
+  ok(expected.every(id => keys.includes(id)), 'klíče misí odpovídají 1-1 … 7-3');
+
+  // 2) zapojení v rpg-mat-N.html
+  const htmlPath = path.join(PROJ, `rpg-mat-${g}.html`);
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  ok(html.includes('id="s-learn"'), 'HTML má obrazovku s-learn');
+  ok(html.includes('function startLearn'), 'HTML má funkci startLearn');
+  ok(html.includes('function renderLearn'), 'HTML má funkci renderLearn');
+  ok(html.includes('function launchLearnBattle'), 'HTML má funkci launchLearnBattle');
+  ok(html.includes(`window.RPG_LEARN_${g}`), `renderLearn čte RPG_LEARN_${g}`);
+  ok(html.includes(`./rpg-learn-${g}.js`), `HTML načítá rpg-learn-${g}.js`);
+  ok(html.includes("if(active.id==='s-learn'){launchLearnBattle();}"), 's-learn má klávesovou zkratku');
+  ok(html.includes('startLearn('), 'tlačítko Teorie volá startLearn');
+}
+
+console.log('\n══════════════════════════════════════════');
+console.log(`  VÝSLEDEK: ${pass} ✅  /  ${fail} ❌`);
+console.log('══════════════════════════════════════════');
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## Souhrn

Dokončení learning contentu — teorie pro **8. a 9. ročník** (6. a 7. už v mainu z PR #55). Tím má všechny 4 ročníky stejný vzor.

### Nové soubory
- **`rpg-learn-8.js`** — Citadela arcimága 🏛️, 21 lekcí (celá/racionální čísla, procenta, mocniny, Pythagorova věta, rovnice, výrazy a vzorce, vytýkání, kruh, válec, konstrukce, Thaletova kružnice)
- **`rpg-learn-9.js`** — NULL_BYTE 💻 cyberpunk, 21 lekcí (procenta/promile, mocniny a pravidla, vědecký zápis, rovnice, lomené výrazy, soustavy, směsi/pohyb, lineární a lomená funkce, podobnost, tělesa)
- **`tests/rpg-learn.test.cjs`** — ověřuje všechny 4 ročníky (moduly + zapojení v HTML)

### Změny v hrách
- `rpg-mat-8.html`, `rpg-mat-9.html` — obrazovka `s-learn`, tlačítko **📖 Teorie** u každé mise (graceful degradation), klávesová zkratka

### Videa
Z kanálu **@matematikajednoduse** (Lucie Straková), ID ověřená přes vyhledávač podle přesných názvů:
- 8. ročník: 7 misí · 9. ročník: 5 misí
- Zbývající mise mají `video: null` (kanál pro ně nemá přímý ekvivalent) — tlačítko videa se prostě nezobrazí

### Testy
- `tests/rpg-learn.test.cjs` → **56/56 ✅**
- `rpg-teacher` 50/50, `rpg-cloud` 24/24, `rpg-train` 6/7/8 + base → vše zelené

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_