### PR TITLE
fix(security): vyřešení 32 CodeQL code scanning alertů

### DIFF
--- a/projects/cesta_penez.html
+++ b/projects/cesta_penez.html
@@ -779,11 +779,14 @@ function buildResult() {
   const defaultName = i18n('Tomu, kdo prošel <i>Cestu peněz</i>', 'To whoever completed <i>Money Journey</i>');
   const savedName = STATE.studentName || '';
   nameInp.value = savedName;
-  nameDisp.innerHTML = savedName ? savedName : defaultName;
+  // jméno od uživatele vykreslíme jako text (textContent → žádné XSS);
+  // výchozí popisek je důvěryhodné HTML (<i>…</i>), ten jako innerHTML.
+  const setNameDisp = v => { if (v) nameDisp.textContent = v; else nameDisp.innerHTML = defaultName; };
+  setNameDisp(savedName);
   nameInp.oninput = () => {
     const v = nameInp.value.trim();
     STATE.studentName = v;
-    nameDisp.innerHTML = v ? v : defaultName;
+    setNameDisp(v);
     saveState();
   };
   document.getElementById('result-restart').addEventListener('click', () => {

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -1302,20 +1302,20 @@ let curArea=null;
 function openArea(aid){
  const ar=AREAS.find(a=>a.id===aid);
  curArea=ar;
- document.getElementById('area-title-sm').textContent=ar.name.replace('\n',' ');
+ document.getElementById('area-title-sm').textContent=ar.name.replace(/\n/g,' ');
  const hd=document.getElementById('area-head');
  const artHave=S.inv.includes(ar.art.id);
  hd.innerHTML=`
  <div style="display:flex;gap:14px;align-items:center">
  <div style="font-size:42px">${ar.icon}</div>
  <div>
- <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace('\n',' ')}</div>
+ <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace(/\n/g,' ')}</div>
  <div style="font-family:var(--vt);font-size:21px;color:var(--muted);margin-top:4px;line-height:1.3">${ar.desc}</div>
  </div>
  </div>
  <div style="margin-top:12px;display:flex;align-items:center;gap:10px;padding-top:10px;border-top:2px solid var(--panel2)">
  <div style="font-size:26px">${ar.art.ic}</div>
- <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace('\n',' ')}</span></div>
+ <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace(/\n/g,' ')}</span></div>
  ${artHave?'<div style="margin-left:auto;font-family:var(--px);font-weight:700;font-size:13px;color:var(--gold)">✓ ZÍSKÁNO</div>':''}
  </div>`;
  const ml=document.getElementById('mission-list');
@@ -1897,7 +1897,7 @@ function checkMissionComplete(){
  S.inv.push(ar.art.id);
  Object.entries(ar.attrGain).forEach(([k,v])=>{if(S.attrs[k]!==undefined)S.attrs[k]+=v;});
  saveS();
- setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace('\n',' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
+ setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace(/\n/g,' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
  }
  }
 }
@@ -1991,7 +1991,7 @@ function renderTrainPicker(){
   const sec=document.createElement('div');
   sec.className='panel';
   sec.style.marginTop='12px';
-  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace('\n',' ')}</div>`;
+  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
    const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -1314,20 +1314,20 @@ let curArea=null;
 function openArea(aid){
  const ar=AREAS.find(a=>a.id===aid);
  curArea=ar;
- document.getElementById('area-title-sm').textContent=ar.name.replace('\n',' ');
+ document.getElementById('area-title-sm').textContent=ar.name.replace(/\n/g,' ');
  const hd=document.getElementById('area-head');
  const artHave=S.inv.includes(ar.art.id);
  hd.innerHTML=`
  <div style="display:flex;gap:14px;align-items:center">
  <div style="font-size:42px">${ar.icon}</div>
  <div>
- <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace('\n',' ')}</div>
+ <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace(/\n/g,' ')}</div>
  <div style="font-family:var(--vt);font-size:21px;color:var(--muted);margin-top:4px;line-height:1.3">${ar.desc}</div>
  </div>
  </div>
  <div style="margin-top:12px;display:flex;align-items:center;gap:10px;padding-top:10px;border-top:2px solid var(--panel2)">
  <div style="font-size:26px">${ar.art.ic}</div>
- <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace('\n',' ')}</span></div>
+ <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace(/\n/g,' ')}</span></div>
  ${artHave?'<div style="margin-left:auto;font-family:var(--px);font-weight:700;font-size:13px;color:var(--gold)">✓ ZÍSKÁNO</div>':''}
  </div>`;
  const ml=document.getElementById('mission-list');
@@ -1909,7 +1909,7 @@ function checkMissionComplete(){
  S.inv.push(ar.art.id);
  Object.entries(ar.attrGain).forEach(([k,v])=>{if(S.attrs[k]!==undefined)S.attrs[k]+=v;});
  saveS();
- setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace('\n',' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
+ setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace(/\n/g,' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
  }
  }
 }
@@ -2000,7 +2000,7 @@ function renderTrainPicker(){
   const sec=document.createElement('div');
   sec.className='panel';
   sec.style.marginTop='12px';
-  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace('\n',' ')}</div>`;
+  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
    const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -1496,20 +1496,20 @@ let curArea=null;
 function openArea(aid){
  const ar=AREAS.find(a=>a.id===aid);
  curArea=ar;
- document.getElementById('area-title-sm').textContent=ar.name.replace('\n',' ');
+ document.getElementById('area-title-sm').textContent=ar.name.replace(/\n/g,' ');
  const hd=document.getElementById('area-head');
  const artHave=S.inv.includes(ar.art.id);
  hd.innerHTML=`
  <div style="display:flex;gap:14px;align-items:center">
  <div style="font-size:42px">${ar.icon}</div>
  <div>
- <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace('\n',' ')}</div>
+ <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace(/\n/g,' ')}</div>
  <div style="font-family:var(--vt);font-size:21px;color:var(--muted);margin-top:4px;line-height:1.3">${ar.desc}</div>
  </div>
  </div>
  <div style="margin-top:12px;display:flex;align-items:center;gap:10px;padding-top:10px;border-top:2px solid var(--panel2)">
  <div style="font-size:26px">${ar.art.ic}</div>
- <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace('\n',' ')}</span></div>
+ <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace(/\n/g,' ')}</span></div>
  ${artHave?'<div style="margin-left:auto;font-family:var(--px);font-weight:700;font-size:13px;color:var(--gold)">✓ ZÍSKÁNO</div>':''}
  </div>`;
  const ml=document.getElementById('mission-list');
@@ -2087,7 +2087,7 @@ function checkMissionComplete(){
  S.inv.push(ar.art.id);
  Object.entries(ar.attrGain).forEach(([k,v])=>{if(S.attrs[k]!==undefined)S.attrs[k]+=v;});
  saveS();
- setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace('\n',' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
+ setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace(/\n/g,' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
  }
  }
 }
@@ -2200,7 +2200,7 @@ function renderTrainPicker(){
   const sec=document.createElement('div');
   sec.className='panel';
   sec.style.marginTop='12px';
-  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace('\n',' ')}</div>`;
+  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
    const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -1355,20 +1355,20 @@ let curArea=null;
 function openArea(aid){
  const ar=AREAS.find(a=>a.id===aid);
  curArea=ar;
- document.getElementById('area-title-sm').textContent=ar.name.replace('\n',' ');
+ document.getElementById('area-title-sm').textContent=ar.name.replace(/\n/g,' ');
  const hd=document.getElementById('area-head');
  const artHave=S.inv.includes(ar.art.id);
  hd.innerHTML=`
  <div style="display:flex;gap:14px;align-items:center">
  <div style="font-size:42px">${ar.icon}</div>
  <div>
- <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace('\n',' ')}</div>
+ <div style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);letter-spacing:.5px">${ar.name.replace(/\n/g,' ')}</div>
  <div style="font-family:var(--vt);font-size:21px;color:var(--muted);margin-top:4px;line-height:1.3">${ar.desc}</div>
  </div>
  </div>
  <div style="margin-top:12px;display:flex;align-items:center;gap:10px;padding-top:10px;border-top:2px solid var(--panel2)">
  <div style="font-size:26px">${ar.art.ic}</div>
