### PR TITLE
chore: add Supabase MCP server config (project scope)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=ovajoalbyofenjbbyhcy&features=docs%2Caccount%2Cdatabase%2Cdebugging%2Cdevelopment%2Cfunctions%2Cbranching"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.mcp.json` configuring the **Supabase MCP server** at project scope (step 1 of Supabase's connect-your-project flow) for the `rpg-cloud` project (`ovajoalbyofenjbbyhcy`).

Once merged/pulled, anyone running Claude Code in this repo will have the Supabase MCP server pre-configured and just needs the one-time OAuth auth.

## What this does NOT do
- ❌ Does **not** connect Supabase to the current Claude Code web session (MCP servers load at session start; OAuth can't run in the remote container).
- ❌ Does **not** authenticate — that's a separate one-time step (`claude /mcp` → Authenticate) run **locally in an interactive terminal**.
- ✅ No secrets in the file; project ref is already public in `rpg-cloud.js` / `CLAUDE.md`.

## Next steps (run locally on Windows / Git Bash)
1. Pull this branch (or merge it).
2. `claude /mcp` → select `supabase` → Authenticate (opens browser OAuth).
3. (Optional) `npx skills add supabase/agent-skills`.

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_