### PR TITLE
Phase 7: live battle backend + teacher unlock fix + grouped console + hero rename

### DIFF
--- a/projects/rpg-battle-9.js
+++ b/projects/rpg-battle-9.js
@@ -189,9 +189,10 @@
     return out;
   }
 
-  window.RPG_BATTLE_9 = {
-    game: 'RPG_MAT_9',
-    topicCount: GEN.length,
-    build,
-  };
+  const API = { game: 'RPG_MAT_9', topicCount: GEN.length, build };
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = API;
+  } else {
+    window.RPG_BATTLE_9 = API;
+  }
 })();

--- a/projects/rpg-battle-9.js
+++ b/projects/rpg-battle-9.js
@@ -1,0 +1,197 @@
+/* ════════════════════════════════════════════════════════════════════
+   RPG Matematika — ŽIVÝ SOUBOJ: banka otázek (9. ročník / NULL_BYTE)
+
+   SAMOSTATNÁ soutěžní sada (oddělená od učiva i tréninku). Rychlé MC
+   otázky (4 možnosti) v kyberpunk duchu, laděné na Kahoot-style tempo.
+
+   Deterministická: build(seed, count) vrátí pro STEJNÝ seed STEJNÝ
+   uspořádaný seznam otázek → všichni hráči v jedné místnosti dostanou
+   identické otázky ve stejném pořadí (host pošle jen seed přes cloud).
+
+   Každá otázka: { id, topic, text, choices:[4×string], correct:0..3, answer:string }
+   ════════════════════════════════════════════════════════════════════ */
+(function () {
+  'use strict';
+
+  // ── deterministický PRNG (mulberry32) ──
+  function rng(seed) {
+    let a = seed >>> 0;
+    return function () {
+      a |= 0; a = (a + 0x6D2B79F5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+  const ri = (r, lo, hi) => lo + Math.floor(r() * (hi - lo + 1));   // celé [lo,hi]
+  const pick = (r, arr) => arr[Math.floor(r() * arr.length)];
+  const S = v => String(v);
+
+  // ── generátory: každý vrací {topic, text, value, distractors:[3]} ──
+  // value i distractors jsou čísla nebo řetězce; assemble() z nich složí MC.
+  const GEN = [
+
+    // 1) lineární rovnice ax + b = c
+    function (r) {
+      const a = ri(r, 2, 9), x = ri(r, -6, 9), b = ri(r, -9, 9);
+      const c = a * x + b;
+      const sign = b >= 0 ? '+ ' + b : '- ' + (-b);
+      return { topic: 'rovnice', text: `Vyřeš: ${a}x ${sign} = ${c}`, value: x,
+               distractors: [x + 1, x - 1, x + 2] };
+    },
+
+    // 2) procenta z čísla
+    function (r) {
+      const p = pick(r, [5, 10, 15, 20, 25, 40, 50, 75]);
+      const base = ri(r, 2, 20) * 20;          // násobek 20 → hezké výsledky
+      const v = Math.round(base * p / 100);
+      return { topic: 'procenta', text: `Kolik je ${p} % z ${base}?`, value: v,
+               distractors: [v + base / 20, Math.round(base * p / 1000), v - 5] };
+    },
+
+    // 3) druhá / třetí mocnina
+    function (r) {
+      const a = ri(r, 2, 13);
+      if (r() < 0.5) {
+        const v = a * a;
+        return { topic: 'mocniny', text: `Vypočítej ${a}²`, value: v,
+                 distractors: [a * 2, v + a, v - a] };
+      }
+      const b = ri(r, 2, 7), v = b * b * b;
+      return { topic: 'mocniny', text: `Vypočítej ${b}³`, value: v,
+               distractors: [b * b, b * 3, v + b] };
+    },
+
+    // 4) druhá odmocnina (z úplného čtverce)
+    function (r) {
+      const a = ri(r, 2, 15), v = a * a;
+      return { topic: 'odmocniny', text: `Vypočítej √${v}`, value: a,
+               distractors: [a + 1, a - 1, Math.round(v / 2)] };
+    },
+
+    // 5) Pythagoras — přepona z celočíselné trojice
+    function (r) {
+      const trips = [[3, 4, 5], [6, 8, 10], [5, 12, 13], [8, 15, 17], [9, 12, 15], [7, 24, 25]];
+      const [p, q, c] = pick(r, trips);
+      return { topic: 'pythagoras', text: `Pravoúhlý trojúhelník má odvěsny ${p} a ${q}. Jak dlouhá je přepona?`,
+               value: c, distractors: [c + 1, c - 1, p + q] };
+    },
+
+    // 6) pořadí operací
+    function (r) {
+      const a = ri(r, 2, 9), b = ri(r, 2, 9), c = ri(r, 2, 9);
+      const v = a + b * c;
+      return { topic: 'operace', text: `Vypočítej: ${a} + ${b} · ${c}`, value: v,
+               distractors: [(a + b) * c, a + b + c, v + b] };
+    },
+
+    // 7) záporná čísla
+    function (r) {
+      const a = ri(r, -12, -2), b = ri(r, 2, 12);
+      const v = a - b;
+      return { topic: 'záporná', text: `Vypočítej: (${a}) − ${b}`, value: v,
+               distractors: [a + b, -(a - b), v + 2] };
+    },
+
+    // 8) hodnota lineární funkce
+    function (r) {
+      const a = ri(r, 2, 6), b = ri(r, -6, 6), k = ri(r, -4, 6);
+      const v = a * k + b;
+      const sign = b >= 0 ? '+ ' + b : '− ' + (-b);
+      return { topic: 'funkce', text: `f(x) = ${a}x ${sign}. Kolik je f(${k})?`, value: v,
+               distractors: [a + k + b, a * k - b, v + a] };
+    },
+
+    // 9) přímá úměrnost
+    function (r) {
+      const unit = ri(r, 2, 9), q1 = ri(r, 2, 6), q2 = q1 * ri(r, 2, 4);
+      const v = unit * q2;
+      return { topic: 'úměra', text: `${q1} ks stojí ${unit * q1} Kč. Kolik stojí ${q2} ks?`,
+               value: v, distractors: [unit * q1 + q2, v + unit, v - unit] };
+    },
+
+    // 10) sleva (procenta v praxi)
+    function (r) {
+      const price = ri(r, 3, 20) * 100, p = pick(r, [10, 20, 25, 50]);
+      const v = Math.round(price * (100 - p) / 100);
+      return { topic: 'sleva', text: `Zboží za ${price} Kč se zlevní o ${p} %. Nová cena?`,
+               value: v, distractors: [Math.round(price * p / 100), v - 100, price] };
+    },
+
+    // 11) aritmetická posloupnost — další člen
+    function (r) {
+      const start = ri(r, -5, 8), d = ri(r, 2, 7);
+      const seq = [start, start + d, start + 2 * d, start + 3 * d];
+      const v = start + 4 * d;
+      return { topic: 'posloupnost', text: `Jaké číslo následuje: ${seq.join(', ')}, …?`,
+               value: v, distractors: [v + d, v - d, start + 5 * d] };
+    },
+
+    // 12) zlomek → desetinné číslo (hezké)
+    function (r) {
+      const opts = [[1, 2, '0,5'], [1, 4, '0,25'], [3, 4, '0,75'], [1, 5, '0,2'],
+                    [2, 5, '0,4'], [1, 10, '0,1'], [3, 10, '0,3'], [1, 8, '0,125']];
+      const [num, den, dec] = pick(r, opts);
+      const wrong = opts.filter(o => o[2] !== dec).map(o => o[2]);
+      return { topic: 'zlomky', text: `Zapiš zlomek ${num}/${den} jako desetinné číslo`,
+               value: dec, distractors: [wrong[0], wrong[1], wrong[2]] };
+    },
+
+  ];
+
+  // ── složení jedné MC otázky (deterministické) ──
+  function assemble(r, raw, id) {
+    const correct = S(raw.value);
+    // unikátní distraktory ≠ správná odpověď
+    const seen = new Set([correct]);
+    const distractors = [];
+    for (const d of raw.distractors) {
+      let s = S(d);
+      if (seen.has(s) || s === 'NaN' || s === 'undefined' || s === '') continue;
+      seen.add(s); distractors.push(s);
+    }
+    // doplň, kdyby kolize vyhodily moc možností (číselné okolí)
+    let bump = 1;
+    const baseNum = Number(raw.value);
+    while (distractors.length < 3) {
+      const cand = Number.isFinite(baseNum) ? S(baseNum + bump) : S('?' + bump);
+      if (!seen.has(cand)) { seen.add(cand); distractors.push(cand); }
+      bump++;
+      if (bump > 50) { distractors.push(S('x' + distractors.length)); }   // pojistka
+    }
+    // poskládej 4 možnosti a deterministicky zamíchej
+    const choices = [correct, distractors[0], distractors[1], distractors[2]];
+    for (let i = choices.length - 1; i > 0; i--) {
+      const j = Math.floor(r() * (i + 1));
+      [choices[i], choices[j]] = [choices[j], choices[i]];
+    }
+    return { id, topic: raw.topic, text: raw.text, choices,
+             correct: choices.indexOf(correct), answer: correct };
+  }
+
+  // ── veřejné API ──
+  function build(seed, count) {
+    seed = (seed >>> 0) || 1;
+    count = Math.max(1, Math.min(40, count | 0 || 10));
+    const r = rng(seed);
+    const out = [];
+    let guard = 0;
+    while (out.length < count && guard < count * 20) {
+      guard++;
+      const gen = GEN[Math.floor(r() * GEN.length)];
+      const raw = gen(r);
+      const q = assemble(r, raw, out.length + 1);
+      // přeskoč otázku, kde se nepovedlo udělat platné 4 možnosti
+      if (q.correct < 0 || q.choices.length !== 4) continue;
+      if (new Set(q.choices).size !== 4) continue;
+      out.push(q);
+    }
+    return out;
+  }
+
+  window.RPG_BATTLE_9 = {
+    game: 'RPG_MAT_9',
+    topicCount: GEN.length,
+    build,
+  };
+})();

--- a/projects/rpg-cloud-setup-phase7.sql
+++ b/projects/rpg-cloud-setup-phase7.sql
@@ -1,0 +1,272 @@
+-- ═══════════════════════════════════════════════════════════════════
+-- RPG Matematika — Fáze 7: ŽIVÝ SOUBOJ (Kahoot-style, pilot 9. ročník)
+-- Spustit po fázi 2 (nutné: funkce my_role()).
+--
+-- Model:
+--   • Hostit může KDOKOLI (žák i učitel) — vytvoří místnost, dostane KÓD,
+--     pozve spolužáky kódem nebo e-mailem.
+--   • UČITEL má „god mode": vidí VŠECHNY běžící souboje a může kterýkoli
+--     pauznout / spustit / zastavit / ukončit (list_active_battles +
+--     _battle_can_control vrací true pro teacher/superadmin).
+--
+-- Bezpečnost: na tabulkách je RLS BEZ permisivních politik → přímý
+-- přístup je zakázán. VŠECHNO jde přes SECURITY DEFINER funkce, které
+-- si autorizaci hlídají samy (kdo smí řídit, kdo smí číst). Otázky se
+-- negenerují tady — klient je deterministicky vyrobí z q_seed
+-- (projects/rpg-battle-9.js), takže všichni hráči dostanou stejnou sadu.
+-- ═══════════════════════════════════════════════════════════════════
+
+-- ── Tabulky ──────────────────────────────────────────────────────────
+create table if not exists battles (
+  id            uuid primary key default gen_random_uuid(),
+  code          text unique not null,
+  host_id       uuid references auth.users not null,
+  host_name     text,
+  game          text not null default 'RPG_MAT_9',
+  status        text not null default 'lobby',   -- lobby|active|paused|finished
+  q_index       int  not null default -1,        -- -1 = ještě nezačalo
+  q_count       int  not null default 10,
+  q_seed        bigint not null,                 -- klient z něj vyrobí otázky
+  q_started_at  timestamptz,
+  controlled_by uuid,                            -- učitel, co převzal řízení
+  created_at    timestamptz default now(),
+  updated_at    timestamptz default now()
+);
+
+create table if not exists battle_players (
+  id            uuid primary key default gen_random_uuid(),
+  battle_id     uuid references battles on delete cascade not null,
+  user_id       uuid references auth.users not null,
+  display_name  text,
+  score         int  not null default 0,
+  correct_count int  not null default 0,
+  last_qi       int  not null default -1,        -- poslední zodpovězená otázka
+  joined_at     timestamptz default now(),
+  last_seen     timestamptz default now(),
+  unique (battle_id, user_id)
+);
+
+create table if not exists battle_invites (
+  id         bigserial primary key,
+  battle_id  uuid references battles on delete cascade not null,
+  email      text not null,
+  created_at timestamptz default now(),
+  unique (battle_id, email)
+);
+
+create index if not exists battles_code   on battles(code);
+create index if not exists battles_status on battles(status);
+create index if not exists bplayers_battle on battle_players(battle_id);
+create index if not exists binvites_email  on battle_invites(lower(email));
+
+-- ── RLS: deny-all (žádné permisivní politiky) ────────────────────────
+alter table battles        enable row level security;
+alter table battle_players enable row level security;
+alter table battle_invites enable row level security;
+-- (úmyslně bez CREATE POLICY → přímý SELECT/INSERT/UPDATE/DELETE je zakázán;
+--  veškerý přístup teče přes SECURITY DEFINER funkce níže)
+
+-- ── Generátor join-kódu (bez matoucích znaků 0/O/1/I) ────────────────
+create or replace function public._battle_gen_code()
+returns text language plpgsql security definer set search_path = public as $$
+declare chars text := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; c text; i int;
+begin
+  loop
+    c := '';
+    for i in 1..4 loop
+      c := c || substr(chars, 1 + floor(random() * length(chars))::int, 1);
+    end loop;
+    exit when not exists (select 1 from battles where code = c and status <> 'finished');
+  end loop;
+  return c;
+end; $$;
+
+-- ── Autorizační helper: smí caller řídit tuto bitvu? (host nebo staff) ─
+create or replace function public._battle_can_control(p_battle uuid)
+returns boolean language sql security definer set search_path = public stable as $$
+  select exists (select 1 from battles where id = p_battle and host_id = auth.uid())
+      or (select my_role()) in ('teacher', 'superadmin');
+$$;
+
+-- ── Vytvoření místnosti (host = libovolný přihlášený) ────────────────
+create or replace function public.create_battle(p_game text, p_qcount int, p_host_name text)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles;
+begin
+  if auth.uid() is null then raise exception 'not authenticated'; end if;
+  insert into battles (code, host_id, host_name, game, q_count, q_seed)
+  values (_battle_gen_code(), auth.uid(), coalesce(nullif(p_host_name, ''), 'Host'),
+          coalesce(nullif(p_game, ''), 'RPG_MAT_9'),
+          greatest(3, least(40, coalesce(p_qcount, 10))),
+          (floor(random() * 2000000000))::bigint)
+  returning * into b;
+  insert into battle_players (battle_id, user_id, display_name)
+  values (b.id, auth.uid(), coalesce(nullif(p_host_name, ''), 'Host'));
+  return b;
+end; $$;
+
+-- ── Připojení podle kódu ─────────────────────────────────────────────
+create or replace function public.join_battle(p_code text, p_name text)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles;
+begin
+  if auth.uid() is null then raise exception 'not authenticated'; end if;
+  select * into b from battles
+   where upper(code) = upper(trim(p_code)) and status <> 'finished'
+   order by created_at desc limit 1;
+  if b.id is null then raise exception 'battle not found'; end if;
+  insert into battle_players (battle_id, user_id, display_name)
+  values (b.id, auth.uid(), coalesce(nullif(p_name, ''), 'Hráč'))
+  on conflict (battle_id, user_id)
+    do update set display_name = excluded.display_name, last_seen = now();
+  return b;
+end; $$;
+
+-- ── Posun na další otázku (host/staff) ───────────────────────────────
+create or replace function public.advance_battle(p_battle uuid, p_qi int)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles;
+begin
+  if not _battle_can_control(p_battle) then raise exception 'forbidden'; end if;
+  update battles
+     set q_index = p_qi, q_started_at = now(), updated_at = now(),
+         status  = case when p_qi >= q_count then 'finished' else 'active' end
+   where id = p_battle returning * into b;
+  return b;
+end; $$;
+
+-- ── Změna stavu (lobby/active/paused/finished) — host/staff ──────────
+create or replace function public.set_battle_status(p_battle uuid, p_status text)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles;
+begin
+  if not _battle_can_control(p_battle) then raise exception 'forbidden'; end if;
+  if p_status not in ('lobby', 'active', 'paused', 'finished') then
+    raise exception 'bad status'; end if;
+  update battles
+     set status = p_status, updated_at = now(),
+         controlled_by = case
+           when (select my_role()) in ('teacher', 'superadmin') and host_id <> auth.uid()
+           then auth.uid() else controlled_by end
+   where id = p_battle returning * into b;
+  return b;
+end; $$;
+
+-- ── Odeslání odpovědi (jen na aktuální otázku, bez dvojího skórování) ─
+create or replace function public.submit_battle_answer(
+  p_battle uuid, p_qi int, p_correct boolean, p_points int)
+returns void language plpgsql security definer set search_path = public as $$
+declare b battles; pts int;
+begin
+  select * into b from battles where id = p_battle;
+  if b.id is null then return; end if;
+  if b.status <> 'active' or b.q_index <> p_qi then return; end if;   -- jen živá otázka
+  pts := greatest(0, least(1500, coalesce(p_points, 0)));             -- strop proti podvodu
+  update battle_players
+     set score         = score + case when p_correct then pts else 0 end,
+         correct_count = correct_count + case when p_correct then 1 else 0 end,
+         last_qi       = p_qi,
+         last_seen     = now()
+   where battle_id = p_battle and user_id = auth.uid() and last_qi < p_qi;
+end; $$;
+
+-- ── Snapshot stavu pro polling (člen/host/staff) ─────────────────────
+create or replace function public.battle_state(p_battle uuid)
+returns json language plpgsql security definer set search_path = public as $$
+declare b battles; allowed boolean;
+begin
+  select * into b from battles where id = p_battle;
+  if b.id is null then return null; end if;
+  allowed := b.host_id = auth.uid()
+          or (select my_role()) in ('teacher', 'superadmin')
+          or exists (select 1 from battle_players where battle_id = p_battle and user_id = auth.uid());
+  if not allowed then raise exception 'forbidden'; end if;
+  update battle_players set last_seen = now()
+   where battle_id = p_battle and user_id = auth.uid();
+  return json_build_object(
+    'battle',  row_to_json(b),
+    'players', coalesce((
+       select json_agg(row_to_json(p))
+       from (select user_id, display_name, score, correct_count, last_qi, last_seen
+             from battle_players where battle_id = p_battle
+             order by score desc, display_name) p), '[]'::json),
+    'me', auth.uid()
+  );
+end; $$;
+
+-- ── Učitelský přehled: všechny neukončené bitvy + počty hráčů ────────
+create or replace function public.list_active_battles()
+returns table (id uuid, code text, host_name text, game text, status text,
+               q_index int, q_count int, players int, updated_at timestamptz)
+language sql security definer set search_path = public stable as $$
+  select b.id, b.code, b.host_name, b.game, b.status, b.q_index, b.q_count,
+         (select count(*)::int from battle_players p where p.battle_id = b.id),
+         b.updated_at
+  from battles b
+  where (select my_role()) in ('teacher', 'superadmin')
+    and b.status <> 'finished'
+  order by b.updated_at desc;
+$$;
+
+-- ── Pozvánka e-mailem (host/staff) ───────────────────────────────────
+create or replace function public.invite_battle_email(p_battle uuid, p_email text)
+returns void language plpgsql security definer set search_path = public as $$
+begin
+  if not _battle_can_control(p_battle) then raise exception 'forbidden'; end if;
+  insert into battle_invites (battle_id, email) values (p_battle, lower(trim(p_email)))
+  on conflict (battle_id, email) do nothing;
+end; $$;
+
+-- ── Moje pozvánky (podle e-mailu přihlášeného) ───────────────────────
+create or replace function public.my_battle_invites()
+returns table (id uuid, code text, host_name text, game text, status text)
+language sql security definer set search_path = public stable as $$
+  select b.id, b.code, b.host_name, b.game, b.status
+  from battles b join battle_invites i on i.battle_id = b.id
+  where lower(i.email) = lower((select email from auth.users where id = auth.uid()))
+    and b.status <> 'finished'
+  order by b.created_at desc;
+$$;
+
+-- ── Úklid starých bitev (volitelné; klidně i přes pg_cron) ────────────
+create or replace function public.cleanup_battles()
+returns int language plpgsql security definer set search_path = public as $$
+declare n int;
+begin
+  if (select my_role()) not in ('teacher', 'superadmin') then raise exception 'forbidden'; end if;
+  with del as (delete from battles where created_at < now() - interval '12 hours' returning 1)
+  select count(*) into n from del;
+  return n;
+end; $$;
+
+-- ── Grants: jen přihlášení smí volat funkce (RLS uvnitř hlídá rozsah) ─
+grant execute on function public.create_battle(text, int, text)        to authenticated;
+grant execute on function public.join_battle(text, text)               to authenticated;
+grant execute on function public.advance_battle(uuid, int)             to authenticated;
+grant execute on function public.set_battle_status(uuid, text)         to authenticated;
+grant execute on function public.submit_battle_answer(uuid, int, boolean, int) to authenticated;
+grant execute on function public.battle_state(uuid)                    to authenticated;
+grant execute on function public.list_active_battles()                 to authenticated;
+grant execute on function public.invite_battle_email(uuid, text)       to authenticated;
+grant execute on function public.my_battle_invites()                   to authenticated;
+grant execute on function public.cleanup_battles()                     to authenticated;
+
+-- ── Realtime (volitelné zrychlení; klient stejně i polluje) ──────────
+do $$
+begin
+  if not exists (select 1 from pg_publication_tables
+                 where pubname = 'supabase_realtime' and tablename = 'battles') then
+    alter publication supabase_realtime add table battles;
+  end if;
+  if not exists (select 1 from pg_publication_tables
+                 where pubname = 'supabase_realtime' and tablename = 'battle_players') then
+    alter publication supabase_realtime add table battle_players;
+  end if;
+exception when others then null;  -- když publikace neexistuje, nevadí (klient pollu je)
+end $$;
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Hotovo. Klient (rpg-cloud.js) volá funkce přes RPC a pollu je
+-- battle_state() každých ~1,2 s. Bez přihlášení/cloudu se živý souboj
+-- prostě nenabídne (graceful). Otázky: projects/rpg-battle-9.js.
+-- ═══════════════════════════════════════════════════════════════════

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -731,11 +731,16 @@ window.RPGCloud = (function () {
             ...(Array.isArray(localNow && localNow.teacherUnlocked) ? localNow.teacherUnlocked : [])
           ]);
           if (tuSet.size === (Array.isArray(localNow && localNow.teacherUnlocked) ? localNow.teacherUnlocked.length : 0)) return;
-          // Nové učitelské odemčení → aktualizuj lokál + notifikuj hru
+          // Nové učitelské odemčení → aktualizuj in-memory stav + localStorage + překresli mapu
           const merged = [...tuSet];
           if (localNow) {
             localNow.teacherUnlocked = merged;
             localStorage.setItem(saveKey, JSON.stringify(localNow));
+            // Aktualizuj i globální S (in-memory) aby mapa ihned reagovala
+            if (typeof window.S !== 'undefined' && window.S) {
+              window.S.teacherUnlocked = merged;
+              if (typeof window.saveS === 'function') window.saveS();
+            }
             if (typeof window.renderMap === 'function') { try { window.renderMap(); } catch (e) {} }
           }
         } catch {}

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -487,8 +487,8 @@ window.RPGCloud = (function () {
         '<span style="min-width:26px;text-align:center">' + medal(i) + '</span>' +
         '<span style="flex:1;color:' + (r.is_me ? 'var(--gold,#19e6e6)' : 'var(--text,#e8eaf6)') + ';font-weight:700;' +
         'overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(r.display_name) + (r.is_me ? ' (ty)' : '') + '</span>' +
-        '<span style="color:var(--muted,#8895b5);font-size:11px">LV ' + (r.lvl || 1) + '</span>' +
-        '<span style="color:var(--blue,#5dc8f0);min-width:62px;text-align:right">' + (r.xp || 0) + ' XP</span>' +
+        '<span style="color:var(--muted,#8895b5);font-size:11px">LV ' + ((r.lvl || 1) | 0) + '</span>' +
+        '<span style="color:var(--blue,#5dc8f0);min-width:62px;text-align:right">' + ((r.xp || 0) | 0) + ' XP</span>' +
         '</div>'
       ).join('');
     el.style.display = 'block';

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -467,22 +467,31 @@ window.RPGCloud = (function () {
   }
 
   // centrální vykreslení žebříčku do prvku v mapě (žádné per-game edity).
-  // Graceful: bez přihlášení / bez spolužáků / chyba ⇒ prvek se skryje.
+  // Bez cloudu/preview → skryje. Bez přihlášení → teaser. Přihlášen → reálná data.
   async function renderLeaderboardInto(elId, game) {
     const el = document.getElementById(elId);
     if (!el) return;
-    if (!client || !user || previewActive) { el.style.display = 'none'; return; }
+    if (!client || previewActive) { el.style.display = 'none'; return; }
+    const px = 'font-family:var(--px,monospace)';
+    const header = '<div style="' + px + ';font-weight:700;font-size:12px;color:var(--gold,#19e6e6);margin-bottom:8px;letter-spacing:1px">— 🏆 ŽEBŘÍČEK TŘÍDY —</div>';
+    if (!user) {
+      const ghost = ['🥇 ████████  LV ?  ??? XP', '🥈 ██████  LV ?  ??? XP', '🥉 ███████  LV ?  ??? XP'];
+      el.style.display = 'block';
+      el.innerHTML = header +
+        ghost.map(t => '<div style="' + px + ';font-size:13px;padding:5px 8px;border-radius:5px;background:rgba(255,255,255,.03);margin:3px 0;filter:blur(3.5px);user-select:none;color:var(--muted,#8895b5)">' + t + '</div>').join('') +
+        '<div style="text-align:center;margin-top:10px;' + px + ';font-size:11px;color:var(--muted,#8895b5)">Přihlas se a zjisti pořadí ve třídě<br>' +
+        '<button onclick="var b=document.getElementById(\'cloud-btn\');if(b)b.click();" style="margin-top:6px;cursor:pointer;' + px + ';font-weight:700;font-size:11px;padding:5px 10px;border-radius:4px;border:1px solid var(--blue,#5dc8f0);background:transparent;color:var(--blue,#5dc8f0)">🔑 Přihlásit</button></div>';
+      return;
+    }
     let rows = [];
     try { rows = await leaderboard(game); } catch (e) { el.style.display = 'none'; return; }
     // sám hráč bez spolužáků = jen 1 řádek (on sám) → nemá smysl ukazovat
     if (!rows || rows.length < 2) { el.style.display = 'none'; return; }
     const medal = i => (i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : (i + 1) + '.');
-    el.innerHTML =
-      '<div style="font-family:var(--px,monospace);font-weight:700;font-size:12px;color:var(--gold,#19e6e6);' +
-      'margin-bottom:8px;letter-spacing:1px">— 🏆 ŽEBŘÍČEK TŘÍDY —</div>' +
+    el.innerHTML = header +
       rows.map((r, i) =>
         '<div style="display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:5px;' +
-        'font-family:var(--px,monospace);font-size:13px;margin:3px 0;' +
+        px + ';font-size:13px;margin:3px 0;' +
         (r.is_me ? 'background:rgba(25,230,230,.14);border:1px solid var(--gold,#19e6e6)' : 'background:rgba(255,255,255,.03)') + '">' +
         '<span style="min-width:26px;text-align:center">' + medal(i) + '</span>' +
         '<span style="flex:1;color:' + (r.is_me ? 'var(--gold,#19e6e6)' : 'var(--text,#e8eaf6)') + ';font-weight:700;' +

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -645,17 +645,59 @@ window.RPGCloud = (function () {
           try { local = JSON.parse(localStorage.getItem(saveKey)); } catch {}
           const localDone = local && local.done ? Object.keys(local.done).length : 0;
           const cloudDone = cloud && cloud.done ? Object.keys(cloud.done).length : 0;
+
+          // Vždy sluč teacherUnlocked z cloudu i lokálu — unlock nesmí být nikdy ztracen
+          const tuSet = new Set([
+            ...(Array.isArray(cloud && cloud.teacherUnlocked) ? cloud.teacherUnlocked : []),
+            ...(Array.isArray(local && local.teacherUnlocked) ? local.teacherUnlocked : [])
+          ]);
+          const mergedTU = [...tuSet];
+
+          let chosen = null;
           if (cloud && cloudDone >= localDone) {
             // cloud je stejně pokročilý nebo lepší → přepiš lokál
+            if (mergedTU.length) cloud.teacherUnlocked = mergedTU;
             localStorage.setItem(saveKey, JSON.stringify(cloud));
-            const cp = document.getElementById('continue-panel');
-            if (cp) cp.style.display = 'block';
+            chosen = cloud;
             if (typeof onLoaded === 'function') onLoaded(cloud);
           } else if (local && localDone > 0) {
-            // lokál je pokročilejší → nahraj ho do cloudu
+            // lokál je pokročilejší → nahraj ho do cloudu (s mergnutými unlocks)
+            if (mergedTU.length) local.teacherUnlocked = mergedTU;
+            localStorage.setItem(saveKey, JSON.stringify(local));
             push(saveKey, local);
-            const cp = document.getElementById('continue-panel');
-            if (cp) cp.style.display = 'block';
+            chosen = local;
+          }
+
+          // Předvyplnit #ni jménem z libovolného existujícího save (cross-game)
+          const ni = document.getElementById('ni');
+          if (ni && !ni.value) {
+            const existingName = chosen && chosen.name ? chosen.name
+              : ['RPG_MAT_6','RPG_MAT_7','RPG_MAT_8','RPG_MAT_9']
+                  .map(k=>{ try{ const s=JSON.parse(localStorage.getItem(k)); return s&&s.name?s.name:null; }catch{return null;} })
+                  .find(n=>n && n!=='HRDINA');
+            if (existingName) ni.value = existingName;
+          }
+
+          // Doménový žák (@husovaliberec.cz): přeskočit intro obrazovku → rovnou do hry
+          const isDomain = (u.email || '').toLowerCase().endsWith('@husovaliberec.cz');
+          if (isDomain) {
+            // Předvyplnit z Google jména, pokud ještě nic není
+            if (ni && !ni.value) {
+              const gFirst = ((u.user_metadata && u.user_metadata.full_name) || '').split(' ')[0];
+              if (gFirst) ni.value = gFirst.toUpperCase().slice(0, 14);
+            }
+            if (chosen && typeof window.continueGame === 'function') {
+              window.continueGame();
+            } else if (!chosen && typeof window.startGame === 'function') {
+              // První přihlášení bez jakéhokoliv save — automaticky spustit
+              window.startGame();
+            }
+          } else {
+            // Nespravovaný účet: ukázat tlačítko Pokračovat
+            if (chosen) {
+              const cp = document.getElementById('continue-panel');
+              if (cp) cp.style.display = 'block';
+            }
           }
         }
       });

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -383,6 +383,89 @@ window.RPGCloud = (function () {
       return data || [];
     } catch (e) { console.warn('[RPGCloud] listExplanations selhal:', e); return []; }
   }
+
+  // ════════════ Fáze 7 — živý souboj (Kahoot-style) ════════════
+  // Tenké wrappery nad SECURITY DEFINER RPC funkcemi (viz phase7.sql).
+  // Vše graceful: bez clienta/přihlášení vrací null/[]/false.
+  async function createBattle(game, qcount, hostName) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('create_battle',
+        { p_game: game, p_qcount: qcount, p_host_name: hostName });
+      if (error) throw error; return data;
+    } catch (e) { console.warn('[RPGCloud] createBattle:', e); return null; }
+  }
+  async function joinBattle(code, name) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('join_battle', { p_code: code, p_name: name });
+      if (error) throw error; return data;
+    } catch (e) { console.warn('[RPGCloud] joinBattle:', e); return null; }
+  }
+  async function battleState(battleId) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('battle_state', { p_battle: battleId });
+      if (error) throw error; return data;
+    } catch (e) { return null; }
+  }
+  async function submitBattleAnswer(battleId, qi, correct, points) {
+    if (!client || !user) return false;
+    try {
+      const { error } = await client.rpc('submit_battle_answer',
+        { p_battle: battleId, p_qi: qi, p_correct: !!correct, p_points: Math.round(points) || 0 });
+      return !error;
+    } catch (e) { return false; }
+  }
+  async function advanceBattle(battleId, qi) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('advance_battle', { p_battle: battleId, p_qi: qi });
+      if (error) throw error; return data;
+    } catch (e) { console.warn('[RPGCloud] advanceBattle:', e); return null; }
+  }
+  async function setBattleStatus(battleId, status) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('set_battle_status', { p_battle: battleId, p_status: status });
+      if (error) throw error; return data;
+    } catch (e) { console.warn('[RPGCloud] setBattleStatus:', e); return null; }
+  }
+  async function listActiveBattles() {
+    if (!client || !user) return [];
+    try {
+      const { data, error } = await client.rpc('list_active_battles');
+      if (error) throw error; return data || [];
+    } catch (e) { return []; }
+  }
+  async function inviteBattleEmail(battleId, email) {
+    if (!client || !user) return false;
+    try {
+      const { error } = await client.rpc('invite_battle_email', { p_battle: battleId, p_email: email });
+      return !error;
+    } catch (e) { return false; }
+  }
+  async function myBattleInvites() {
+    if (!client || !user) return [];
+    try {
+      const { data, error } = await client.rpc('my_battle_invites');
+      if (error) throw error; return data || [];
+    } catch (e) { return []; }
+  }
+  /* Polling: zavolá cb(state) hned a pak každých intervalMs (default 1200).
+     Vrací stop() funkci. Klient tím drží živý stav bez websocketů. */
+  function pollBattle(battleId, cb, intervalMs) {
+    let stopped = false, timer = null;
+    async function tick() {
+      if (stopped) return;
+      const st = await battleState(battleId);
+      if (!stopped && st && typeof cb === 'function') { try { cb(st); } catch (e) {} }
+      if (!stopped) timer = setTimeout(tick, intervalMs || 1200);
+    }
+    tick();
+    return () => { stopped = true; if (timer) clearTimeout(timer); };
+  }
+
   // centrální vykreslení žebříčku do prvku v mapě (žádné per-game edity).
   // Graceful: bez přihlášení / bez spolužáků / chyba ⇒ prvek se skryje.
   async function renderLeaderboardInto(elId, game) {
@@ -621,5 +704,9 @@ window.RPGCloud = (function () {
            // Fáze 4 — žebříček třídy
            leaderboard, renderLeaderboardInto,
            // Fáze 6 — vysvětlení postupu
-           saveExplanation, listExplanations };
+           saveExplanation, listExplanations,
+           // Fáze 7 — živý souboj
+           createBattle, joinBattle, battleState, submitBattleAnswer,
+           advanceBattle, setBattleStatus, listActiveBattles,
+           inviteBattleEmail, myBattleInvites, pollBattle };
 })();

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -696,7 +696,12 @@ window.RPGCloud = (function () {
             // Nespravovaný účet: ukázat tlačítko Pokračovat
             if (chosen) {
               const cp = document.getElementById('continue-panel');
-              if (cp) cp.style.display = 'block';
+              if (cp) {
+                cp.style.display = 'block';
+                // Přihlášení přes Google = save v cloudu → nelze začít znovu bez ztráty dat
+                const rb = document.getElementById('go-fresh-btn');
+                if (rb) rb.style.display = 'none';
+              }
             }
           }
         }

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -680,13 +680,22 @@ window.RPGCloud = (function () {
 
           // Doménový žák (@husovaliberec.cz): přeskočit intro obrazovku → rovnou do hry
           const isDomain = (u.email || '').toLowerCase().endsWith('@husovaliberec.cz');
+          // Zjistit, zda hráč už hraje (není na intro obrazovce) — pokud ano, nepřerušovat
+          const introVisible = (()=>{ const s=document.getElementById('s-intro'); return s&&s.classList.contains('active'); })();
           if (isDomain) {
             // Předvyplnit z Google jména, pokud ještě nic není
             if (ni && !ni.value) {
               const gFirst = ((u.user_metadata && u.user_metadata.full_name) || '').split(' ')[0];
               if (gFirst) ni.value = gFirst.toUpperCase().slice(0, 14);
             }
-            if (chosen && typeof window.continueGame === 'function') {
+            if (!introVisible) {
+              // Hráč je ve hře — pouze slouč teacherUnlocked, nerušit in-memory stav
+              if (chosen && mergedTU.length && typeof window.S !== 'undefined') {
+                window.S.teacherUnlocked = mergedTU;
+                if (typeof window.saveS === 'function') window.saveS();
+                if (typeof window.renderMap === 'function') { try { window.renderMap(); } catch (e) {} }
+              }
+            } else if (chosen && typeof window.continueGame === 'function') {
               window.continueGame();
             } else if (!chosen && typeof window.startGame === 'function') {
               // První přihlášení bez jakéhokoliv save — automaticky spustit

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -595,7 +595,7 @@ window.RPGCloud = (function () {
         '<div style="background:#1f2740;border-radius:8px;padding:8px 10px;margin:6px 0">' +
         '<div style="font-size:14px;line-height:1.5">' + esc(n.body) + '</div>' +
         '<div style="font-size:11px;color:#8896a6;margin-top:5px">' + esc(n.author_name || 'učitel') + ' · ' +
-        new Date(n.created_at).toLocaleDateString('cs-CZ') + '</div></div>'
+        esc(new Date(n.created_at).toLocaleDateString('cs-CZ')) + '</div></div>'
       ).join('');
   }
 

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -706,11 +706,29 @@ window.RPGCloud = (function () {
           }
         }
       });
-      // Heartbeat: udržuje updated_at čerstvé → indikátor „online" v konzoli
-      setInterval(() => {
+      // Heartbeat: udržuje updated_at čerstvé + kontroluje teacherUnlocked ze serveru
+      setInterval(async () => {
         try {
+          if (!client || !currentUser()) return;
           const s = JSON.parse(localStorage.getItem(saveKey));
-          if (s && client && currentUser()) push(saveKey, s);
+          if (!s) return;
+          push(saveKey, s);
+          // Stáhni aktuální save ze serveru a sluč teacherUnlocked
+          const cloud = await pull(saveKey);
+          if (!cloud) return;
+          const localNow = (() => { try { return JSON.parse(localStorage.getItem(saveKey)); } catch { return null; } })();
+          const tuSet = new Set([
+            ...(Array.isArray(cloud.teacherUnlocked) ? cloud.teacherUnlocked : []),
+            ...(Array.isArray(localNow && localNow.teacherUnlocked) ? localNow.teacherUnlocked : [])
+          ]);
+          if (tuSet.size === (Array.isArray(localNow && localNow.teacherUnlocked) ? localNow.teacherUnlocked.length : 0)) return;
+          // Nové učitelské odemčení → aktualizuj lokál + notifikuj hru
+          const merged = [...tuSet];
+          if (localNow) {
+            localNow.teacherUnlocked = merged;
+            localStorage.setItem(saveKey, JSON.stringify(localNow));
+            if (typeof window.renderMap === 'function') { try { window.renderMap(); } catch (e) {} }
+          }
         } catch {}
       }, 120000);
       init().then(paint);

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -2106,7 +2106,7 @@ function renderCrossGames(){
   html+='<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--line)'+(cur?';font-weight:700':'')+'">' +
    '<span style="font-size:16px">'+g.ic+'</span>'+
    '<span style="flex:1;font-size:12px;color:'+(cur?'#fff':'var(--muted)')+'">'+g.nm+(cur?' ◀':'')+'</span>'+
-   (s?'<span style="font-size:12px;color:var(--gold)">LV '+(s.level||1)+' · '+(s.xp||0)+' XP</span>':'<span style="font-size:11px;color:var(--muted)">—</span>')+
+   (s?'<span style="font-size:12px;color:var(--gold)">LV '+((s.level||1)|0)+' · '+((s.xp||0)|0)+' XP</span>':'<span style="font-size:11px;color:var(--muted)">—</span>')+
   '</div>';
  });
  html+='<a href="rpg-matematika.html" style="display:block;margin-top:10px;color:var(--blue);font-size:12px;font-family:var(--px);text-align:center">🌐 Velitelské centrum – přehled a obchod pro všechny hry</a>';

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -2203,10 +2203,10 @@ function renderTrainPicker(){
   let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
-   const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));
+   const pct=Math.min(100,Math.round((ms.score|0)/MASTERY_GOAL*100))|0;
    html+=`<button class="ms-item avail" style="width:100%;text-align:left;border:none;cursor:pointer" onclick="startTrain('${m.id}')">
      <div style="flex:1"><div class="ms-name">${ms.mastered?'🏅 ':''}${m.name}</div>
-     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':ms.score+' / '+MASTERY_GOAL}</div>
+     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':(ms.score|0)+' / '+MASTERY_GOAL}</div>
      <div class="bar-out bar-xp" style="margin-top:6px;height:6px"><div class="bar-in" style="width:${pct}%"></div></div></div>
      <div style="font-size:16px;margin-left:8px">${ms.mastered?'🏅':'🎯'}</div></button>`;
   });

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -2120,7 +2120,7 @@ function renderProfile(){
  const el=document.getElementById('pr-attrs');
  el.innerHTML='';
  Object.entries(ATTR_META).forEach(([k,m])=>{
- const v=S.attrs[k]||0,pct=Math.min(100,v);
+ const v=(S.attrs[k]||0)|0,pct=Math.min(100,v)|0;
  const row=document.createElement('div');
  row.className='attr-row';
  row.innerHTML=`<div class="attr-ic">${m.ic}</div><div class="attr-nm">${m.nm}</div>

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -690,6 +690,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <button class="btn sm" onclick="importPrompt()">NAČÍST KÓD</button>
  </div>
  </div>
+ <div class="panel" id="pr-allgames"></div>
 </div>
 </div>
 
@@ -2090,6 +2091,27 @@ function checkMissionComplete(){
 // ══════════════════════════════════════════
 // PROFILE
 // ══════════════════════════════════════════
+const ALL_GAMES=[
+ {key:'RPG_MAT_6',ic:'🚀',nm:'6. ročník – Vesmírná expedice'},
+ {key:'RPG_MAT_7',ic:'⛏️',nm:'7. ročník – Ztracený chrám'},
+ {key:'RPG_MAT_8',ic:'🎓',nm:'8. ročník – Mat. akademie'},
+ {key:'RPG_MAT_9',ic:'💻',nm:'9. ročník – NULL_BYTE'},
+];
+function renderCrossGames(){
+ const el=document.getElementById('pr-allgames');if(!el)return;
+ let html='<div style="font-family:var(--px);font-weight:700;font-size:12px;color:var(--muted);margin-bottom:10px;letter-spacing:1px">— PŘEHLED VŠECH HER —</div>';
+ ALL_GAMES.forEach(g=>{
+  let s=null;try{s=JSON.parse(localStorage.getItem(g.key));}catch{}
+  const cur=g.key===SAVE_KEY;
+  html+='<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--line)'+(cur?';font-weight:700':'')+'">' +
+   '<span style="font-size:16px">'+g.ic+'</span>'+
+   '<span style="flex:1;font-size:12px;color:'+(cur?'#fff':'var(--muted)')+'">'+g.nm+(cur?' ◀':'')+'</span>'+
+   (s?'<span style="font-size:12px;color:var(--gold)">LV '+(s.level||1)+' · '+(s.xp||0)+' XP</span>':'<span style="font-size:11px;color:var(--muted)">—</span>')+
+  '</div>';
+ });
+ html+='<a href="rpg-matematika.html" style="display:block;margin-top:10px;color:var(--blue);font-size:12px;font-family:var(--px);text-align:center">🌐 Velitelské centrum – přehled a obchod pro všechny hry</a>';
+ el.innerHTML=html;
+}
 function renderProfile(){
  calcLevel();
  document.getElementById('pr-name').textContent=S.name;
@@ -2131,6 +2153,7 @@ function renderProfile(){
  document.getElementById('pr-ach-t').textContent=ACH.length;
  }
  const rm=document.getElementById('pr-rm');if(rm)rm.checked=!!(S.settings&&S.settings.reducedMotion);
+ renderCrossGames();
 }
 
 function exportCode(){

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -457,7 +457,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="continue-panel" class="panel b" style="display:none">
  <div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--blue);margin-bottom:10px">POKRAČOVAT VE HŘE</div>
  <button class="btn b full" style="margin-bottom:8px" onclick="continueGame()">▶ NAČÍST ULOŽENOU HRU</button>
- <button class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
+ <button id="go-fresh-btn" class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
  </div>
  <div style="text-align:center;font-family:var(--px);font-weight:400;font-size:13px;color:var(--muted);margin-top:8px">
  STISKNI ENTER PRO START <span class="blink">▌</span>

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -1175,16 +1175,15 @@ const SHOP_ITEMS=[
 ];
 let _shopCat='border';
 function setShopCat(cat,btn){_shopCat=cat;document.querySelectorAll('.shop-tab').forEach(b=>b.classList.remove('on'));if(btn)btn.classList.add('on');renderShop();}
+function _walletBal(){return(typeof RPGWallet!=='undefined')?RPGWallet.getCredits():(S.credits||0);}
+function _updateCreditsUI(){const b=_walletBal();const mc=document.getElementById('map-credits');if(mc)mc.textContent=b;const sb=document.getElementById('shop-bal');if(sb)sb.textContent=b;const pc=document.getElementById('pr-credits');if(pc)pc.textContent=b;}
 function earnCredits(n){
  n=Number(n);
  if(!isFinite(n)||n<=0)return;
  n=Math.floor(n);
- if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;
- S.credits=Math.floor(S.credits)+n;
- saveS();
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits;
+ if(typeof RPGWallet!=='undefined'){RPGWallet.earn(n);}
+ else{if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits)+n;saveS();}
+ _updateCreditsUI();
  try{const r=document.createElement('div');r.className='float-txt';r.textContent='+'+n+' kr';r.style.cssText='left:50%;top:40%;transform:translateX(-50%)';document.body.appendChild(r);setTimeout(()=>r.remove(),950);}catch(e){}
 }
 function sanitizeCosmetics(){
@@ -1202,28 +1201,29 @@ function sanitizeCosmetics(){
   if(item.price>0&&!owned.includes(id))S.cosmetics.active[cat]=cat==='theme'?'theme-default':cat==='victory'?'victory-default':null;
  });
 }
+function _activeCosmetics(){return(typeof RPGWallet!=='undefined')?RPGWallet.get().cosmetics:S.cosmetics;}
 function applyCosmetics(){
- if(!S.cosmetics)return;
+ const cos=_activeCosmetics()||S.cosmetics;
+ if(!cos)return;
  const av=document.getElementById('pr-avatar');
- if(av){av.className='';const b=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.border&&i.cat==='border');if(b)av.classList.add(b.cssKey);}
+ if(av){av.className='';const b=SHOP_ITEMS.find(i=>i.id===cos.active?.border&&i.cat==='border');if(b)av.classList.add(b.cssKey);}
  const nm=document.getElementById('pr-name');const mnm=document.getElementById('map-name');
  ['nm-cyan','nm-gold','nm-green','nm-purple'].forEach(c=>{nm&&nm.classList.remove(c);mnm&&mnm.classList.remove(c);});
- const bg=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.badge&&i.cat==='badge');
+ const bg=SHOP_ITEMS.find(i=>i.id===cos.active?.badge&&i.cat==='badge');
  if(bg){nm&&nm.classList.add(bg.cssKey);mnm&&mnm.classList.add(bg.cssKey);}
- const th=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.theme&&i.cat==='theme');
+ const th=SHOP_ITEMS.find(i=>i.id===cos.active?.theme&&i.cat==='theme');
  document.documentElement.dataset.theme=th&&th.cssKey?th.cssKey:'';
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits||0;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits||0;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits||0;
+ _updateCreditsUI();
  renderShop();
 }
 function renderShop(){
  const grid=document.getElementById('shop-grid');if(!grid)return;
+ const bal=_walletBal();
  const items=SHOP_ITEMS.filter(i=>i.cat===_shopCat);
  grid.innerHTML=items.map(item=>{
-  const owned=S.cosmetics&&S.cosmetics.owned&&S.cosmetics.owned.includes(item.id);
-  const active=S.cosmetics&&S.cosmetics.active&&S.cosmetics.active[item.cat]===item.id;
-  const canBuy=S.credits>=item.price;
+  const owned=(typeof RPGWallet!=='undefined')?RPGWallet.owns(item.id)||(item.price===0):(S.cosmetics&&S.cosmetics.owned&&S.cosmetics.owned.includes(item.id))||item.price===0;
+  const active=(typeof RPGWallet!=='undefined')?RPGWallet.isActive(item.id):(S.cosmetics&&S.cosmetics.active&&S.cosmetics.active[item.cat]===item.id);
+  const canBuy=!owned&&bal>=item.price;
   return `<div class="shop-card${active?' active':owned?' owned':''}">
    <div class="shop-ic">${item.ic}</div>
    <div class="shop-nm">${item.name}</div>
@@ -1237,6 +1237,7 @@ function renderShop(){
  }).join('');
 }
 function buyItem(id){
+ if(typeof RPGWallet!=='undefined'){const r=RPGWallet.buy(id);if(!r.ok){alert('Nedostatek kreditů!');return;}applyCosmetics();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics||!Array.isArray(S.cosmetics.owned))sanitizeCosmetics();
  if(item.price===0||S.cosmetics.owned.includes(id)){activateItem(id);return;}
@@ -1246,6 +1247,7 @@ function buyItem(id){
  saveS();activateItem(id);
 }
 function activateItem(id){
+ if(typeof RPGWallet!=='undefined'){RPGWallet.activate(id);applyCosmetics();renderShop();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics||!Array.isArray(S.cosmetics.owned))sanitizeCosmetics();
  if(item.price>0&&!S.cosmetics.owned.includes(id)){console.warn('[shop] activateItem: not owned',id);return;}
@@ -1262,7 +1264,7 @@ let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},
 let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();if(typeof RPGWallet!=='undefined')RPGWallet.migrateFrom(SAVE_KEY,S);return true;}
 function applyMotionPref(){document.documentElement.classList.toggle('reduced-motion',(S.settings&&S.settings.reducedMotion)||false);}
 function toggleReducedMotion(on){if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};S.settings.reducedMotion=on;applyMotionPref();saveS();}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
@@ -1613,8 +1615,23 @@ function launchBattle(aid,mid){
  void mon.offsetWidth;
  mon.classList.add('enter');
  setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
+ setTimeout(introStrike,660);
  renderTask();
  go('battle');
+}
+
+function introStrike(){
+ const mon=document.getElementById('bt-mon');
+ const top=document.getElementById('bt-top');
+ const flash=document.getElementById('hit-flash');
+ if(!mon||!top||!flash)return;
+ mon.classList.remove('idle','idle-2');
+ void mon.offsetWidth;
+ mon.classList.add('hit');
+ top.classList.add('shake');
+ flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
+ spawnParticles();
+ setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){
@@ -1816,14 +1833,12 @@ function submitMC(opt,btn){
  const fb=document.getElementById('bt-fb');
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('next-btn').style.display='inline-block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2013,8 +2028,7 @@ function submitAnswer(){
  const xpGain=firstTime?Math.max(3,10-BT.hl*3)*(isCrit?2:1):0;
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('bt-ans').disabled=true;
@@ -2023,7 +2037,6 @@ function submitAnswer(){
  if(!BT.mcMode)document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2302,7 +2315,8 @@ function trCorrect(){
  const fb=document.getElementById('tr-fb');
  fb.className='feedback ok';
  if(!wasMastered&&m.mastered){earnCredits(30);fb.textContent='🏅 MISTROVSTVÍ SPLNĚNO! +3 XP +30 kr';}
- else{earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else if(!wasMastered){earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else{fb.textContent='✓ SPRÁVNĚ! +3 XP';}
  document.getElementById('tr-hint-btn').disabled=true;
  document.getElementById('tr-next-btn').style.display='inline-block';
  document.getElementById('tr-next-btn').focus();
@@ -2390,6 +2404,7 @@ window.addEventListener('load',()=>{
 </script>
 <script src="./rpg-tasks-6.js"></script>
 <script src="./rpg-learn-6.js"></script>
+<script src="./rpg-wallet.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="./rpg-cloud.js"></script>
 <script>RPGCloud.attachGame(SAVE_KEY);</script>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -2212,10 +2212,10 @@ function renderTrainPicker(){
   let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
-   const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));
+   const pct=Math.min(100,Math.round((ms.score|0)/MASTERY_GOAL*100))|0;
    html+=`<button class="ms-item avail" style="width:100%;text-align:left;border:none;cursor:pointer" onclick="startTrain('${m.id}')">
      <div style="flex:1"><div class="ms-name">${ms.mastered?'🏅 ':''}${m.name}</div>
-     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':ms.score+' / '+MASTERY_GOAL}</div>
+     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':(ms.score|0)+' / '+MASTERY_GOAL}</div>
      <div class="bar-out bar-xp" style="margin-top:6px;height:6px"><div class="bar-in" style="width:${pct}%"></div></div></div>
      <div style="font-size:16px;margin-left:8px">${ms.mastered?'🏅':'🎯'}</div></button>`;
   });

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -458,7 +458,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="continue-panel" class="panel b" style="display:none">
  <div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--blue);margin-bottom:10px">POKRAČOVAT VE HŘE</div>
  <button class="btn b full" style="margin-bottom:8px" onclick="continueGame()">▶ NAČÍST ULOŽENOU HRU</button>
- <button class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
+ <button id="go-fresh-btn" class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
  </div>
  <div style="text-align:center;font-family:var(--px);font-weight:400;font-size:13px;color:var(--muted);margin-top:8px">
  STISKNI ENTER PRO START <span class="blink">▌</span>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -2132,7 +2132,7 @@ function renderProfile(){
  const el=document.getElementById('pr-attrs');
  el.innerHTML='';
  Object.entries(ATTR_META).forEach(([k,m])=>{
- const v=S.attrs[k]||0,pct=Math.min(100,v);
+ const v=(S.attrs[k]||0)|0,pct=Math.min(100,v)|0;
  const row=document.createElement('div');
  row.className='attr-row';
  row.innerHTML=`<div class="attr-ic">${m.ic}</div><div class="attr-nm">${m.nm}</div>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -1187,16 +1187,15 @@ const SHOP_ITEMS=[
 ];
 let _shopCat='border';
 function setShopCat(cat,btn){_shopCat=cat;document.querySelectorAll('.shop-tab').forEach(b=>b.classList.remove('on'));if(btn)btn.classList.add('on');renderShop();}
+function _walletBal(){return(typeof RPGWallet!=='undefined')?RPGWallet.getCredits():(S.credits||0);}
+function _updateCreditsUI(){const b=_walletBal();const mc=document.getElementById('map-credits');if(mc)mc.textContent=b;const sb=document.getElementById('shop-bal');if(sb)sb.textContent=b;const pc=document.getElementById('pr-credits');if(pc)pc.textContent=b;}
 function earnCredits(n){
  n=Number(n);
  if(!isFinite(n)||n<=0)return;
  n=Math.floor(n);
- if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;
- S.credits=Math.floor(S.credits)+n;
- saveS();
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits;
+ if(typeof RPGWallet!=='undefined'){RPGWallet.earn(n);}
+ else{if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits)+n;saveS();}
+ _updateCreditsUI();
  try{const r=document.createElement('div');r.className='float-txt';r.textContent='+'+n+' kr';r.style.cssText='left:50%;top:40%;transform:translateX(-50%)';document.body.appendChild(r);setTimeout(()=>r.remove(),950);}catch(e){}
 }
 function sanitizeCosmetics(){
@@ -1214,28 +1213,29 @@ function sanitizeCosmetics(){
   if(item.price>0&&!owned.includes(id))S.cosmetics.active[cat]=cat==='theme'?'theme-default':cat==='victory'?'victory-default':null;
  });
 }
+function _activeCosmetics(){return(typeof RPGWallet!=='undefined')?RPGWallet.get().cosmetics:S.cosmetics;}
 function applyCosmetics(){
- if(!S.cosmetics)return;
+ const cos=_activeCosmetics()||S.cosmetics;
+ if(!cos)return;
  const av=document.getElementById('pr-avatar');
- if(av){av.className='';const b=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.border&&i.cat==='border');if(b)av.classList.add(b.cssKey);}
+ if(av){av.className='';const b=SHOP_ITEMS.find(i=>i.id===cos.active?.border&&i.cat==='border');if(b)av.classList.add(b.cssKey);}
  const nm=document.getElementById('pr-name');const mnm=document.getElementById('map-name');
  ['nm-cyan','nm-gold','nm-green','nm-purple'].forEach(c=>{nm&&nm.classList.remove(c);mnm&&mnm.classList.remove(c);});
- const bg=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.badge&&i.cat==='badge');
+ const bg=SHOP_ITEMS.find(i=>i.id===cos.active?.badge&&i.cat==='badge');
  if(bg){nm&&nm.classList.add(bg.cssKey);mnm&&mnm.classList.add(bg.cssKey);}
- const th=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.theme&&i.cat==='theme');
+ const th=SHOP_ITEMS.find(i=>i.id===cos.active?.theme&&i.cat==='theme');
  document.documentElement.dataset.theme=th&&th.cssKey?th.cssKey:'';
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits||0;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits||0;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits||0;
+ _updateCreditsUI();
  renderShop();
 }
 function renderShop(){
  const grid=document.getElementById('shop-grid');if(!grid)return;
+ const bal=_walletBal();
  const items=SHOP_ITEMS.filter(i=>i.cat===_shopCat);
  grid.innerHTML=items.map(item=>{
-  const owned=S.cosmetics&&S.cosmetics.owned&&S.cosmetics.owned.includes(item.id);
-  const active=S.cosmetics&&S.cosmetics.active&&S.cosmetics.active[item.cat]===item.id;
-  const canBuy=S.credits>=item.price;
+  const owned=(typeof RPGWallet!=='undefined')?RPGWallet.owns(item.id)||(item.price===0):(S.cosmetics&&S.cosmetics.owned&&S.cosmetics.owned.includes(item.id))||item.price===0;
+  const active=(typeof RPGWallet!=='undefined')?RPGWallet.isActive(item.id):(S.cosmetics&&S.cosmetics.active&&S.cosmetics.active[item.cat]===item.id);
+  const canBuy=!owned&&bal>=item.price;
   return `<div class="shop-card${active?' active':owned?' owned':''}">
    <div class="shop-ic">${item.ic}</div>
    <div class="shop-nm">${item.name}</div>
@@ -1249,6 +1249,7 @@ function renderShop(){
  }).join('');
 }
 function buyItem(id){
+ if(typeof RPGWallet!=='undefined'){const r=RPGWallet.buy(id);if(!r.ok){alert('Nedostatek kreditů!');return;}applyCosmetics();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics||!Array.isArray(S.cosmetics.owned))sanitizeCosmetics();
  if(item.price===0||S.cosmetics.owned.includes(id)){activateItem(id);return;}
@@ -1258,6 +1259,7 @@ function buyItem(id){
  saveS();activateItem(id);
 }
 function activateItem(id){
+ if(typeof RPGWallet!=='undefined'){RPGWallet.activate(id);applyCosmetics();renderShop();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics||!Array.isArray(S.cosmetics.owned))sanitizeCosmetics();
  if(item.price>0&&!S.cosmetics.owned.includes(id)){console.warn('[shop] activateItem: not owned',id);return;}
@@ -1274,7 +1276,7 @@ let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},
 let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();if(typeof RPGWallet!=='undefined')RPGWallet.migrateFrom(SAVE_KEY,S);return true;}
 function applyMotionPref(){document.documentElement.classList.toggle('reduced-motion',(S.settings&&S.settings.reducedMotion)||false);}
 function toggleReducedMotion(on){if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};S.settings.reducedMotion=on;applyMotionPref();saveS();}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
@@ -1625,8 +1627,23 @@ function launchBattle(aid,mid){
  void mon.offsetWidth;
  mon.classList.add('enter');
  setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
+ setTimeout(introStrike,660);
  renderTask();
  go('battle');
+}
+
+function introStrike(){
+ const mon=document.getElementById('bt-mon');
+ const top=document.getElementById('bt-top');
+ const flash=document.getElementById('hit-flash');
+ if(!mon||!top||!flash)return;
+ mon.classList.remove('idle','idle-2');
+ void mon.offsetWidth;
+ mon.classList.add('hit');
+ top.classList.add('shake');
+ flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
+ spawnParticles();
+ setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){
@@ -1828,14 +1845,12 @@ function submitMC(opt,btn){
  const fb=document.getElementById('bt-fb');
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('next-btn').style.display='inline-block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2025,8 +2040,7 @@ function submitAnswer(){
  const xpGain=firstTime?Math.max(3,10-BT.hl*3)*(isCrit?2:1):0;
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('bt-ans').disabled=true;
@@ -2035,7 +2049,6 @@ function submitAnswer(){
  if(!BT.mcMode)document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2311,7 +2324,8 @@ function trCorrect(){
  const fb=document.getElementById('tr-fb');
  fb.className='feedback ok';
  if(!wasMastered&&m.mastered){earnCredits(30);fb.textContent='🏅 MISTROVSTVÍ SPLNĚNO! +3 XP +30 kr';}
- else{earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else if(!wasMastered){earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else{fb.textContent='✓ SPRÁVNĚ! +3 XP';}
  document.getElementById('tr-hint-btn').disabled=true;
  document.getElementById('tr-next-btn').style.display='inline-block';
  document.getElementById('tr-next-btn').focus();
@@ -2399,6 +2413,7 @@ window.addEventListener('load',()=>{
 </script>
 <script src="./rpg-tasks-7.js"></script>
 <script src="./rpg-learn-7.js"></script>
+<script src="./rpg-wallet.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="./rpg-cloud.js"></script>
 <script>RPGCloud.attachGame(SAVE_KEY);</script>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -690,6 +690,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <button class="btn sm" onclick="importPrompt()">NAČÍST KÓD</button>
  </div>
  </div>
+ <div class="panel" id="pr-allgames"></div>
 </div>
 </div>
 
@@ -2102,6 +2103,27 @@ function checkMissionComplete(){
 // ══════════════════════════════════════════
 // PROFILE
 // ══════════════════════════════════════════
+const ALL_GAMES=[
+ {key:'RPG_MAT_6',ic:'🚀',nm:'6. ročník – Vesmírná expedice'},
+ {key:'RPG_MAT_7',ic:'⛏️',nm:'7. ročník – Ztracený chrám'},
+ {key:'RPG_MAT_8',ic:'🎓',nm:'8. ročník – Mat. akademie'},
+ {key:'RPG_MAT_9',ic:'💻',nm:'9. ročník – NULL_BYTE'},
+];
+function renderCrossGames(){
+ const el=document.getElementById('pr-allgames');if(!el)return;
+ let html='<div style="font-family:var(--px);font-weight:700;font-size:12px;color:var(--muted);margin-bottom:10px;letter-spacing:1px">— PŘEHLED VŠECH HER —</div>';
+ ALL_GAMES.forEach(g=>{
+  let s=null;try{s=JSON.parse(localStorage.getItem(g.key));}catch{}
+  const cur=g.key===SAVE_KEY;
+  html+='<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--line)'+(cur?';font-weight:700':'')+'">' +
+   '<span style="font-size:16px">'+g.ic+'</span>'+
+   '<span style="flex:1;font-size:12px;color:'+(cur?'#fff':'var(--muted)')+'">'+g.nm+(cur?' ◀':'')+'</span>'+
+   (s?'<span style="font-size:12px;color:var(--gold)">LV '+((s.level||1)|0)+' · '+((s.xp||0)|0)+' XP</span>':'<span style="font-size:11px;color:var(--muted)">—</span>')+
+  '</div>';
+ });
+ html+='<a href="rpg-matematika.html" style="display:block;margin-top:10px;color:var(--blue);font-size:12px;font-family:var(--px);text-align:center">🌐 Velitelské centrum – přehled a obchod pro všechny hry</a>';
+ el.innerHTML=html;
+}
 function renderProfile(){
  calcLevel();
  document.getElementById('pr-name').textContent=S.name;
@@ -2143,6 +2165,7 @@ function renderProfile(){
  document.getElementById('pr-ach-t').textContent=ACH.length;
  }
  const rm=document.getElementById('pr-rm');if(rm)rm.checked=!!(S.settings&&S.settings.reducedMotion);
+ renderCrossGames();
 }
 
 function exportCode(){

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -2331,7 +2331,7 @@ function renderProfile(){
  const el=document.getElementById('pr-attrs');
  el.innerHTML='';
  Object.entries(ATTR_META).forEach(([k,m])=>{
- const v=S.attrs[k]||0,pct=Math.min(100,v);
+ const v=(S.attrs[k]||0)|0,pct=Math.min(100,v)|0;
  const row=document.createElement('div');
  row.className='attr-row';
  row.innerHTML=`<div class="attr-ic">${m.ic}</div><div class="attr-nm">${m.nm}</div>

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -693,6 +693,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <button class="btn sm" onclick="importPrompt()">NAČÍST KÓD</button>
  </div>
  </div>
+ <div class="panel" id="pr-allgames"></div>
 </div>
 </div>
 
@@ -2301,6 +2302,27 @@ function checkMissionComplete(){
 // ══════════════════════════════════════════
 // PROFILE
 // ══════════════════════════════════════════
+const ALL_GAMES=[
+ {key:'RPG_MAT_6',ic:'🚀',nm:'6. ročník – Vesmírná expedice'},
+ {key:'RPG_MAT_7',ic:'⛏️',nm:'7. ročník – Ztracený chrám'},
+ {key:'RPG_MAT_8',ic:'🎓',nm:'8. ročník – Mat. akademie'},
+ {key:'RPG_MAT_9',ic:'💻',nm:'9. ročník – NULL_BYTE'},
+];
+function renderCrossGames(){
+ const el=document.getElementById('pr-allgames');if(!el)return;
+ let html='<div style="font-family:var(--px);font-weight:700;font-size:12px;color:var(--muted);margin-bottom:10px;letter-spacing:1px">— PŘEHLED VŠECH HER —</div>';
+ ALL_GAMES.forEach(g=>{
+  let s=null;try{s=JSON.parse(localStorage.getItem(g.key));}catch{}
+  const cur=g.key===SAVE_KEY;
+  html+='<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--line)'+(cur?';font-weight:700':'')+'">' +
+   '<span style="font-size:16px">'+g.ic+'</span>'+
+   '<span style="flex:1;font-size:12px;color:'+(cur?'#fff':'var(--muted)')+'">'+g.nm+(cur?' ◀':'')+'</span>'+
+   (s?'<span style="font-size:12px;color:var(--gold)">LV '+((s.level||1)|0)+' · '+((s.xp||0)|0)+' XP</span>':'<span style="font-size:11px;color:var(--muted)">—</span>')+
+  '</div>';
+ });
+ html+='<a href="rpg-matematika.html" style="display:block;margin-top:10px;color:var(--blue);font-size:12px;font-family:var(--px);text-align:center">🌐 Velitelské centrum – přehled a obchod pro všechny hry</a>';
+ el.innerHTML=html;
+}
 function renderProfile(){
  calcLevel();
  document.getElementById('pr-name').textContent=S.name;
@@ -2342,6 +2364,7 @@ function renderProfile(){
  document.getElementById('pr-ach-t').textContent=ACH.length;
  }
  const rm=document.getElementById('pr-rm');if(rm)rm.checked=!!(S.settings&&S.settings.reducedMotion);
+ renderCrossGames();
 }
 
 function exportCode(){

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -2433,10 +2433,10 @@ function renderTrainPicker(){
   let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
-   const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));
+   const pct=Math.min(100,Math.round((ms.score|0)/MASTERY_GOAL*100))|0;
    html+=`<button class="ms-item avail" style="width:100%;text-align:left;border:none;cursor:pointer" onclick="startTrain('${m.id}')">
      <div style="flex:1"><div class="ms-name">${ms.mastered?'🏅 ':''}${m.name}</div>
-     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':ms.score+' / '+MASTERY_GOAL}</div>
+     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':(ms.score|0)+' / '+MASTERY_GOAL}</div>
      <div class="bar-out bar-xp" style="margin-top:6px;height:6px"><div class="bar-in" style="width:${pct}%"></div></div></div>
      <div style="font-size:16px;margin-left:8px">${ms.mastered?'🏅':'🎯'}</div></button>`;
   });

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -460,7 +460,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="continue-panel" class="panel b" style="display:none">
  <div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--blue);margin-bottom:10px">POKRAČOVAT VE HŘE</div>
  <button class="btn b full" style="margin-bottom:8px" onclick="continueGame()">▶ NAČÍST ULOŽENOU HRU</button>
- <button class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
+ <button id="go-fresh-btn" class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
  </div>
  <div style="text-align:center;font-family:var(--px);font-weight:400;font-size:13px;color:var(--muted);margin-top:8px">
  STISKNI ENTER PRO START <span class="blink">▌</span>

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -1377,16 +1377,15 @@ const SHOP_ITEMS=[
 ];
 let _shopCat='border';
 function setShopCat(cat,btn){_shopCat=cat;document.querySelectorAll('.shop-tab').forEach(b=>b.classList.remove('on'));if(btn)btn.classList.add('on');renderShop();}
+function _walletBal(){return(typeof RPGWallet!=='undefined')?RPGWallet.getCredits():(S.credits||0);}
+function _updateCreditsUI(){const b=_walletBal();const mc=document.getElementById('map-credits');if(mc)mc.textContent=b;const sb=document.getElementById('shop-bal');if(sb)sb.textContent=b;const pc=document.getElementById('pr-credits');if(pc)pc.textContent=b;}
 function earnCredits(n){
  n=Number(n);
  if(!isFinite(n)||n<=0)return;
  n=Math.floor(n);
- if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;
- S.credits=Math.floor(S.credits)+n;
- saveS();
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits;
+ if(typeof RPGWallet!=='undefined'){RPGWallet.earn(n);}
+ else{if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits)+n;saveS();}
+ _updateCreditsUI();
  try{const r=document.createElement('div');r.className='float-txt';r.textContent='+'+n+' kr';r.style.cssText='left:50%;top:40%;transform:translateX(-50%)';document.body.appendChild(r);setTimeout(()=>r.remove(),950);}catch(e){}
 }
 function sanitizeCosmetics(){
@@ -1404,28 +1403,29 @@ function sanitizeCosmetics(){
   if(item.price>0&&!owned.includes(id))S.cosmetics.active[cat]=cat==='theme'?'theme-default':cat==='victory'?'victory-default':null;
  });
 }
+function _activeCosmetics(){return(typeof RPGWallet!=='undefined')?RPGWallet.get().cosmetics:S.cosmetics;}
 function applyCosmetics(){
- if(!S.cosmetics)return;
+ const cos=_activeCosmetics()||S.cosmetics;
+ if(!cos)return;
  const av=document.getElementById('pr-avatar');
- if(av){av.className='';const b=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.border&&i.cat==='border');if(b)av.classList.add(b.cssKey);}
+ if(av){av.className='';const b=SHOP_ITEMS.find(i=>i.id===cos.active?.border&&i.cat==='border');if(b)av.classList.add(b.cssKey);}
  const nm=document.getElementById('pr-name');const mnm=document.getElementById('map-name');
  ['nm-cyan','nm-gold','nm-green','nm-purple'].forEach(c=>{nm&&nm.classList.remove(c);mnm&&mnm.classList.remove(c);});
- const bg=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.badge&&i.cat==='badge');
+ const bg=SHOP_ITEMS.find(i=>i.id===cos.active?.badge&&i.cat==='badge');
  if(bg){nm&&nm.classList.add(bg.cssKey);mnm&&mnm.classList.add(bg.cssKey);}
- const th=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.theme&&i.cat==='theme');
+ const th=SHOP_ITEMS.find(i=>i.id===cos.active?.theme&&i.cat==='theme');
  document.documentElement.dataset.theme=th&&th.cssKey?th.cssKey:'';
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits||0;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits||0;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits||0;
+ _updateCreditsUI();
  renderShop();
 }
 function renderShop(){
  const grid=document.getElementById('shop-grid');if(!grid)return;
+ const bal=_walletBal();
  const items=SHOP_ITEMS.filter(i=>i.cat===_shopCat);
  grid.innerHTML=items.map(item=>{
-  const owned=S.cosmetics&&S.cosmetics.owned&&S.cosmetics.owned.includes(item.id);
-  const active=S.cosmetics&&S.cosmetics.active&&S.cosmetics.active[item.cat]===item.id;
-  const canBuy=S.credits>=item.price;
+  const owned=(typeof RPGWallet!=='undefined')?RPGWallet.owns(item.id)||(item.price===0):(S.cosmetics&&S.cosmetics.owned&&S.cosmetics.owned.includes(item.id))||item.price===0;
+  const active=(typeof RPGWallet!=='undefined')?RPGWallet.isActive(item.id):(S.cosmetics&&S.cosmetics.active&&S.cosmetics.active[item.cat]===item.id);
+  const canBuy=!owned&&bal>=item.price;
   return `<div class="shop-card${active?' active':owned?' owned':''}">
    <div class="shop-ic">${item.ic}</div>
    <div class="shop-nm">${item.name}</div>
@@ -1439,6 +1439,7 @@ function renderShop(){
  }).join('');
 }
 function buyItem(id){
+ if(typeof RPGWallet!=='undefined'){const r=RPGWallet.buy(id);if(!r.ok){alert('Nedostatek kreditů!');return;}applyCosmetics();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics||!Array.isArray(S.cosmetics.owned))sanitizeCosmetics();
  if(item.price===0||S.cosmetics.owned.includes(id)){activateItem(id);return;}
@@ -1448,6 +1449,7 @@ function buyItem(id){
  saveS();activateItem(id);
 }
 function activateItem(id){
+ if(typeof RPGWallet!=='undefined'){RPGWallet.activate(id);applyCosmetics();renderShop();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics||!Array.isArray(S.cosmetics.owned))sanitizeCosmetics();
  if(item.price>0&&!S.cosmetics.owned.includes(id)){console.warn('[shop] activateItem: not owned',id);return;}
@@ -1459,7 +1461,7 @@ let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},
 let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();if(typeof RPGWallet!=='undefined')RPGWallet.migrateFrom(SAVE_KEY,S);return true;}
 function applyMotionPref(){document.documentElement.classList.toggle('reduced-motion',(S.settings&&S.settings.reducedMotion)||false);}
 function toggleReducedMotion(on){if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};S.settings.reducedMotion=on;applyMotionPref();saveS();}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
@@ -1829,8 +1831,23 @@ function launchBattle(aid,mid){
  void mon.offsetWidth;
  mon.classList.add('enter');
  setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
+ setTimeout(introStrike,660);
  renderTask();
  go('battle');
+}
+
+function introStrike(){
+ const mon=document.getElementById('bt-mon');
+ const top=document.getElementById('bt-top');
+ const flash=document.getElementById('hit-flash');
+ if(!mon||!top||!flash)return;
+ mon.classList.remove('idle','idle-2');
+ void mon.offsetWidth;
+ mon.classList.add('hit');
+ top.classList.add('shake');
+ flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
+ spawnParticles();
+ setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){
@@ -2027,14 +2044,12 @@ function submitMC(opt,btn){
  const fb=document.getElementById('bt-fb');
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('next-btn').style.display='inline-block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2224,8 +2239,7 @@ function submitAnswer(){
  const xpGain=firstTime?Math.max(3,10-BT.hl*3)*(isCrit?2:1):0;
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('bt-ans').disabled=true;
@@ -2234,7 +2248,6 @@ function submitAnswer(){
  if(!BT.mcMode)document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2532,7 +2545,8 @@ function trCorrect(){
  const fb=document.getElementById('tr-fb');
  fb.className='feedback ok';
  if(!wasMastered&&m.mastered){earnCredits(30);fb.textContent='🏅 MISTROVSTVÍ SPLNĚNO! +3 XP +30 kr';}
- else{earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else if(!wasMastered){earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else{fb.textContent='✓ SPRÁVNĚ! +3 XP';}
  document.getElementById('tr-hint-btn').disabled=true;
  document.getElementById('tr-next-btn').style.display='inline-block';
  document.getElementById('tr-next-btn').focus();
@@ -2599,6 +2613,7 @@ window.addEventListener('load',()=>{
 </script>
 <script src="./rpg-tasks-8.js"></script>
 <script src="./rpg-learn-8.js"></script>
+<script src="./rpg-wallet.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="./rpg-cloud.js"></script>
 <script>RPGCloud.attachGame(SAVE_KEY);setInterval(updateCermatChip,60000);</script>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -773,13 +773,14 @@ const SHOP_ITEMS=[
  {id:'victory-neon',   cat:'victory',name:'Neon záření', ic:'💚',price:140, cssKey:'vc-neon'},
 ];
 
+function _walletBal(){return(typeof RPGWallet!=='undefined')?RPGWallet.getCredits():(S.credits||0);}
+function _updateCreditsUI(){const b=_walletBal();const mc=document.getElementById('map-credits');if(mc)mc.textContent=b;const pc=document.getElementById('pr-credits');if(pc)pc.textContent=b;const sb=document.getElementById('shop-bal');if(sb)sb.textContent=b;}
 function earnCredits(n){
  n=Number(n);
  if(!isFinite(n)||n<=0)return;
  n=Math.floor(n);
- if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;
- S.credits=Math.floor(S.credits)+n;
- saveS();
+ if(typeof RPGWallet!=='undefined'){RPGWallet.earn(n);}
+ else{if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits)+n;saveS();}
  const el=document.createElement('div');
  el.className='float-txt';
  el.style.cssText='left:60%;top:42%;color:#f4d03f';
@@ -787,9 +788,7 @@ function earnCredits(n){
  document.body.appendChild(el);
  void el.offsetWidth;el.classList.add('go');
  setTimeout(()=>el.remove(),1200);
- const mc=document.getElementById('map-credits');if(mc)mc.textContent=S.credits;
- const pc=document.getElementById('pr-credits');if(pc)pc.textContent=S.credits;
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits;
+ _updateCreditsUI();
 }
 
 // normalizace kosmetiky — i po manipulaci s localStorage:
@@ -811,23 +810,25 @@ function sanitizeCosmetics(){
  S.cosmetics.active=clean;
 }
 
+function _activeCosmetics(){return(typeof RPGWallet!=='undefined')?RPGWallet.get().cosmetics:S.cosmetics;}
 function applyCosmetics(){
- if(!S.cosmetics)return;
+ const cos=_activeCosmetics();
+ if(!cos)return;
  const av=document.getElementById('pr-avatar');
  if(av){
   av.className='';
-  const b=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.border&&i.cat==='border');
+  const b=SHOP_ITEMS.find(i=>i.id===cos.active?.border&&i.cat==='border');
   if(b&&b.cssKey)av.classList.add(b.cssKey);
  }
  const nm=document.getElementById('pr-name');
  const mnm=document.getElementById('map-name');
  if(nm||mnm){
-  const bg=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.badge&&i.cat==='badge');
+  const bg=SHOP_ITEMS.find(i=>i.id===cos.active?.badge&&i.cat==='badge');
   const cls=bg?.cssKey||'';
   ['nm-cyan','nm-gold','nm-green','nm-purple'].forEach(c=>{nm&&nm.classList.remove(c);mnm&&mnm.classList.remove(c);});
   if(cls){nm&&nm.classList.add(cls);mnm&&mnm.classList.add(cls);}
  }
- const th=SHOP_ITEMS.find(i=>i.id===S.cosmetics.active?.theme&&i.cat==='theme');
+ const th=SHOP_ITEMS.find(i=>i.id===cos.active?.theme&&i.cat==='theme');
  document.documentElement.dataset.theme=th?.cssKey||'';
 }
 
@@ -841,15 +842,17 @@ function shopCat(cat){
 }
 
 function renderShop(){
- if(!S.cosmetics){S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};}
- const sb=document.getElementById('shop-bal');if(sb)sb.textContent=S.credits||0;
+ const cos=_activeCosmetics();
+ if(!cos&&!S.cosmetics){S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};}
+ _updateCreditsUI();
  const grid=document.getElementById('shop-content');if(!grid)return;
  const items=SHOP_ITEMS.filter(i=>i.cat===_shopCat);
+ const bal=_walletBal();
  grid.innerHTML='';
  items.forEach(item=>{
-  const owned=S.cosmetics.owned.includes(item.id)||item.price===0;
-  const isActive=S.cosmetics.active?.[item.cat]===item.id||(item.price===0&&!S.cosmetics.active?.[item.cat]);
-  const canBuy=!owned&&(S.credits||0)>=item.price;
+  const owned=(typeof RPGWallet!=='undefined')?RPGWallet.owns(item.id)||(item.price===0):(cos||S.cosmetics).owned.includes(item.id)||item.price===0;
+  const isActive=(typeof RPGWallet!=='undefined')?RPGWallet.isActive(item.id)||(item.price===0&&!(cos||{active:{}}).active?.[item.cat]):(cos||S.cosmetics).active?.[item.cat]===item.id||(item.price===0&&!(cos||S.cosmetics).active?.[item.cat]);
+  const canBuy=!owned&&bal>=item.price;
   const div=document.createElement('div');
   div.className='shop-item'+(owned?' owned':'')+(isActive?' active-item':'');
   div.innerHTML=`<span class="si-ic">${item.ic}</span>
@@ -865,10 +868,14 @@ function renderShop(){
 }
 
 function buyItem(id){
+ if(typeof RPGWallet!=='undefined'){
+  const r=RPGWallet.buy(id);
+  if(!r.ok){alert('Nedostatek kreditů!');return;}
+  applyCosmetics();renderShop();return;
+ }
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics)S.cosmetics={owned:['theme-default','victory-default'],active:{}};
  if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];
- // už vlastní nebo je zdarma → jen aktivuj, neúčtuj znovu
  if(item.price===0||S.cosmetics.owned.includes(id)){activateItem(id);return;}
  if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<item.price){alert('Nedostatek kreditů!');return;}
  S.credits-=item.price;
@@ -877,11 +884,11 @@ function buyItem(id){
 }
 
 function activateItem(id){
+ if(typeof RPGWallet!=='undefined'){RPGWallet.activate(id);applyCosmetics();renderShop();return;}
  const item=SHOP_ITEMS.find(i=>i.id===id);if(!item)return;
  if(!S.cosmetics)S.cosmetics={owned:[],active:{}};
  if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];
  if(!S.cosmetics.active)S.cosmetics.active={};
- // nelze aktivovat nevlastněnou placenou položku (anti-cheat z konzole)
  if(item.price>0&&!S.cosmetics.owned.includes(id))return;
  S.cosmetics.active[item.cat]=id;
  saveS();
@@ -1370,7 +1377,7 @@ let S = {name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},
 let GODMODE=false;
 
 function saveS(){localStorage.setItem(SAVE_KEY,JSON.stringify(S));if(window.RPGCloud&&RPGCloud.push)RPGCloud.push(SAVE_KEY,S);}
-function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();return true;}
+function loadS(){const r=localStorage.getItem(SAVE_KEY);if(!r)return false;try{S=JSON.parse(r);}catch(e){return false;}if(!S||typeof S!=='object'){S={name:'HRDINA',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[],mastery:{},xpClaimed:{},teacherUnlocked:[]};return false;}if(typeof S.name!=='string')S.name='HRDINA';if(typeof S.xp!=='number'||!isFinite(S.xp))S.xp=0;if(typeof S.level!=='number'||!isFinite(S.level))S.level=1;if(!S.attrs||typeof S.attrs!=='object')S.attrs={calc:0,geo:0,anal:0,craft:0};if(!S.done||typeof S.done!=='object')S.done={};if(!Array.isArray(S.inv))S.inv=[];if(!S.mastery||typeof S.mastery!=='object')S.mastery={};if(!S.xpClaimed||typeof S.xpClaimed!=='object')S.xpClaimed={};if(!Array.isArray(S.teacherUnlocked))S.teacherUnlocked=[];if(!S.ach||typeof S.ach!=='object')S.ach={};if(!S.stats||typeof S.stats!=='object')S.stats={crits:0,trainCorrect:0,bestCombo:0};if(!S.streak||typeof S.streak!=='object')S.streak={count:0,last:''};if(!S.errs||typeof S.errs!=='object')S.errs={};if(!Array.isArray(S.errsSnap))S.errsSnap=[];if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};if(typeof S.credits!=='number'||!isFinite(S.credits)||S.credits<0)S.credits=0;S.credits=Math.floor(S.credits);if(!S.cosmetics||typeof S.cosmetics!=='object')S.cosmetics={owned:['theme-default','victory-default'],active:{border:null,badge:null,theme:'theme-default',victory:'victory-default'}};if(!Array.isArray(S.cosmetics.owned))S.cosmetics.owned=['theme-default','victory-default'];if(!S.cosmetics.active||typeof S.cosmetics.active!=='object')S.cosmetics.active={border:null,badge:null,theme:'theme-default',victory:'victory-default'};if(!S.creditsClaimed||typeof S.creditsClaimed!=='object')S.creditsClaimed={};sanitizeCosmetics();if(typeof RPGWallet!=='undefined')RPGWallet.migrateFrom(SAVE_KEY,S);return true;}
 function applyMotionPref(){document.documentElement.classList.toggle('reduced-motion',(S.settings&&S.settings.reducedMotion)||false);}
 function toggleReducedMotion(on){if(!S.settings||typeof S.settings!=='object')S.settings={reducedMotion:false};S.settings.reducedMotion=on;applyMotionPref();saveS();}
 function calcLevel(){S.level=Math.floor(S.xp/100)+1;}
@@ -1744,8 +1751,23 @@ function launchBattle(aid,mid){
  void mon.offsetWidth;
  mon.classList.add('enter');
  setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
+ setTimeout(introStrike,660);
  renderTask();
  go('battle');
+}
+
+function introStrike(){
+ const mon=document.getElementById('bt-mon');
+ const top=document.getElementById('bt-top');
+ const flash=document.getElementById('hit-flash');
+ if(!mon||!top||!flash)return;
+ mon.classList.remove('idle','idle-2');
+ void mon.offsetWidth;
+ mon.classList.add('hit');
+ top.classList.add('shake');
+ flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
+ spawnParticles();
+ setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){
@@ -1947,14 +1969,12 @@ function submitMC(opt,btn){
  const fb=document.getElementById('bt-fb');
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('next-btn').style.display='inline-block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2144,8 +2164,7 @@ function submitAnswer(){
  const xpGain=firstTime?Math.max(3,10-BT.hl*3)*(isCrit?2:1):0;
  fb.textContent=firstTime?((isCrit?'✓✓ KRITICKÝ ZÁSAH! +':'✓ SPRÁVNĚ! +')+xpGain+' XP'):'✓ SPRÁVNĚ! (mise už splněna — bez XP)';
  fb.className='feedback ok';
- if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);}
- else earnCredits(2);
+ if(firstTime){awardXp(xpGain,isCrit);if(t.skill&&S.attrs[t.skill]!==undefined)S.attrs[t.skill]+=3;S.xpClaimed[xpKey]=true;earnCredits(isCrit?7:5);tryDropItem();}
  S.done[`${BT.mid}-${BT.idx}`]=true;
  saveS();
  document.getElementById('bt-ans').disabled=true;
@@ -2154,7 +2173,6 @@ function submitAnswer(){
  document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);
  updateCombo();
- tryDropItem();
  if(!S.stats)S.stats={};if(BT.combo>(S.stats.bestCombo||0))S.stats.bestCombo=BT.combo;
  evalAch({correct:true,combo:BT.combo,timeLeft:BT.timeLeft});
  checkMissionComplete();
@@ -2339,7 +2357,8 @@ function trCorrect(){
  const fb=document.getElementById('tr-fb');
  fb.className='feedback ok';
  if(!wasMastered&&m.mastered){earnCredits(30);fb.textContent='🏅 MISTROVSTVÍ SPLNĚNO! +3 XP +30 kr';}
- else{earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else if(!wasMastered){earnCredits(1);fb.textContent='✓ SPRÁVNĚ! +3 XP +1 kr';}
+ else{fb.textContent='✓ SPRÁVNĚ! +3 XP';}
  document.getElementById('tr-hint-btn').disabled=true;
  document.getElementById('tr-next-btn').style.display='inline-block';
  document.getElementById('tr-next-btn').focus();
@@ -2522,6 +2541,7 @@ window.addEventListener('load',()=>{
  }
 });
 </script>
+<script src="./rpg-wallet.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="./rpg-cloud.js"></script>
 <script>RPGCloud.attachGame(SAVE_KEY);</script>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -2420,7 +2420,7 @@ function renderProfile(){
  const el=document.getElementById('pr-attrs');
  el.innerHTML='';
  Object.entries(ATTR_META).forEach(([k,m])=>{
- const v=S.attrs[k]||0,pct=Math.min(100,v);
+ const v=(S.attrs[k]||0)|0,pct=Math.min(100,v)|0;
  const row=document.createElement('div');
  row.className='attr-row';
  row.innerHTML=`<div class="attr-ic">${m.ic}</div><div class="attr-nm">${m.nm}</div>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -2239,10 +2239,10 @@ function renderTrainPicker(){
   let html=`<div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);margin-bottom:8px">${ar.icon} ${ar.name.replace(/\n/g,' ')}</div>`;
   ar.missions.forEach(m=>{
    const ms=masteryOf(m.id);
-   const pct=Math.min(100,Math.round(ms.score/MASTERY_GOAL*100));
+   const pct=Math.min(100,Math.round((ms.score|0)/MASTERY_GOAL*100))|0;
    html+=`<button class="ms-item avail" style="width:100%;text-align:left;border:none;cursor:pointer" onclick="startTrain('${m.id}')">
      <div style="flex:1"><div class="ms-name">${ms.mastered?'🏅 ':''}${m.name}</div>
-     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':ms.score+' / '+MASTERY_GOAL}</div>
+     <div class="ms-sub">${m.sub} · ${ms.mastered?'mistrovství splněno':(ms.score|0)+' / '+MASTERY_GOAL}</div>
      <div class="bar-out bar-xp" style="margin-top:6px;height:6px"><div class="bar-in" style="width:${pct}%"></div></div></div>
      <div style="font-size:16px;margin-left:8px">${ms.mastered?'🏅':'🎯'}</div></button>`;
   });

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -471,7 +471,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="continue-panel" class="panel b" style="display:none">
  <div style="font-family:var(--px);font-weight:700;font-size:14px;color:var(--blue);margin-bottom:10px">POKRAČOVAT VE HŘE</div>
  <button class="btn b full" style="margin-bottom:8px" onclick="continueGame()">▶ NAČÍST ULOŽENOU HRU</button>
- <button class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
+ <button id="go-fresh-btn" class="btn sm" onclick="document.getElementById('continue-panel').style.display='none'">nebo začít znovu</button>
  </div>
  <div style="text-align:center;font-family:var(--px);font-weight:400;font-size:13px;color:var(--muted);margin-top:8px">
  STISKNI ENTER PRO START <span class="blink">▌</span>
@@ -1227,9 +1227,9 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const m=ri(2,8)*50,p=[10,20,25,50][ri(0,3)];return{text:`V roztoku o hmotnosti ${m} g je ${p} % soli.\nKolik gramů soli obsahuje?`,ans:String(m*p/100),hints:[`${p} % z ${m} = ${m}·${p/100}.`,``],skill:'anal'};})(),
-   (()=>{const s=ri(2,9)*10,m=s*ri(4,8);return{text:`Roztok má hmotnost ${m} g a obsahuje ${s} g soli.\nKolik procent soli obsahuje?`,ans:String(Math.round(s/m*100)),hints:[`Část ÷ celek × 100.`,`${s} ÷ ${m} × 100`],skill:'anal'};})(),
+   (()=>{const f=[4,5,8,10][ri(0,3)],s=ri(2,9)*10,m=s*f;const p=100/f;return{text:`Roztok má hmotnost ${m} g a obsahuje ${s} g soli.\nKolik procent soli obsahuje?`,ans:cz(p),hints:[`Část ÷ celek × 100.`,`${s} ÷ ${m} × 100 = ${cz(p)}`],skill:'anal'};})(),
    (()=>{const a=ri(2,5),pa=ri(8,15)*10,b=ri(2,5),pb=ri(2,7)*10;const tot=(a*pa+b*pb)/(a+b);return{text:`Smícháme ${a} kg kávy po ${pa} Kč a ${b} kg po ${pb} Kč.\nCena 1 kg směsi? (Kč)`,ans:String(Math.round(tot)),hints:[`(${a}·${pa} + ${b}·${pb}) ÷ ${a+b}.`,`${a*pa+b*pb} ÷ ${a+b}`],skill:'anal'};})(),
-   (()=>{const t=ri(4,10);return{text:`Dělník zvládne celou práci za ${t} hodin.\nKolik procent práce udělá za 1 hodinu?`,ans:String(Math.round(100/t)),hints:[`Za 1 h udělá 1/${t} práce.`,`100 ÷ ${t}`],skill:'anal'};})(),
+   (()=>{const t=[4,5,8,10,20,25][ri(0,5)];const pct=100/t;return{text:`Dělník zvládne celou práci za ${t} hodin.\nKolik procent práce udělá za 1 hodinu?`,ans:cz(pct),hints:[`Za 1 h udělá 1/${t} práce.`,`100 ÷ ${t} = ${cz(pct)}`],skill:'anal'};})(),
    (()=>{const t=ri(2,5)*2,h=t/2;return{text:`Stroj udělá zakázku za ${t} hodin.\nKolik zakázek (i nedokončených, v %) zvládne za ${h} hodin?`,ans:String(Math.round(h/t*100)),hints:[`${h}/${t} celé práce.`,`${h} ÷ ${t} × 100`],skill:'anal'};})(),
    (()=>{const c=ri(2,6)*10,p=[20,25,40,50][ri(0,3)],voda=c*(100-p)/p;return{text:`Chceš ${p}% roztok. Máš ${c} g soli.\nKolik g vody přidat? (celková hmotnost − sůl)`,ans:String(Math.round(c*100/p - c)),hints:[`Celý roztok = sůl ÷ ${p/100} = ${Math.round(c*100/p)} g.`,`voda = ${Math.round(c*100/p)} − ${c}`],skill:'anal'};})()
   ]

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -710,6 +710,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <button class="btn sm" onclick="importPrompt()">NAČÍST KÓD</button>
  </div>
  </div>
+ <div class="panel" id="pr-allgames"></div>
 </div>
 </div>
 
@@ -2388,6 +2389,27 @@ function trEnd(){renderTrainPicker();}
 // ══════════════════════════════════════════
 // PROFILE
 // ══════════════════════════════════════════
+const ALL_GAMES=[
+ {key:'RPG_MAT_6',ic:'🚀',nm:'6. ročník – Vesmírná expedice'},
+ {key:'RPG_MAT_7',ic:'⛏️',nm:'7. ročník – Ztracený chrám'},
+ {key:'RPG_MAT_8',ic:'🎓',nm:'8. ročník – Mat. akademie'},
+ {key:'RPG_MAT_9',ic:'💻',nm:'9. ročník – NULL_BYTE'},
+];
+function renderCrossGames(){
+ const el=document.getElementById('pr-allgames');if(!el)return;
+ let html='<div style="font-family:var(--px);font-weight:700;font-size:12px;color:var(--muted);margin-bottom:10px;letter-spacing:1px">— PŘEHLED VŠECH HER —</div>';
+ ALL_GAMES.forEach(g=>{
+  let s=null;try{s=JSON.parse(localStorage.getItem(g.key));}catch{}
+  const cur=g.key===SAVE_KEY;
+  html+='<div style="display:flex;align-items:center;gap:10px;padding:7px 0;border-bottom:1px solid var(--line)'+(cur?';font-weight:700':'')+'">' +
+   '<span style="font-size:16px">'+g.ic+'</span>'+
+   '<span style="flex:1;font-size:12px;color:'+(cur?'#fff':'var(--muted)')+'">'+g.nm+(cur?' ◀':'')+'</span>'+
+   (s?'<span style="font-size:12px;color:var(--gold)">LV '+((s.level||1)|0)+' · '+((s.xp||0)|0)+' XP</span>':'<span style="font-size:11px;color:var(--muted)">—</span>')+
+  '</div>';
+ });
+ html+='<a href="rpg-matematika.html" style="display:block;margin-top:10px;color:var(--blue);font-size:12px;font-family:var(--px);text-align:center">🌐 Velitelské centrum – přehled a obchod pro všechny hry</a>';
+ el.innerHTML=html;
+}
 function renderProfile(){
  calcLevel();
  document.getElementById('pr-name').textContent=S.name;
@@ -2431,6 +2453,7 @@ function renderProfile(){
  document.getElementById('pr-ach-t').textContent=ACH.length;
  }
  const rm=document.getElementById('pr-rm');if(rm)rm.checked=!!(S.settings&&S.settings.reducedMotion);
+ renderCrossGames();
 }
 
 function exportCode(){

--- a/projects/rpg-matematika.html
+++ b/projects/rpg-matematika.html
@@ -244,12 +244,12 @@ function render(){
   if(S){
    started++;
    if(HUB_HAS_WALLET) RPGWallet.absorbGame(g.key, S);
-   const lv=S.level||1, xp=S.xp||0;
+   const lv=(S.level||1)|0, xp=(S.xp||0)|0;
    const done=S.done?Object.keys(S.done).length:0;
    const arts=Array.isArray(S.inv)?S.inv.length:0;
    totXp+=xp; totTasks+=done; totArts+=arts;
    const pct=Math.min(100,Math.round(done/TOTAL_TASKS*100));
-   const attrHtml=ATTR.map(([k,ic])=>`<span class="a">${ic} <b>${(S.attrs&&S.attrs[k])||0}</b></span>`).join('');
+   const attrHtml=ATTR.map(([k,ic])=>`<span class="a">${ic} <b>${((S.attrs&&S.attrs[k])||0)|0}</b></span>`).join('');
    body=`<div class="charline"><span class="cn">👤 ${esc(S.name||'HRDINA')}</span><span class="lv">LV ${lv} · ${xp} XP</span></div>
    <div class="attrs">${attrHtml}</div>
    <div class="prog"><div class="pl"><span>POKROK</span><span>${done} / ${TOTAL_TASKS} úkolů · ${pct}%</span></div>
@@ -371,7 +371,7 @@ function renderGlobalProfile(){
  ATTR.forEach(([k])=>{ tot[k]=0; });
  GAMES.forEach(g=>{ const S=load(g.key); if(S&&S.attrs) ATTR.forEach(([k])=>{ tot[k]+=(S.attrs[k]||0); }); });
  document.getElementById('gp-attrs').innerHTML=ATTR.map(([k,ic,label])=>
-  `<span class="a">${ic} ${esc(label)}<br><b>${tot[k]}</b></span>`
+  `<span class="a">${ic} ${esc(label)}<br><b>${tot[k]|0}</b></span>`
  ).join('');
  // odznaky z všech her dohromady
  const allAch={};

--- a/projects/rpg-matematika.html
+++ b/projects/rpg-matematika.html
@@ -161,7 +161,15 @@ body::before{
    <div class="gp-id">
     <span class="gp-av" id="gp-av">🧙</span>
     <div>
-     <div class="gp-name" id="gp-name">TY</div>
+     <div style="display:flex;align-items:center;gap:8px">
+      <div class="gp-name" id="gp-name">TY</div>
+      <button id="gp-edit-btn" onclick="startHeroRename()" title="Přejmenovat hrdinu" style="background:none;border:none;cursor:pointer;font-size:13px;color:var(--muted);padding:0 4px;display:none">✏️</button>
+     </div>
+     <div id="gp-rename" style="display:none;margin-top:4px">
+      <input id="gp-rename-in" maxlength="14" style="width:120px;background:#111;border:1px solid #555;color:#fff;padding:3px 6px;border-radius:4px;font-size:14px;text-transform:uppercase">
+      <button onclick="saveHeroRename()" style="background:var(--accent);border:none;color:#000;padding:3px 10px;border-radius:4px;cursor:pointer;font-size:12px;font-weight:700;margin-left:4px">OK</button>
+      <button onclick="cancelHeroRename()" style="background:#333;border:none;color:#aaa;padding:3px 8px;border-radius:4px;cursor:pointer;font-size:12px;margin-left:2px">✕</button>
+     </div>
      <div class="gp-sub">Tvůj společný profil pro všechny hry</div>
     </div>
    </div>
@@ -372,11 +380,54 @@ function renderGlobalProfile(){
  // VFX přepínač
  const vfxCheck=document.getElementById('gp-vfx');
  if(vfxCheck) vfxCheck.checked=w.settings.reducedMotion;
+ // Edit tlačítko (jen pokud má save)
+ maybeShowEditBtn();
+}
+function maybeShowEditBtn(){
+ const hasAny=GAMES.some(g=>{try{return!!localStorage.getItem(g.key);}catch{return false;}});
+ const btn=document.getElementById('gp-edit-btn');
+ if(btn)btn.style.display=hasAny?'':'none';
 }
 
 if(HUB_HAS_WALLET) RPGWallet.onChange(()=>{ renderGlobalProfile(); renderShop(); });
 
+// Zakázaná slova (základní filtr)
+const BAD_WORDS=['kurva','kokot','pica','suka','prdel','hovno','debil','blbec','idiot','cretin','bastard','asshole','fuck','shit','cunt','dick','bitch','nigger','faggot'];
+function containsBad(str){const lo=str.toLowerCase();return BAD_WORDS.some(w=>lo.includes(w));}
+
+function startHeroRename(){
+  const nameEl=document.getElementById('gp-name');
+  const ri=document.getElementById('gp-rename-in');
+  if(ri)ri.value=nameEl.textContent!=='TY'?nameEl.textContent:'';
+  document.getElementById('gp-edit-btn').style.display='none';
+  document.getElementById('gp-rename').style.display='block';
+  if(ri){ri.focus();ri.select();}
+}
+function cancelHeroRename(){
+  document.getElementById('gp-rename').style.display='none';
+  document.getElementById('gp-edit-btn').style.display='';
+}
+async function saveHeroRename(){
+  const ri=document.getElementById('gp-rename-in');
+  const v=(ri.value||'').trim().toUpperCase().slice(0,14);
+  if(!v){ri.focus();return;}
+  if(containsBad(v)){alert('Toto jméno není povoleno. Zvol jiné.');ri.focus();return;}
+  // Ulož do všech her v localStorage
+  GAMES.forEach(g=>{
+    try{
+      const s=JSON.parse(localStorage.getItem(g.key));
+      if(s){s.name=v;localStorage.setItem(g.key,JSON.stringify(s));
+        // Odešli do cloudu (pokud existuje API)
+        if(window.RPGCloud&&RPGCloud.currentUser&&RPGCloud.currentUser())RPGCloud.push(g.key,s);
+      }
+    }catch{}
+  });
+  cancelHeroRename();
+  renderGlobalProfile();
+}
+
 render();
+setTimeout(maybeShowEditBtn,200);
 </script>
 <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 <script src="./rpg-cloud.js"></script>

--- a/projects/rpg-matematika.html
+++ b/projects/rpg-matematika.html
@@ -439,7 +439,7 @@ function refreshLeaderboards(){
 RPGCloud.attachHub(GAMES.map(g=>g.key), ()=>{render();refreshLeaderboards();}, '.wrap');
 RPGCloud.onChange(u=>{
   const w=document.getElementById('who-where');
-  if(w) w.innerHTML = u ? 'Postavy účtu <b>'+(u.email||'')+'</b>' : 'Postavy uložené na <b>tomto zařízení</b>';
+  if(w) w.innerHTML = u ? 'Postavy účtu <b>'+esc(u.email||'')+'</b>' : 'Postavy uložené na <b>tomto zařízení</b>';
   const tl=document.getElementById('teacher-link');
   if(tl) tl.style.display = RPGCloud.isStaff() ? 'inline-block' : 'none';
   refreshLeaderboards();

--- a/projects/rpg-tasks-6.js
+++ b/projects/rpg-tasks-6.js
@@ -52,12 +52,12 @@ function gen_1_2(){
 function gen_1_3(){
   const tasks=[];
   const a=ri(3,9),b=ri(10,30);
-  tasks.push({text:`V krabici je ${a} sáčků, v každém ${b} bonbónů. Kolik bonbónů je celkem?`,ans:a*b,hints:['Počet sáčků × bonbonů v sáčku.',`${a}·${b} = ${a*b}`],skill:'anal'});
+  tasks.push({text:`V krabici je ${a} ${skl(a,'sáček','sáčky','sáčků')}, v každém ${b} bonbónů. Kolik bonbónů je celkem?`,ans:a*b,hints:['Počet sáčků × bonbonů v sáčku.',`${a}·${b} = ${a*b}`],skill:'anal'});
   const c=ri(50,200),d=ri(3,9);
   const rem=c%d;
   tasks.push({text:`Rozdělíme ${c} kuliček mezi ${d} dětí rovnoměrně. Kolik kuliček zbude?`,ans:rem,hints:['Spočítej zbytek po dělení '+c+' ÷ '+d+'.',`zbytek = ${rem}`],skill:'anal'});
   const e=ri(2,6),f=ri(20,60);
-  tasks.push({text:`Auto ujede za hodinu ${f} km. Kolik km ujede za ${e} hodin?`,ans:e*f,hints:['Vzdálenost = rychlost × čas.',`${e}·${f} = ${e*f} km`],skill:'anal'});
+  tasks.push({text:`Auto ujede za hodinu ${f} km. Kolik km ujede za ${e} ${skl(e,'hodinu','hodiny','hodin')}?`,ans:e*f,hints:['Vzdálenost = rychlost × čas.',`${e}·${f} = ${e*f} km`],skill:'anal'});
   const g=ri(100,500),h=ri(20,80);
   tasks.push({text:`Máš ${g} Kč a utratíš ${h} Kč. Kolik ti zbude?`,ans:g-h,hints:['Odečti utracenou částku.',`${g}−${h} = ${g-h} Kč`],skill:'anal'});
   const k=ri(2,5),l=ri(3,8);

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -59,6 +59,8 @@ body{background:var(--bg);color:var(--text);font-family:var(--px);min-height:100
 .tbl tr:hover td{background:var(--panel)}
 .tbl .nm{font-weight:700;color:#fff}
 .tbl .em{font-size:11px;color:var(--muted)}
+.tbl tr.user-hdr td{background:rgba(255,255,255,0.04);border-top:1px solid var(--line)}
+.tbl tr.user-hdr.exp td{background:rgba(50,180,255,0.08)}
 .tag{display:inline-block;font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px;color:#06101e}
 .bar{height:7px;background:#0006;border:1px solid var(--line);border-radius:5px;overflow:hidden;min-width:80px}
 .bar > i{display:block;height:100%;background:var(--accent)}
@@ -473,6 +475,8 @@ function filtered(){
 }
 const SEL=new Set();              // klíče vybraných postav: user_id|game
 function selKey(r){return r.user_id+'|'+r.game;}
+const EXPANDED_USERS=new Set();   // user_id → expanded in table
+function toggleUserRow(uid){if(EXPANDED_USERS.has(uid))EXPANDED_USERS.delete(uid);else EXPANDED_USERS.add(uid);renderTable();}
 function renderTable(){
  const rows=filtered();
  if(!rows.length){document.getElementById('tbl-wrap').innerHTML='<div class="empty">— žádné postavy —</div>';window.__filtered=rows;updateBulkBar();return;}
@@ -480,36 +484,76 @@ function renderTable(){
  // vyčisti výběr od postav, které zmizely z filtru
  const keys=new Set(rows.map(selKey));
  [...SEL].forEach(k=>{if(!keys.has(k))SEL.delete(k);});
+ // skupiny podle user_id
+ const userMap=new Map();
+ rows.forEach((r,i)=>{
+  if(!userMap.has(r.user_id))userMap.set(r.user_id,{uid:r.user_id,email:r.email||'',name:r.full_name||'',rows:[]});
+  const u=userMap.get(r.user_id);
+  if(r.full_name&&!u.name)u.name=r.full_name;
+  u.rows.push({r,i});
+ });
+ const COLS=admin?9:8;
  let html='<table class="tbl"><thead><tr>'+
    (admin?'<th style="width:28px"><input type="checkbox" id="sel-all" onclick="toggleSelAll(this.checked)" title="vybrat vše"></th>':'')+
-   '<th>Žák</th><th>Hra</th><th>LV</th><th>XP</th><th>Pokrok</th><th>Mistrovství</th><th>Poslední aktivita</th><th>Akce</th></tr></thead><tbody>';
- rows.forEach((r,i)=>{
-  const g=gMeta(r.game), d=r.data||{}, p=pct(d);
-  const mc=masteryCount(d), totalM=missionsFor(r.game).length||21;
-  const mastCell=mc>0
-   ?'<span style="color:var(--gold);font-weight:700">'+mc+'</span><span style="color:var(--muted)">/'+totalM+' 🏅</span>'
-   :'<span style="color:var(--muted)">0/'+totalM+'</span>';
-  const checked=SEL.has(selKey(r))?' checked':'';
-  html+='<tr>'+
-   (admin?'<td><input type="checkbox" class="sel-row" data-i="'+i+'" onclick="toggleSel('+i+',this.checked)"'+checked+'></td>':'')+
-   '<td><div class="nm">'+esc(d.name||'—')+'</div><div class="em">'+esc(r.full_name||r.email||'')+'</div></td>'+
-   '<td><span class="tag" style="background:'+g.accent+'">'+g.emoji+' '+g.gr+'</span></td>'+
-   '<td>'+(d.level||1)+'</td>'+
-   '<td>'+(d.xp||0)+'</td>'+
-   '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+p+'%;background:'+g.accent+'"></i></div><span style="font-size:11px;color:var(--muted)">'+p+'%</span></div></td>'+
-   '<td style="font-size:13px">'+mastCell+'</td>'+
-   '<td style="font-size:12px;color:var(--muted)">'+onlineDot(r.updated_at)+fmtDate(r.updated_at)+'</td>'+
-   '<td><div class="rowbtns">'+
-     '<button class="mini" onclick="openDetail('+i+')">Detail</button>'+
-     '<a class="mini" style="text-decoration:none" target="_blank" href="'+g.file+'?su='+encodeURIComponent(r.user_id)+'">👁 Náhled</a>'+
-     (admin?'<button class="mini red" onclick="delChar('+i+')">🗑</button>':'')+
-   '</div></td></tr>';
+   '<th>Žák</th><th>Hry</th><th>LV</th><th>Celkem XP</th><th>Pokrok</th><th>Mistrovství</th><th>Poslední aktivita</th><th>Akce</th></tr></thead><tbody>';
+ userMap.forEach(u=>{
+  const expanded=EXPANDED_USERS.has(u.uid);
+  const lastAt=u.rows.reduce((m,x)=>(x.r.updated_at||'')>(m||'')?x.r.updated_at:m,'');
+  const totalXP=u.rows.reduce((s,x)=>s+((x.r.data||{}).xp||0),0);
+  const totalMast=u.rows.reduce((s,x)=>s+masteryCount(x.r.data||{}),0);
+  const maxLv=u.rows.reduce((m,x)=>Math.max(m,(x.r.data||{}).level||1),1);
+  const avgPct=Math.round(u.rows.reduce((s,x)=>s+pct(x.r.data||{}),0)/u.rows.length);
+  // gamečipy
+  const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};return '<span class="tag" style="background:'+g.accent+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+(d.level||1)+'</span>';}).join(' ');
+  // checkbox pro všechny hry uživatele
+  const allSel=u.rows.every(x=>SEL.has(selKey(x.r)));
+  const someSel=!allSel&&u.rows.some(x=>SEL.has(selKey(x.r)));
+  const selAttr=allSel?' checked':someSel?' data-indeterminate="1"':'';
+  html+='<tr class="user-hdr'+(expanded?' exp':'')+'" style="cursor:pointer" onclick="toggleUserRow(\''+esc(u.uid)+'\')">'+
+   (admin?'<td onclick="event.stopPropagation()"><input type="checkbox" class="sel-user" data-uid="'+esc(u.uid)+'" onclick="toggleSelUser(\''+esc(u.uid)+'\',this.checked)"'+selAttr+'></td>':'')+
+   '<td><div class="nm" style="font-weight:700">'+esc(u.name||'—')+'</div><div class="em">'+esc(u.email)+'</div></td>'+
+   '<td style="white-space:nowrap">'+chips+'</td>'+
+   '<td>'+maxLv+'</td>'+
+   '<td>'+totalXP+'</td>'+
+   '<td><div style="display:flex;align-items:center;gap:6px"><div class="bar" style="flex:1;min-width:60px"><i style="width:'+avgPct+'%;background:#888"></i></div><span style="font-size:11px;color:var(--muted)">'+avgPct+'%</span></div></td>'+
+   '<td style="font-size:13px">'+(totalMast>0?'<span style="color:var(--gold);font-weight:700">'+totalMast+'</span> 🏅':'<span style="color:var(--muted)">0</span>')+'</td>'+
+   '<td style="font-size:12px;color:var(--muted)">'+onlineDot(lastAt)+fmtDate(lastAt)+'</td>'+
+   '<td><span style="font-size:12px;color:var(--muted)">'+(expanded?'▲ sbalit':'▶ '+u.rows.length+' '+(u.rows.length===1?'hra':'hry'))+'</span></td></tr>';
+  if(expanded){
+   u.rows.forEach(({r,i})=>{
+    const g=gMeta(r.game),d=r.data||{},p=pct(d);
+    const mc=masteryCount(d),totalM=missionsFor(r.game).length||21;
+    const mastCell=mc>0?'<span style="color:var(--gold);font-weight:700">'+mc+'</span><span style="color:var(--muted)">/'+totalM+' 🏅</span>':'<span style="color:var(--muted)">0/'+totalM+'</span>';
+    const checked=SEL.has(selKey(r))?' checked':'';
+    html+='<tr style="background:rgba(0,0,0,0.15)">'+
+     (admin?'<td><input type="checkbox" class="sel-row" data-i="'+i+'" onclick="event.stopPropagation();toggleSel('+i+',this.checked)"'+checked+'></td>':'')+
+     '<td style="padding-left:28px"><div class="em" style="font-size:11px">'+esc(d.name||'—')+'</div></td>'+
+     '<td><span class="tag" style="background:'+g.accent+'">'+g.emoji+' '+g.gr+'</span></td>'+
+     '<td>'+(d.level||1)+'</td>'+
+     '<td>'+(d.xp||0)+'</td>'+
+     '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+p+'%;background:'+g.accent+'"></i></div><span style="font-size:11px;color:var(--muted)">'+p+'%</span></div></td>'+
+     '<td style="font-size:13px">'+mastCell+'</td>'+
+     '<td style="font-size:12px;color:var(--muted)">'+onlineDot(r.updated_at)+fmtDate(r.updated_at)+'</td>'+
+     '<td><div class="rowbtns">'+
+       '<button class="mini" onclick="openDetail('+i+')">Detail</button>'+
+       '<a class="mini" style="text-decoration:none" target="_blank" href="'+g.file+'?su='+encodeURIComponent(r.user_id)+'">👁 Náhled</a>'+
+       (admin?'<button class="mini red" onclick="delChar('+i+')">🗑</button>':'')+
+     '</div></td></tr>';
+   });
+  }
  });
  html+='</tbody></table>';
  document.getElementById('tbl-wrap').innerHTML=html;
+ // obnov indeterminate checkbox stav
+ document.querySelectorAll('.sel-user[data-indeterminate="1"]').forEach(cb=>{cb.indeterminate=true;});
  window.__filtered=rows;
  updateBulkBar();
 }
+function toggleSelUser(uid,on){
+ ROWS.filter(r=>r.user_id===uid&&keys_filtered().has(selKey(r))).forEach(r=>{if(on)SEL.add(selKey(r));else SEL.delete(selKey(r));});
+ renderTable();
+}
+function keys_filtered(){return new Set((window.__filtered||[]).map(selKey));}
 
 /* ── hromadné akce (jen superadmin) ── */
 function toggleSel(i,on){
@@ -519,12 +563,12 @@ function toggleSel(i,on){
 }
 function toggleSelAll(on){
  (window.__filtered||[]).forEach(r=>{if(on)SEL.add(selKey(r));else SEL.delete(selKey(r));});
- document.querySelectorAll('.sel-row').forEach(cb=>{cb.checked=on;});
+ document.querySelectorAll('.sel-row,.sel-user').forEach(cb=>{cb.checked=on;cb.indeterminate=false;});
  updateBulkBar();
 }
 function clearSel(){
  SEL.clear();
- document.querySelectorAll('.sel-row').forEach(cb=>{cb.checked=false;});
+ document.querySelectorAll('.sel-row,.sel-user').forEach(cb=>{cb.checked=false;cb.indeterminate=false;});
  const a=document.getElementById('sel-all');if(a)a.checked=false;
  updateBulkBar();
 }

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -839,7 +839,7 @@ async function loadTeachers(){
  let html='<table class="tbl"><thead><tr><th>E-mail</th><th>Role</th><th>Přidal</th><th></th></tr></thead><tbody>';
  list.forEach(t=>{
   html+='<tr><td class="nm">'+esc(t.email)+'</td>'+
-   '<td><span class="tag" style="background:'+(t.role==='superadmin'?'var(--gold)':'var(--accent)')+'">'+t.role+'</span></td>'+
+   '<td><span class="tag" style="background:'+(t.role==='superadmin'?'var(--gold)':'var(--accent)')+'">'+esc(t.role)+'</span></td>'+
    '<td class="em">'+esc(t.added_by||'')+'</td>'+
    '<td><button class="mini red" onclick="delTeacher(\''+esc(t.email)+'\')">odebrat</button></td></tr>';
  });
@@ -978,28 +978,28 @@ function renderClasses(){
     cohortBadge+
     '<span class="tag" style="background:var(--accent)">'+mem.size+' žáků</span>'+
     '<div style="margin-left:auto;display:flex;gap:6px">'+
-     '<button class="mini gold" onclick="toggleRoster(\''+c.id+'\')">'+(open?'▲ hotovo':'👥 spravovat žáky')+'</button>'+
-     '<button class="mini" onclick="editCohortUI(\''+c.id+'\')" title="ročník / automatický posun">📈</button>'+
-     '<button class="mini" onclick="renameClassUI(\''+c.id+'\')" title="přejmenovat">✎</button>'+
-     '<button class="mini red" onclick="deleteClassUI(\''+c.id+'\')">🗑</button>'+
+     '<button class="mini gold" onclick="toggleRoster(\''+esc(c.id)+'\')">'+(open?'▲ hotovo':'👥 spravovat žáky')+'</button>'+
+     '<button class="mini" onclick="editCohortUI(\''+esc(c.id)+'\')" title="ročník / automatický posun">📈</button>'+
+     '<button class="mini" onclick="renameClassUI(\''+esc(c.id)+'\')" title="přejmenovat">✎</button>'+
+     '<button class="mini red" onclick="deleteClassUI(\''+esc(c.id)+'\')">🗑</button>'+
     '</div>'+
    '</div>';
   // akce pro celou třídu
   html+='<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-top:10px">'+
    '<span style="color:var(--muted);font-size:12px">Hromadně třídě:</span>'+
-   '<button class="mini gold" onclick="classAwardXp(\''+c.id+'\')">⭐ +XP</button>';
+   '<button class="mini gold" onclick="classAwardXp(\''+esc(c.id)+'\')">⭐ +XP</button>';
   if(grade>=6&&grade<=9){
    const missions=missionsFor('RPG_MAT_'+grade);
    let opts='<option value="">— mise '+grade+'. roč. —</option>';
    missions.forEach(m=>{opts+='<option value="'+m.id+'">'+m.id+' '+esc(m.name)+'</option>';});
-   html+='<select id="cls-mid-'+c.id+'" style="max-width:220px">'+opts+'</select>'+
-    '<button class="mini gold" onclick="classUnlock(\''+c.id+'\')">🔓 Odemknout třídě</button>';
+   html+='<select id="cls-mid-'+esc(c.id)+'" style="max-width:220px">'+opts+'</select>'+
+    '<button class="mini gold" onclick="classUnlock(\''+esc(c.id)+'\')">🔓 Odemknout třídě</button>';
   }
-  if(admin)html+='<button class="mini red" onclick="classDeleteChars(\''+c.id+'\')">🗑 Smazat postavy třídy</button>';
+  if(admin)html+='<button class="mini red" onclick="classDeleteChars(\''+esc(c.id)+'\')">🗑 Smazat postavy třídy</button>';
   html+='</div>'+
    '<div style="display:flex;gap:6px;align-items:center;margin-top:8px">'+
-    '<input id="cls-note-'+c.id+'" placeholder="📨 Vzkaz celé třídě…" style="flex:1;padding:5px 8px;border-radius:6px;border:1px solid var(--line);background:var(--bg);color:#fff;font-size:13px">'+
-    '<button class="mini gold" onclick="classNote(\''+c.id+'\')">Odeslat</button>'+
+    '<input id="cls-note-'+esc(c.id)+'" placeholder="📨 Vzkaz celé třídě…" style="flex:1;padding:5px 8px;border-radius:6px;border:1px solid var(--line);background:var(--bg);color:#fff;font-size:13px">'+
+    '<button class="mini gold" onclick="classNote(\''+esc(c.id)+'\')">Odeslat</button>'+
    '</div>';
   if(open){
    if(!students.length){html+='<div class="empty" style="margin-top:10px">— žádní žáci zatím nehráli —</div>';}
@@ -1008,7 +1008,7 @@ function renderClasses(){
     students.forEach(s=>{
      const inC=mem.has(s.user_id);
      html+='<label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;padding:4px 6px;border-radius:4px;background:'+(inC?'rgba(244,208,63,.12)':'transparent')+'">'+
-      '<input type="checkbox"'+(inC?' checked':'')+' onclick="toggleMember(\''+c.id+'\',\''+s.user_id+'\',this.checked)">'+
+      '<input type="checkbox"'+(inC?' checked':'')+' onclick="toggleMember(\''+esc(c.id)+'\',\''+esc(s.user_id)+'\',this.checked)">'+
       '<span><b style="color:#fff">'+esc(s.name||'—')+'</b> <span style="color:var(--muted);font-size:11px">'+esc(s.email||'')+'</span></span>'+
      '</label>';
     });

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -736,14 +736,14 @@ function openDetail(i){
  document.getElementById('modal').innerHTML=
   '<button class="close" onclick="closeModal()">✕</button>'+
   '<h3>'+g.emoji+' '+esc(d.name||'—')+'</h3>'+
-  '<div class="msub">'+esc(r.full_name||'')+' · '+esc(r.email||'')+' · '+g.nm+'</div>'+
-  '<div class="row"><span>Level</span><b>'+(d.level||1)+'</b></div>'+
-  '<div class="row"><span>XP</span><b>'+(d.xp||0)+'</b></div>'+
-  '<div class="row"><span>Splněno úkolů</span><b>'+doneCount(d)+' / '+TOTAL_TASKS+' ('+pct(d)+' %)</b></div>'+
+  '<div class="msub">'+esc(r.full_name||'')+' · '+esc(r.email||'')+' · '+esc(g.nm)+'</div>'+
+  '<div class="row"><span>Level</span><b>'+((d.level||1)|0)+'</b></div>'+
+  '<div class="row"><span>XP</span><b>'+((d.xp||0)|0)+'</b></div>'+
+  '<div class="row"><span>Splněno úkolů</span><b>'+(doneCount(d)|0)+' / '+TOTAL_TASKS+' ('+(pct(d)|0)+' %)</b></div>'+
   '<div class="row"><span>Artefakty</span><b>'+(inv.length?esc(inv.join(', ')):'—')+'</b></div>'+
   (Array.isArray(d.teacherUnlocked)&&d.teacherUnlocked.length?'<div class="row"><span>Odemčeno učitelem</span><b style="color:var(--gold)">🔓 '+esc(d.teacherUnlocked.join(', '))+'</b></div>':'')+
   '<div class="row"><span>Třídy</span><b>'+([...classesOfUser(r.user_id)].map(cid=>'🏫 '+esc(classNameOf(cid))).join(', ')||'<span style="color:var(--muted)">— žádná —</span>')+'</b></div>'+
-  '<div class="row"><span>Poslední aktivita</span><b>'+fmtDate(r.updated_at)+'</b></div>'+
+  '<div class="row"><span>Poslední aktivita</span><b>'+esc(fmtDate(r.updated_at))+'</b></div>'+
   '<h4>Atributy</h4>'+attrHtml+
   (MISSIONS_BY_GAME[r.game]?buildMasteryHtml(d,r.game):'')+
   buildUnlockHtml(r)+

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -476,10 +476,17 @@ function filtered(){
 const SEL=new Set();              // klíče vybraných postav: user_id|game
 function selKey(r){return r.user_id+'|'+r.game;}
 const EXPANDED_USERS=new Set();   // user_id → expanded in table
-function toggleUserRow(uid){if(EXPANDED_USERS.has(uid))EXPANDED_USERS.delete(uid);else EXPANDED_USERS.add(uid);renderTable();}
+// toggleUserRow/toggleSelUser přijímají číselný index do window.__userList (žádná uživatelská data v onclick)
+function toggleUserRow(ui){const u=window.__userList&&window.__userList[ui];if(!u)return;if(EXPANDED_USERS.has(u.uid))EXPANDED_USERS.delete(u.uid);else EXPANDED_USERS.add(u.uid);renderTable();}
+function toggleSelUser(ui,on){
+ const u=window.__userList&&window.__userList[ui];if(!u)return;
+ ROWS.filter(r=>r.user_id===u.uid&&keys_filtered().has(selKey(r))).forEach(r=>{if(on)SEL.add(selKey(r));else SEL.delete(selKey(r));});
+ renderTable();
+}
+function keys_filtered(){return new Set((window.__filtered||[]).map(selKey));}
 function renderTable(){
  const rows=filtered();
- if(!rows.length){document.getElementById('tbl-wrap').innerHTML='<div class="empty">— žádné postavy —</div>';window.__filtered=rows;updateBulkBar();return;}
+ if(!rows.length){document.getElementById('tbl-wrap').innerHTML='<div class="empty">— žádné postavy —</div>';window.__filtered=rows;window.__userList=[];updateBulkBar();return;}
  const admin=RPGCloud.isAdmin();
  // vyčisti výběr od postav, které zmizely z filtru
  const keys=new Set(rows.map(selKey));
@@ -492,25 +499,26 @@ function renderTable(){
   if(r.full_name&&!u.name)u.name=r.full_name;
   u.rows.push({r,i});
  });
- const COLS=admin?9:8;
+ // uložíme indexovatelný seznam (onclick používá jen číslo, nikoliv uid)
+ const userList=[...userMap.values()];
+ window.__userList=userList;
  let html='<table class="tbl"><thead><tr>'+
    (admin?'<th style="width:28px"><input type="checkbox" id="sel-all" onclick="toggleSelAll(this.checked)" title="vybrat vše"></th>':'')+
    '<th>Žák</th><th>Hry</th><th>LV</th><th>Celkem XP</th><th>Pokrok</th><th>Mistrovství</th><th>Poslední aktivita</th><th>Akce</th></tr></thead><tbody>';
- userMap.forEach(u=>{
+ userList.forEach((u,ui)=>{
   const expanded=EXPANDED_USERS.has(u.uid);
   const lastAt=u.rows.reduce((m,x)=>(x.r.updated_at||'')>(m||'')?x.r.updated_at:m,'');
   const totalXP=u.rows.reduce((s,x)=>s+((x.r.data||{}).xp||0),0);
   const totalMast=u.rows.reduce((s,x)=>s+masteryCount(x.r.data||{}),0);
   const maxLv=u.rows.reduce((m,x)=>Math.max(m,(x.r.data||{}).level||1),1);
   const avgPct=Math.round(u.rows.reduce((s,x)=>s+pct(x.r.data||{}),0)/u.rows.length);
-  // gamečipy
   const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};return '<span class="tag" style="background:'+g.accent+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+(d.level||1)+'</span>';}).join(' ');
-  // checkbox pro všechny hry uživatele
   const allSel=u.rows.every(x=>SEL.has(selKey(x.r)));
   const someSel=!allSel&&u.rows.some(x=>SEL.has(selKey(x.r)));
   const selAttr=allSel?' checked':someSel?' data-indeterminate="1"':'';
-  html+='<tr class="user-hdr'+(expanded?' exp':'')+'" style="cursor:pointer" onclick="toggleUserRow(\''+esc(u.uid)+'\')">'+
-   (admin?'<td onclick="event.stopPropagation()"><input type="checkbox" class="sel-user" data-uid="'+esc(u.uid)+'" onclick="toggleSelUser(\''+esc(u.uid)+'\',this.checked)"'+selAttr+'></td>':'')+
+  // onclick obsahuje pouze číselný index ui (bezpečné, žádná uživatelská data)
+  html+='<tr class="user-hdr'+(expanded?' exp':'')+'" style="cursor:pointer" onclick="toggleUserRow('+ui+')">'+
+   (admin?'<td onclick="event.stopPropagation()"><input type="checkbox" class="sel-user" data-ui="'+ui+'" onclick="toggleSelUser('+ui+',this.checked)"'+selAttr+'></td>':'')+
    '<td><div class="nm" style="font-weight:700">'+esc(u.name||'—')+'</div><div class="em">'+esc(u.email)+'</div></td>'+
    '<td style="white-space:nowrap">'+chips+'</td>'+
    '<td>'+maxLv+'</td>'+
@@ -544,16 +552,10 @@ function renderTable(){
  });
  html+='</tbody></table>';
  document.getElementById('tbl-wrap').innerHTML=html;
- // obnov indeterminate checkbox stav
  document.querySelectorAll('.sel-user[data-indeterminate="1"]').forEach(cb=>{cb.indeterminate=true;});
  window.__filtered=rows;
  updateBulkBar();
 }
-function toggleSelUser(uid,on){
- ROWS.filter(r=>r.user_id===uid&&keys_filtered().has(selKey(r))).forEach(r=>{if(on)SEL.add(selKey(r));else SEL.delete(selKey(r));});
- renderTable();
-}
-function keys_filtered(){return new Set((window.__filtered||[]).map(selKey));}
 
 /* ── hromadné akce (jen superadmin) ── */
 function toggleSel(i,on){

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -508,11 +508,11 @@ function renderTable(){
  userList.forEach((u,ui)=>{
   const expanded=EXPANDED_USERS.has(u.uid);
   const lastAt=u.rows.reduce((m,x)=>(x.r.updated_at||'')>(m||'')?x.r.updated_at:m,'');
-  const totalXP=u.rows.reduce((s,x)=>s+((x.r.data||{}).xp||0),0);
-  const totalMast=u.rows.reduce((s,x)=>s+masteryCount(x.r.data||{}),0);
-  const maxLv=u.rows.reduce((m,x)=>Math.max(m,(x.r.data||{}).level||1),1);
-  const avgPct=Math.round(u.rows.reduce((s,x)=>s+pct(x.r.data||{}),0)/u.rows.length);
-  const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};return '<span class="tag" style="background:'+g.accent+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+(d.level||1)+'</span>';}).join(' ');
+  const totalXP=(u.rows.reduce((s,x)=>s+((x.r.data||{}).xp||0),0))|0;
+  const totalMast=(u.rows.reduce((s,x)=>s+masteryCount(x.r.data||{}),0))|0;
+  const maxLv=(u.rows.reduce((m,x)=>Math.max(m,(x.r.data||{}).level||1),1))|0;
+  const avgPct=(Math.round(u.rows.reduce((s,x)=>s+pct(x.r.data||{}),0)/u.rows.length))|0;
+  const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};const lv=((d.level||1)|0);return '<span class="tag" style="background:'+g.accent+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+lv+'</span>';}).join(' ');
   const allSel=u.rows.every(x=>SEL.has(selKey(x.r)));
   const someSel=!allSel&&u.rows.some(x=>SEL.has(selKey(x.r)));
   const selAttr=allSel?' checked':someSel?' data-indeterminate="1"':'';
@@ -525,7 +525,7 @@ function renderTable(){
    '<td>'+totalXP+'</td>'+
    '<td><div style="display:flex;align-items:center;gap:6px"><div class="bar" style="flex:1;min-width:60px"><i style="width:'+avgPct+'%;background:#888"></i></div><span style="font-size:11px;color:var(--muted)">'+avgPct+'%</span></div></td>'+
    '<td style="font-size:13px">'+(totalMast>0?'<span style="color:var(--gold);font-weight:700">'+totalMast+'</span> 🏅':'<span style="color:var(--muted)">0</span>')+'</td>'+
-   '<td style="font-size:12px;color:var(--muted)">'+onlineDot(lastAt)+fmtDate(lastAt)+'</td>'+
+   '<td style="font-size:12px;color:var(--muted)">'+onlineDot(lastAt)+esc(fmtDate(lastAt))+'</td>'+
    '<td><span style="font-size:12px;color:var(--muted)">'+(expanded?'▲ sbalit':'▶ '+u.rows.length+' '+(u.rows.length===1?'hra':'hry'))+'</span></td></tr>';
   if(expanded){
    u.rows.forEach(({r,i})=>{
@@ -537,11 +537,11 @@ function renderTable(){
      (admin?'<td><input type="checkbox" class="sel-row" data-i="'+i+'" onclick="event.stopPropagation();toggleSel('+i+',this.checked)"'+checked+'></td>':'')+
      '<td style="padding-left:28px"><div class="em" style="font-size:11px">'+esc(d.name||'—')+'</div></td>'+
      '<td><span class="tag" style="background:'+g.accent+'">'+g.emoji+' '+g.gr+'</span></td>'+
-     '<td>'+(d.level||1)+'</td>'+
-     '<td>'+(d.xp||0)+'</td>'+
-     '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+p+'%;background:'+g.accent+'"></i></div><span style="font-size:11px;color:var(--muted)">'+p+'%</span></div></td>'+
+     '<td>'+((d.level||1)|0)+'</td>'+
+     '<td>'+((d.xp||0)|0)+'</td>'+
+     '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+(p|0)+'%;background:'+g.accent+'"></i></div><span style="font-size:11px;color:var(--muted)">'+(p|0)+'%</span></div></td>'+
      '<td style="font-size:13px">'+mastCell+'</td>'+
-     '<td style="font-size:12px;color:var(--muted)">'+onlineDot(r.updated_at)+fmtDate(r.updated_at)+'</td>'+
+     '<td style="font-size:12px;color:var(--muted)">'+onlineDot(r.updated_at)+esc(fmtDate(r.updated_at))+'</td>'+
      '<td><div class="rowbtns">'+
        '<button class="mini" onclick="openDetail('+i+')">Detail</button>'+
        '<a class="mini" style="text-decoration:none" target="_blank" href="'+g.file+'?su='+encodeURIComponent(r.user_id)+'">👁 Náhled</a>'+

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -697,11 +697,11 @@ function buildMasteryHtml(d,gameKey){
  const unmastered=missionsFor(gameKey).filter(m=>!(d.mastery&&d.mastery[m.id]&&d.mastery[m.id].mastered));
  let pills='';
  mastered.forEach(m=>{
-  const score=(d.mastery[m.id]&&d.mastery[m.id].score)||0;
+  const score=((d.mastery[m.id]&&d.mastery[m.id].score)||0)|0;
   pills+='<span title="skóre: '+score+'" style="display:inline-block;font-size:11px;font-weight:700;padding:3px 8px;border-radius:20px;margin:2px;background:var(--gold);color:#06101e">🏅 '+esc(m.id)+' '+esc(m.name)+'</span>';
  });
  unmastered.forEach(m=>{
-  const score=(d.mastery&&d.mastery[m.id]&&d.mastery[m.id].score)||0;
+  const score=((d.mastery&&d.mastery[m.id]&&d.mastery[m.id].score)||0)|0;
   const bar=score>0?'<span style="color:var(--muted);font-size:10px"> ('+score+'/15)</span>':'';
   pills+='<span style="display:inline-block;font-size:11px;padding:3px 8px;border-radius:20px;margin:2px;background:var(--panel2);color:var(--muted);border:1px solid var(--line)">'+esc(m.id)+''+bar+'</span>';
  });
@@ -728,7 +728,7 @@ function buildMasteryHtml(d,gameKey){
 function openDetail(i){
  const r=window.__filtered[i];if(!r)return;
  const g=gMeta(r.game), d=r.data||{}, admin=RPGCloud.isAdmin();
- const attrHtml=ATTR.map(([k,lbl])=>'<div class="row"><span>'+lbl+'</span><b>'+((d.attrs&&d.attrs[k])||0)+'</b></div>').join('');
+ const attrHtml=ATTR.map(([k,lbl])=>'<div class="row"><span>'+lbl+'</span><b>'+((d.attrs&&d.attrs[k]||0)|0)+'</b></div>').join('');
  const inv=Array.isArray(d.inv)?d.inv:[];
  let admHtml='';
  if(admin){
@@ -736,7 +736,7 @@ function openDetail(i){
    '<h4>Odměny a úpravy (superadmin)</h4>'+
    '<div class="actrow"><input type="number" id="adj-xp" placeholder="±XP" value="100"><button class="mini gold" onclick="giveXP('+i+')">Přidat XP</button>'+
      '<span style="font-size:11px;color:var(--muted)">level se dopočítá z XP</span></div>'+
-   (()=>{const arts=ARTIFACTS_BY_GAME[r.game]||[];const opts='<option value="">— vybrat artefakt —</option>'+arts.map(a=>'<option value="'+a.id+'"'+(inv.includes(a.id)?' disabled':'')+'>'+esc(a.id)+' – '+esc(a.nm)+'</option>').join('');return '<div class="actrow"><select id="adj-item" style="font-family:inherit;font-size:13px;padding:7px 9px;border-radius:5px;border:1px solid var(--line);background:var(--panel2);color:var(--text);flex:1">'+opts+'</select><button class="mini gold" onclick="giveItem('+i+')">+ Artefakt</button></div>';})()+'
+   (()=>{const arts=ARTIFACTS_BY_GAME[r.game]||[];const opts='<option value="">— vybrat artefakt —</option>'+arts.map(a=>'<option value="'+esc(a.id)+'"'+(inv.includes(a.id)?' disabled':'')+'>'+esc(a.id)+' – '+esc(a.nm)+'</option>').join('');return '<div class="actrow"><select id="adj-item" style="font-family:inherit;font-size:13px;padding:7px 9px;border-radius:5px;border:1px solid var(--line);background:var(--panel2);color:var(--text);flex:1">'+opts+'</select><button class="mini gold" onclick="giveItem('+i+')">+ Artefakt</button></div>';})()+'
    '<div class="actrow"><button class="mini red" onclick="delChar('+i+')">🗑 Smazat celou postavu</button></div>';
  }
  document.getElementById('modal').innerHTML=

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -765,8 +765,8 @@ async function loadNotes(uid){
   '<div style="background:var(--panel2);border:1px solid var(--line);border-radius:6px;padding:8px 10px;margin:6px 0">'+
    '<div style="font-size:13px;color:var(--text);line-height:1.5">'+esc(n.body)+'</div>'+
    '<div style="display:flex;justify-content:space-between;align-items:center;margin-top:6px">'+
-    '<span style="font-size:11px;color:var(--muted)">'+esc(n.author_name||n.author_email||'')+' · '+fmtDate(n.created_at)+'</span>'+
-    '<button class="mini red" onclick="delNoteUI(\''+n.id+'\',\''+uid+'\')">smazat</button>'+
+    '<span style="font-size:11px;color:var(--muted)">'+esc(n.author_name||n.author_email||'')+' · '+esc(fmtDate(n.created_at))+'</span>'+
+    '<button class="mini red" onclick="delNoteUI(\''+esc(n.id)+'\',\''+esc(uid)+'\')">smazat</button>'+
    '</div>'+
   '</div>').join('');
 }

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -703,7 +703,7 @@ function buildMasteryHtml(d,gameKey){
  if(d.errs&&Object.keys(d.errs).length){
   const errs=Object.entries(d.errs).filter(([,v])=>v>0).sort((a,b)=>b[1]-a[1]);
   if(errs.length){
-   const errPills=errs.map(([mid,cnt])=>{
+   const errPills=errs.map(([mid,cntRaw])=>{const cnt=cntRaw|0; // |0 kills taint
     const mObj=missionsFor(gameKey).find(m=>m.id===mid);
     const nm=mObj?mObj.name:mid;
     const col=cnt>=4?'var(--red)':cnt>=2?'var(--gold)':'var(--muted)';

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -1048,19 +1048,19 @@ function renderDiag(){
     if(sn.length>=3){const b=(sn[sn.length-2].errs||{})[m.id]||0,c=(sn[sn.length-3].errs||{})[m.id]||0;prev+=Math.max(0,b-c);hasPrev=true;}
    });
    const avg=reached?totErr/reached:0;
-   const hue=Math.max(0,120-Math.min(120,avg*30)); // 0 chyb→zelená, ~4 chyby→červená
+   const hue=(Math.max(0,120-Math.min(120,avg*30)))|0; // 0 chyb→zelená, ~4 chyby→červená, |0 kills taint
    const bg=reached?'hsl('+hue+',65%,20%)':'#161b2e';
    const bd=reached?'hsl('+hue+',65%,42%)':'#2a3450';
    let trendHtml='';
    if(hasTrend){
     let ar='',tcol='var(--muted)';
-    if(hasPrev){ar=recent<prev?'🔽 ':recent>prev?'🔺 ':'▶️ ';tcol=recent<prev?'#5fd38a':recent>prev?'#ff7a7a':'var(--muted)';}
-    trendHtml='<div style="font-size:11px;color:'+tcol+';margin-top:3px">'+ar+'nově +'+recent+' chyb'+(hasPrev?(' (minule +'+prev+')'):' za období')+'</div>';
+    if(hasPrev){ar=(recent|0)<(prev|0)?'🔽 ':(recent|0)>(prev|0)?'🔺 ':'▶️ ';tcol=(recent|0)<(prev|0)?'#5fd38a':(recent|0)>(prev|0)?'#ff7a7a':'var(--muted)';}
+    trendHtml='<div style="font-size:11px;color:'+tcol+';margin-top:3px">'+ar+'nově +'+(recent|0)+' chyb'+(hasPrev?(' (minule +'+(prev|0)+')'):' za období')+'</div>';
    }
    cells+='<div style="background:'+bg+';border:1px solid '+bd+';border-radius:7px;padding:9px 11px">'+
     '<div style="font-weight:700;font-size:13px;color:#fff;margin-bottom:4px">'+m.id+' · '+esc(m.name)+'</div>'+
     '<div style="font-size:12px;color:var(--muted)">'+
-    (reached?('✅ '+completed+'/'+reached+' dokončilo · ⌀ '+avg.toFixed(1)+' chyb'):'zatím nikdo nezkoušel')+
+    (reached?('✅ '+(completed|0)+'/'+(reached|0)+' dokončilo · ⌀ '+esc(avg.toFixed(1))+' chyb'):'zatím nikdo nezkoušel')+
     '</div>'+trendHtml+'</div>';
   });
   html+='<div style="margin-bottom:14px"><div style="font-weight:700;color:var(--gold);font-size:13px;margin-bottom:7px">Oblast '+area+'</div>'+

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -512,7 +512,7 @@ function renderTable(){
   const totalMast=(u.rows.reduce((s,x)=>s+masteryCount(x.r.data||{}),0))|0;
   const maxLv=(u.rows.reduce((m,x)=>Math.max(m,(x.r.data||{}).level||1),1))|0;
   const avgPct=(Math.round(u.rows.reduce((s,x)=>s+pct(x.r.data||{}),0)/u.rows.length))|0;
-  const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};const lv=((d.level||1)|0);return '<span class="tag" style="background:'+g.accent+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+lv+'</span>';}).join(' ');
+  const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};const lv=((d.level||1)|0);return '<span class="tag" style="background:'+esc(g.accent||'#888')+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+lv+'</span>';}).join(' ');
   const allSel=u.rows.every(x=>SEL.has(selKey(x.r)));
   const someSel=!allSel&&u.rows.some(x=>SEL.has(selKey(x.r)));
   const selAttr=allSel?' checked':someSel?' data-indeterminate="1"':'';
@@ -530,16 +530,16 @@ function renderTable(){
   if(expanded){
    u.rows.forEach(({r,i})=>{
     const g=gMeta(r.game),d=r.data||{},p=pct(d);
-    const mc=masteryCount(d),totalM=missionsFor(r.game).length||21;
+    const mc=(masteryCount(d))|0,totalM=(missionsFor(r.game).length||21)|0;
     const mastCell=mc>0?'<span style="color:var(--gold);font-weight:700">'+mc+'</span><span style="color:var(--muted)">/'+totalM+' 🏅</span>':'<span style="color:var(--muted)">0/'+totalM+'</span>';
     const checked=SEL.has(selKey(r))?' checked':'';
     html+='<tr style="background:rgba(0,0,0,0.15)">'+
      (admin?'<td><input type="checkbox" class="sel-row" data-i="'+i+'" onclick="event.stopPropagation();toggleSel('+i+',this.checked)"'+checked+'></td>':'')+
      '<td style="padding-left:28px"><div class="em" style="font-size:11px">'+esc(d.name||'—')+'</div></td>'+
-     '<td><span class="tag" style="background:'+g.accent+'">'+g.emoji+' '+g.gr+'</span></td>'+
+     '<td><span class="tag" style="background:'+esc(g.accent||'#888')+'">'+g.emoji+' '+g.gr+'</span></td>'+
      '<td>'+((d.level||1)|0)+'</td>'+
      '<td>'+((d.xp||0)|0)+'</td>'+
-     '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+(p|0)+'%;background:'+g.accent+'"></i></div><span style="font-size:11px;color:var(--muted)">'+(p|0)+'%</span></div></td>'+
+     '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+(p|0)+'%;background:'+esc(g.accent||'#888')+'"></i></div><span style="font-size:11px;color:var(--muted)">'+(p|0)+'%</span></div></td>'+
      '<td style="font-size:13px">'+mastCell+'</td>'+
      '<td style="font-size:12px;color:var(--muted)">'+onlineDot(r.updated_at)+esc(fmtDate(r.updated_at))+'</td>'+
      '<td><div class="rowbtns">'+

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -525,7 +525,8 @@ function renderTable(){
   // onclick obsahuje pouze číselný index ui (bezpečné, žádná uživatelská data)
   html+='<tr class="user-hdr'+(expanded?' exp':'')+'" style="cursor:pointer" onclick="toggleUserRow('+ui+')">'+
    (admin?'<td onclick="event.stopPropagation()"><input type="checkbox" class="sel-user" data-ui="'+ui+'" onclick="toggleSelUser('+ui+',this.checked)"'+selAttr+'></td>':'')+
-   '<td><div class="nm" style="font-weight:700">'+esc(u.name||'—')+'</div><div class="em">'+esc(u.email)+'</div></td>'+
+   '<td><div class="nm" style="font-weight:700">'+esc(u.name||'—')+'</div><div class="em">'+esc(u.email)+'</div>'+
+   ([...classesOfUser(u.uid)].map(cid=>'<span class="tag" style="background:rgba(58,110,165,.7);font-size:10px;padding:1px 5px;margin-top:2px">🏫 '+esc(classNameOf(cid))+'</span>').join(' '))+'</td>'+
    '<td style="white-space:nowrap">'+chips+'</td>'+
    '<td>'+maxLv+'</td>'+
    '<td>'+totalXP+'</td>'+
@@ -1016,9 +1017,13 @@ function renderClasses(){
     html+='<div style="margin-top:12px;border-top:1px solid var(--line);padding-top:10px;display:grid;grid-template-columns:repeat(auto-fill,minmax(240px,1fr));gap:6px">';
     students.forEach(s=>{
      const inC=mem.has(s.user_id);
+     // skip students already assigned to a different class (one-class-per-student model)
+     const otherClass=[...classesOfUser(s.user_id)].filter(cid=>cid!==c.id);
+     if(!inC&&otherClass.length)return;
+     const otherTag=otherClass.length?(' <span style="color:var(--muted);font-size:10px">('+esc(classNameOf(otherClass[0]))+')</span>'):'';
      html+='<label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;padding:4px 6px;border-radius:4px;background:'+(inC?'rgba(244,208,63,.12)':'transparent')+'">'+
       '<input type="checkbox"'+(inC?' checked':'')+' onclick="toggleMember(\''+esc(c.id)+'\',\''+esc(s.user_id)+'\',this.checked)">'+
-      '<span><b style="color:#fff">'+esc(s.name||'—')+'</b> <span style="color:var(--muted);font-size:11px">'+esc(s.email||'')+'</span></span>'+
+      '<span><b style="color:#fff">'+esc(s.name||'—')+'</b> <span style="color:var(--muted);font-size:11px">'+esc(s.email||'')+otherTag+'</span></span>'+
      '</label>';
     });
     html+='</div>';

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -292,6 +292,12 @@ const MISSIONS_9=[
 ];
 const MISSIONS_BY_GAME={RPG_MAT_6:MISSIONS_6,RPG_MAT_7:MISSIONS_7,RPG_MAT_8:MISSIONS_8,RPG_MAT_9:MISSIONS_9};
 function missionsFor(gameKey){return MISSIONS_BY_GAME[gameKey]||[];}
+const ARTIFACTS_BY_GAME={
+ RPG_MAT_6:[{id:'starmap',nm:'Hvězdná mapa 🗺️'},{id:'crystal',nm:'Desetinný krystal 💎'},{id:'core',nm:'Jádro asteroidu ⚙️'},{id:'protractor',nm:'Hvězdný úhloměr 📐'},{id:'mirror',nm:'Zrcadlový úlomek 🪞'},{id:'cube',nm:'Energetická kostka 🧊'},{id:'medal',nm:'Galaktický odznak 🏅'}],
+ RPG_MAT_7:[{id:'mapscrap',nm:'Útržek staré mapy 🗺️'},{id:'papyrus',nm:'Papyrový svitek 📜'},{id:'lapis',nm:'Lazuritový amulet 🔷'},{id:'weight',nm:'Zlaté závaží ⚖️'},{id:'ring',nm:'Faraonův prsten 💍'},{id:'mirror',nm:'Zrcadlo bohyně 🪞'},{id:'crown',nm:'Faraonova koruna 👑'}],
+ RPG_MAT_8:[{id:'map',nm:'Mapa sedmi krajin 🗺️'},{id:'sword',nm:'Pythagorův meč ⚔️'},{id:'wand',nm:'Algebraická hůl 🪄'},{id:'shield',nm:'Výrazový štít 🛡️'},{id:'ring',nm:'Kruhový prsten 💍'},{id:'compass',nm:'Rýsovací kompas 🧭'},{id:'crown',nm:'Diplom arcimága 👑'}],
+ RPG_MAT_9:[{id:'acckey',nm:'Přístupový klíč 🔑'},{id:'core',nm:'Energetické jádro 🔋'},{id:'decmod',nm:'Dešifrovací modul 💾'},{id:'frag',nm:'Fragment kódu 🧩'},{id:'netkey',nm:'Síťový klíč 🛰️'},{id:'vizchip',nm:'Vizualizační čip 📊'},{id:'root',nm:'Root přístup 👁️'}]
+};
 const ATTR=[['calc','🔢 Výpočty'],['geo','📐 Geometrie'],['anal','🧠 Analýza'],['craft','⚡ Instinkt']];
 const gMeta=k=>GAMES.find(g=>g.key===k)||{emoji:'❓',nm:k,gr:'',accent:'#888'};
 let ROWS=[];   // všechny postavy
@@ -730,7 +736,7 @@ function openDetail(i){
    '<h4>Odměny a úpravy (superadmin)</h4>'+
    '<div class="actrow"><input type="number" id="adj-xp" placeholder="±XP" value="100"><button class="mini gold" onclick="giveXP('+i+')">Přidat XP</button>'+
      '<span style="font-size:11px;color:var(--muted)">level se dopočítá z XP</span></div>'+
-   '<div class="actrow"><input class="wide" id="adj-item" placeholder="název artefaktu"><button class="mini gold" onclick="giveItem('+i+')">+ Artefakt</button></div>'+
+   (()=>{const arts=ARTIFACTS_BY_GAME[r.game]||[];const opts='<option value="">— vybrat artefakt —</option>'+arts.map(a=>'<option value="'+a.id+'"'+(inv.includes(a.id)?' disabled':'')+'>'+esc(a.id)+' – '+esc(a.nm)+'</option>').join('');return '<div class="actrow"><select id="adj-item" style="font-family:inherit;font-size:13px;padding:7px 9px;border-radius:5px;border:1px solid var(--line);background:var(--panel2);color:var(--text);flex:1">'+opts+'</select><button class="mini gold" onclick="giveItem('+i+')">+ Artefakt</button></div>';})()+'
    '<div class="actrow"><button class="mini red" onclick="delChar('+i+')">🗑 Smazat celou postavu</button></div>';
  }
  document.getElementById('modal').innerHTML=
@@ -799,10 +805,13 @@ async function giveXP(i){
 }
 async function giveItem(i){
  const r=window.__filtered[i];if(!r)return;
- const name=document.getElementById('adj-item').value.trim();
- if(!name){toast('Zadej název artefaktu.',1);return;}
+ const sel=document.getElementById('adj-item');
+ const artId=sel&&sel.value;
+ if(!artId){toast('Vyber artefakt.',1);return;}
  const d=Object.assign({},r.data||{});
- d.inv=Array.isArray(d.inv)?d.inv.slice():[];d.inv.push(name);
+ d.inv=Array.isArray(d.inv)?d.inv.slice():[];
+ if(d.inv.includes(artId)){toast('Žák tento artefakt už má.',1);return;}
+ d.inv.push(artId);
  const res=await RPGCloud.updateSaveFor(r.user_id,r.game,d);
  if(res.ok){r.data=d;toast('Artefakt přidán');openDetail(i);}
  else toast('Chyba: '+res.error,1);

--- a/tests/rpg-battle-questions.test.cjs
+++ b/tests/rpg-battle-questions.test.cjs
@@ -7,8 +7,11 @@ const path = require('path');
 const vm = require('vm');
 
 const ROOT = path.join(__dirname, '..');
+// Načtení modulu izolovaně v sandboxu (stejný vzor jako rpg-leaderboard.test.cjs)
+// codeql[js/code-injection]
 const code = fs.readFileSync(path.join(ROOT, 'projects/rpg-battle-9.js'), 'utf8');
 const ctx = vm.createContext({ window: {}, console, Math, String, Number, Set, Array });
+// codeql[js/code-injection]
 vm.runInContext(code, ctx);
 const B = ctx.window.RPG_BATTLE_9;
 

--- a/tests/rpg-battle-questions.test.cjs
+++ b/tests/rpg-battle-questions.test.cjs
@@ -1,0 +1,75 @@
+/* Audit banky otázek živého souboje (rpg-battle-9.js).
+   Determinismus + validita MC napříč tisíci seedy.
+   Spusť: node tests/rpg-battle-questions.test.cjs */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.join(__dirname, '..');
+const code = fs.readFileSync(path.join(ROOT, 'projects/rpg-battle-9.js'), 'utf8');
+const ctx = vm.createContext({ window: {}, console, Math, String, Number, Set, Array });
+vm.runInContext(code, ctx);
+const B = ctx.window.RPG_BATTLE_9;
+
+let pass = 0, fail = 0;
+const ok = (label, cond, d) => { if (cond) { pass++; } else { fail++; console.error('  ✗', label, d ? `[${d}]` : ''); } };
+
+// 1) modul existuje a má API
+ok('modul RPG_BATTLE_9 existuje', !!B);
+ok('build je funkce', typeof B.build === 'function');
+ok('game = RPG_MAT_9', B.game === 'RPG_MAT_9');
+ok('topicCount > 8', B.topicCount > 8, B.topicCount);
+
+// 2) determinismus: stejný seed → identický výstup
+let detOk = true;
+for (let s = 1; s <= 500; s++) {
+  const a = JSON.stringify(B.build(s, 10));
+  const b = JSON.stringify(B.build(s, 10));
+  if (a !== b) { detOk = false; console.error('  ✗ determinismus seed', s); break; }
+}
+ok('determinismus (500 seedů, 2× build identický)', detOk);
+
+// 3) různé seedy → většinou různé sady (sanity, ne 100%)
+let diffCount = 0;
+for (let s = 1; s <= 200; s++) {
+  if (JSON.stringify(B.build(s, 10)) !== JSON.stringify(B.build(s + 1000, 10))) diffCount++;
+}
+ok('různé seedy dávají různé sady (>180/200)', diffCount > 180, diffCount);
+
+// 4) validita: napříč 5000 seedů × 12 otázek
+let badNaN = 0, badChoices = 0, badCorrect = 0, badAnswer = 0, badDup = 0, badEmpty = 0, total = 0;
+for (let s = 1; s <= 5000; s++) {
+  const qs = B.build(s, 12);
+  if (qs.length !== 12) badEmpty++;
+  for (const q of qs) {
+    total++;
+    if (!Array.isArray(q.choices) || q.choices.length !== 4) { badChoices++; continue; }
+    if (new Set(q.choices).size !== 4) badDup++;
+    if (q.correct < 0 || q.correct > 3) badCorrect++;
+    if (q.choices[q.correct] !== q.answer) badAnswer++;
+    for (const c of q.choices) {
+      if (c === undefined || c === null || c === '' || /NaN|undefined/.test(String(c))) badNaN++;
+    }
+    if (!q.text || /NaN|undefined/.test(q.text)) badNaN++;
+  }
+}
+ok(`generováno ${total} otázek, vždy 12/sadu`, badEmpty === 0, `prázdných sad: ${badEmpty}`);
+ok('žádné NaN/undefined v textu ani možnostech', badNaN === 0, badNaN);
+ok('každá otázka má přesně 4 možnosti', badChoices === 0, badChoices);
+ok('žádné duplicitní možnosti', badDup === 0, badDup);
+ok('correct index vždy 0..3', badCorrect === 0, badCorrect);
+ok('choices[correct] === answer', badAnswer === 0, badAnswer);
+
+// 5) count clamp
+ok('count<1 → aspoň 1 otázka', B.build(7, 0).length >= 1);
+ok('count>40 → max 40 otázek', B.build(7, 999).length <= 40);
+
+// 6) seed 0 nepadá (fallback na 1)
+let z = true; try { B.build(0, 10); } catch (e) { z = false; }
+ok('seed 0 bez pádu', z);
+
+console.log(`\n${'═'.repeat(46)}`);
+console.log(`  BATTLE QUESTIONS: ${pass} ✅  /  ${fail} ❌  (${total} otázek)`);
+console.log('═'.repeat(46));
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/rpg-battle-questions.test.cjs
+++ b/tests/rpg-battle-questions.test.cjs
@@ -2,18 +2,10 @@
    Determinismus + validita MC napříč tisíci seedy.
    Spusť: node tests/rpg-battle-questions.test.cjs */
 'use strict';
-const fs = require('fs');
 const path = require('path');
-const vm = require('vm');
 
 const ROOT = path.join(__dirname, '..');
-// Načtení modulu izolovaně v sandboxu (stejný vzor jako rpg-leaderboard.test.cjs)
-// codeql[js/code-injection]
-const code = fs.readFileSync(path.join(ROOT, 'projects/rpg-battle-9.js'), 'utf8');
-const ctx = vm.createContext({ window: {}, console, Math, String, Number, Set, Array });
-// codeql[js/code-injection]
-vm.runInContext(code, ctx);
-const B = ctx.window.RPG_BATTLE_9;
+const B = require(path.join(ROOT, 'projects/rpg-battle-9.js'));
 
 let pass = 0, fail = 0;
 const ok = (label, cond, d) => { if (cond) { pass++; } else { fail++; console.error('  ✗', label, d ? `[${d}]` : ''); } };


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

### Bug fix — teacher unlock sync
- `attachGame` now **merges `teacherUnlocked`** from both cloud and local as a union before any sync — previously when the student had more `done` entries locally than in cloud, local was pushed to cloud without the teacher's unlock, silently losing it
- Domain students (`@husovaliberec.cz`) now **skip the intro screen** entirely and go straight to the map — this eliminates the root UX cause of the bug (pressing "Enter/start fresh" overwrites the cloud save)

### New features

**Hero display name**
- `attachGame` auto-prefills `#ni` name input from any existing `RPG_MAT_*` localStorage save (cross-game prefill)
- For new domain students with no save: prefills from Google account first name
- Hub profile (`rpg-matematika.html`): ✏️ edit button next to hero name — renames across all localStorage saves + pushes to cloud; basic Czech/English offensive-word filter

**Teacher console — grouped by user account**
- Overview table now shows **one row per user account**, not one row per game save
- Each user row shows: name/email, game chips with level (e.g. `🚀 6. LV3 💻 LV7`), total XP, max LV, avg progress, total mastery badges, most recent online status
- Clicking a user row **expands** inline sub-rows showing all their individual games with the existing Detail/Náhled/Delete buttons
- Bulk selection checkbox on user row selects/deselects all their game saves at once; indeterminate state when only some games are selected

### Phase 7 — live battle backend (pilot, grade 9)
- `rpg-battle-9.js`: deterministic MC question bank (12 topic generators, mulberry32 PRNG, `build(seed, count)`)
- `rpg-cloud-setup-phase7.sql`: `battles`/`battle_players`/`battle_invites` tables, 10 SECURITY DEFINER functions, deny-all RLS
- `rpg-cloud.js`: Phase 7 API — `createBattle`, `joinBattle`, `battleState`, `submitBattleAnswer`, `advanceBattle`, `pollBattle`, etc.
- 60,000 questions audited: 15/15 tests passing

## Test plan
- [ ] Teacher unlocks a mission for a student → student logs in → mission is accessible (no longer lost on sync)
- [ ] Domain student logs in → goes directly to map, no intro screen shown
- [ ] Non-domain student with existing save → `#ni` is prefilled with their name from localStorage
- [ ] Hub: ✏️ appears when a save exists → rename → name updates in all games
- [ ] Teacher console: Barbora shows as one row → click to expand → shows her 3 games
- [ ] Bulk checkbox on user row selects all her game rows

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_