- <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace('\n',' ')}</span></div>
+ <div style="font-family:var(--px);font-weight:400;font-size:12px;color:var(--muted);line-height:1.3">Artefakt oblasti:<br><span style="color:var(--gold);font-weight:700">${ar.art.nm.replace(/\n/g,' ')}</span></div>
  ${artHave?'<div style="margin-left:auto;font-family:var(--px);font-weight:700;font-size:13px;color:var(--gold)">✓ ZÍSKÁNO</div>':''}
  </div>`;
  const ml=document.getElementById('mission-list');
@@ -1951,7 +1951,7 @@ function checkMissionComplete(){
  S.inv.push(ar.art.id);
  Object.entries(ar.attrGain).forEach(([k,v])=>{if(S.attrs[k]!==undefined)S.attrs[k]+=v;});
  saveS();
- setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace('\n',' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
+ setTimeout(()=>showModal(ar.art.ic,'OBLAST SPLNĚNA!',`Získal jsi artefakt:\n${ar.art.nm.replace(/\n/g,' ')}!\n\n+${Object.entries(ar.attrGain).map(([k,v])=>v+' '+ATTR_META[k].ic).join(' ')}`),1700);
  }
  }
 }
@@ -1973,7 +1973,7 @@ function renderTrainPicker(){
   const sec=document.createElement('div');
   sec.className='panel';
   sec.style.marginTop='12px';
-  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace('\n',' ')}</div>`;
+  let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
    const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));

--- a/tests/rpg-antispam-robustness.test.cjs
+++ b/tests/rpg-antispam-robustness.test.cjs
@@ -23,7 +23,7 @@ const GRADES = [6,7,8,9];
 function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{let p=req.url.split('?')[0];if(p==='/')p='/index.html';
-   try{const b=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
+   try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const b=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));
 }
 let pass=0,fail=0;

--- a/tests/rpg-cloud.test.cjs
+++ b/tests/rpg-cloud.test.cjs
@@ -37,7 +37,8 @@ function startServer() {
   const srv = http.createServer((req, res) => {
     let p = req.url.split('?')[0];
     if (p === '/') p = '/index.html';
-    const full = path.join(ROOT, p);
+    const full = path.normalize(path.join(ROOT, p));
+    if (!full.startsWith(ROOT + path.sep)) { res.writeHead(403); res.end('forbidden'); return; }
     try {
       const buf = fs.readFileSync(full);
       const ext = p.split('.').pop();

--- a/tests/rpg-tasks-6-integration.test.cjs
+++ b/tests/rpg-tasks-6-integration.test.cjs
@@ -16,7 +16,7 @@ function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{
     let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
-    try{const buf=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
     catch{res.writeHead(404);res.end('nf');}
   });
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));

--- a/tests/rpg-tasks-7-integration.test.cjs
+++ b/tests/rpg-tasks-7-integration.test.cjs
@@ -16,7 +16,7 @@ function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{
     let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
-    try{const buf=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
     catch{res.writeHead(404);res.end('nf');}
   });
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));

--- a/tests/rpg-tasks-8-integration.test.cjs
+++ b/tests/rpg-tasks-8-integration.test.cjs
@@ -16,7 +16,7 @@ function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{
     let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
-    try{const buf=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
     catch{res.writeHead(404);res.end('nf');}
   });
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));

--- a/tests/rpg-tasks-integration.test.cjs
+++ b/tests/rpg-tasks-integration.test.cjs
@@ -16,7 +16,7 @@ function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{
     let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
-    try{const buf=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
     catch{res.writeHead(404);res.end('nf');}
   });
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));

--- a/tests/rpg-teacher.test.cjs
+++ b/tests/rpg-teacher.test.cjs
@@ -64,7 +64,7 @@ function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{
     let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
-    try{const buf=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
     catch{res.writeHead(404);res.end('nf');}
   });
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));

--- a/tests/rpg-train-6.test.cjs
+++ b/tests/rpg-train-6.test.cjs
@@ -15,7 +15,7 @@ const CHROMIUM = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
 function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{let p=req.url.split('?')[0];if(p==='/')p='/index.html';
-   try{const b=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
+   try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const b=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));
 }
 let pass=0,fail=0;

--- a/tests/rpg-train-7.test.cjs
+++ b/tests/rpg-train-7.test.cjs
@@ -15,7 +15,7 @@ const CHROMIUM = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
 function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{let p=req.url.split('?')[0];if(p==='/')p='/index.html';
-   try{const b=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
+   try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const b=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));
 }
 let pass=0,fail=0;

--- a/tests/rpg-train-8.test.cjs
+++ b/tests/rpg-train-8.test.cjs
@@ -15,7 +15,7 @@ const CHROMIUM = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
 function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{let p=req.url.split('?')[0];if(p==='/')p='/index.html';
-   try{const b=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
+   try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const b=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));
 }
 let pass=0,fail=0;

--- a/tests/rpg-train.test.cjs
+++ b/tests/rpg-train.test.cjs
@@ -15,7 +15,7 @@ const CHROMIUM = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
 function startServer(){
   const mime={html:'text/html',js:'application/javascript',css:'text/css',svg:'image/svg+xml',json:'application/json'};
   const srv=http.createServer((req,res)=>{let p=req.url.split('?')[0];if(p==='/')p='/index.html';
-   try{const b=fs.readFileSync(path.join(ROOT,p));res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
+   try{const fp=path.normalize(path.join(ROOT,p));if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}const b=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(b);}catch{res.writeHead(404);res.end('nf');}});
   return new Promise(r=>srv.listen(PORT,()=>r(srv)));
 }
 let pass=0,fail=0;


### PR DESCRIPTION
## Co to řeší

GitHub code scanning (CodeQL, default setup) nahlásilo **32 alertů**. Reprodukoval jsem je lokálně spuštěním přesně stejné CodeQL sady a všech 32 jsem odstranil. Po opravě je re-scan na těchto pravidlech **0**.

### 32 alertů ve třech kategoriích

**1. `js/incomplete-sanitization` — 20× (rpg-mat-6/7/8/9)**
`ar.name.replace('\n',' ')` nahrazovalo jen **první** výskyt nového řádku. Názvy oblastí/artefaktů můžou mít víc řádků → zbytek by zůstal. Oprava: globální regex `.replace(/\n/g,' ')`.

**2. `js/path-injection` — 11× (tests/*.cjs)**
Lokální statické servery v test-harnessech skládaly cestu přímo z `req.url` → teoretický path-traversal (`/../../etc/passwd`). Oprava: cesta se normalizuje a pokud uteče mimo `ROOT`, vrátí se **403** ještě před `readFileSync`. (Stejný guard, jaký už měl `rpg-diag-console.test.cjs`.)

**3. `js/xss-through-dom` — 1× (cesta_penez.html)**
Jméno žáka na certifikátu se vkládalo přes `innerHTML` → self-XSS. Oprava: uživatelská hodnota přes `textContent`, `innerHTML` zůstává jen pro důvěryhodný výchozí popisek (`<i>…</i>`).

### Ověření
- CodeQL re-scan (security-and-quality): `path-injection 0`, `incomplete-sanitization 0`, `xss-through-dom 0`.
- Testy zelené: rpg-cloud 24, rpg-teacher 50, rpg-train 12, rpg-tasks-integration 8, rpg-antispam-robustness 48 — servery dál servírují korektně.

> Pozn.: Zbývají jen *quality/recommendation* nálezy (`unused-local-variable`, `template-syntax-in-string-literal`…), které GitHub default code scanning nespouští — nejsou součástí těch 32. Můžu je uklidit zvlášť, pokud chceš.

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_