### PR TITLE
Oprava lagování souboje + živý souboj přímo z hubu

### DIFF
--- a/projects/rpg-battle-ui.js
+++ b/projects/rpg-battle-ui.js
@@ -34,8 +34,8 @@
     var css = document.createElement('style');
     css.id = 'rpgb-css';
     css.textContent =
-      '#rpgb-ovl{position:fixed;inset:0;z-index:9999;background:rgba(5,8,16,.92);' +
-      'backdrop-filter:blur(3px);display:flex;align-items:center;justify-content:center;' +
+      '#rpgb-ovl{position:fixed;inset:0;z-index:9999;background:rgba(5,8,16,.97);' +
+      'display:flex;align-items:center;justify-content:center;' +
       'font-family:var(--px,"Roboto Mono",monospace);padding:16px;overflow:auto}' +
       '#rpgb-card{background:var(--bg,#0a0e1a);border:2px solid var(--blue,#5dc8f0);' +
       'border-radius:14px;max-width:560px;width:100%;padding:22px;box-shadow:0 0 40px rgba(93,200,240,.25);' +
@@ -68,15 +68,18 @@
       '.rpgb-ch.ok{border-color:#4ade80;background:rgba(74,222,128,.18);color:#4ade80}' +
       '.rpgb-ch.bad{border-color:#ff6b6b;background:rgba(255,107,107,.18);color:#ff6b6b}' +
       '.rpgb-bar{height:8px;border-radius:5px;background:rgba(255,255,255,.08);overflow:hidden;margin:6px 0 14px}' +
-      '.rpgb-bar>i{display:block;height:100%;background:var(--gold,#19e6e6);transition:width .25s linear}' +
+      '.rpgb-bar>i{display:block;height:100%;background:var(--gold,#19e6e6);' +
+      'transform-origin:left center;transform:scaleX(1);transition:transform .25s linear}' +
       '.rpgb-row{display:flex;justify-content:space-between;align-items:center;font-size:13px;color:var(--muted,#8895b5);margin-bottom:8px}' +
-      '.rpgb-x{position:absolute;top:14px;right:18px;font-size:24px;color:var(--muted,#8895b5);cursor:pointer;background:none;border:none}';
+      '.rpgb-hdr{display:flex;justify-content:flex-end;margin:0 -4px 4px}' +
+      '.rpgb-x{font-size:22px;color:var(--muted,#8895b5);cursor:pointer;background:none;border:none;padding:2px 6px;line-height:1}';
     document.head.appendChild(css);
   }
 
   function shell(inner) {
-    root.innerHTML = '<div id="rpgb-card" style="position:relative">' +
-      '<button class="rpgb-x" onclick="RPGBattle.close()" title="zavřít">✕</button>' + inner + '</div>';
+    root.innerHTML = '<div id="rpgb-card">' +
+      '<div class="rpgb-hdr"><button class="rpgb-x" onclick="RPGBattle.close()" title="zavřít">✕</button></div>' +
+      inner + '</div>';
   }
 
   // ════════════ VSTUP ════════════
@@ -96,12 +99,35 @@
         '<button class="rpgb-btn go" onclick="RPGBattle.close();var b=document.getElementById(\'cloud-btn\');if(b)b.click();">🔑 Přihlásit se</button>');
       return;
     }
+    if (Array.isArray(BANK)) BANK = mergeBank(BANK);
     if (!BANK || typeof BANK.build !== 'function') {
       shell('<div class="rpgb-h">⚔️ ŽIVÝ SOUBOJ</div>' +
         '<div class="rpgb-sub">Banka otázek se nenačetla. Zkus obnovit stránku.</div>');
       return;
     }
+    if (opts.autoAction === 'host') { hostUI(); return; }
+    if (opts.autoAction === 'join') { joinUI(); return; }
     renderMenu();
+  }
+
+  function mulberry32(a) {
+    return function () { a |= 0; a = a + 0x6D2B79F5 | 0; var t = Math.imul(a ^ a >>> 15, 1 | a); t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t; return ((t ^ t >>> 14) >>> 0) / 4294967296; };
+  }
+  function mergeBank(banks) {
+    return {
+      build: function (seed, count) {
+        var pool = [];
+        banks.forEach(function (b, i) {
+          if (b && typeof b.build === 'function') {
+            var qs = b.build(seed ^ (i * 0x1F3D7), Math.min(40, count * 4));
+            if (qs) pool = pool.concat(qs);
+          }
+        });
+        var rng = mulberry32(seed);
+        for (var i = pool.length - 1; i > 0; i--) { var j = Math.floor(rng() * (i + 1)); var tmp = pool[i]; pool[i] = pool[j]; pool[j] = tmp; }
+        return pool.slice(0, Math.min(count, pool.length));
+      }
+    };
   }
 
   function renderMenu() {
@@ -237,7 +263,7 @@
       var q = B.questions[qi];
       var inner = '<div class="rpgb-row"><span>OTÁZKA ' + (qi + 1) + ' / ' + bt.q_count + '</span>' +
         '<span id="rpgb-ans">·</span></div>' +
-        '<div class="rpgb-bar"><i id="rpgb-time" style="width:100%"></i></div>' +
+        '<div class="rpgb-bar"><i id="rpgb-time" style="transform:scaleX(1)"></i></div>' +
         '<div class="rpgb-q">' + esc(q.text) + '</div>' +
         '<div id="rpgb-choices">' +
         q.choices.map(function (ch, i) {
@@ -265,7 +291,7 @@
     timer = setInterval(function () {
       var left = Math.max(0, B.deadline - Date.now());
       var bar = document.getElementById('rpgb-time');
-      if (bar) bar.style.width = Math.round(left / (QSEC * 1000) * 100) + '%';
+      if (bar) bar.style.transform = 'scaleX(' + (left / (QSEC * 1000)).toFixed(3) + ')';
       if (left <= 0) {
         clearInterval(timer); timer = null;
         if (!B.locked) lockChoices(false);   // čas vypršel bez odpovědi
@@ -280,6 +306,7 @@
     var left = Math.max(0, B.deadline - Date.now());
     var pts = correct ? Math.round(500 + 1000 * (left / (QSEC * 1000))) : 0;
     B.picked = idx; B.locked = true;
+    if (timer) { clearInterval(timer); timer = null; }
     var c = cloud(); if (c) c.submitBattleAnswer(B.id, qi, correct, pts);
     lockChoices(true);
     var fb = document.getElementById('rpgb-fb');

--- a/projects/rpg-battle-ui.js
+++ b/projects/rpg-battle-ui.js
@@ -22,6 +22,7 @@
   var NAME = 'HRDINA', GAME = 'RPG_MAT_9', BANK = null;
   var B = null;                  // aktuální stav souboje
   var root = null, timer = null;
+  var onResult = null;           // callback z open() — module-level, ne uzávěr
 
   function cloud() { return (typeof RPGCloud !== 'undefined') ? RPGCloud : null; }
   function esc(s) { return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
@@ -82,9 +83,9 @@
   function open(opts) {
     opts = opts || {};
     NAME = opts.name || NAME;
-    var onResult = opts.onResult || null;
+    onResult = opts.onResult || null;
     GAME = opts.game || GAME;
-    BANK = opts.bank || window.RPG_BATTLE_9 || null;
+    BANK = opts.bank || window['RPG_BATTLE_' + (GAME.replace('RPG_MAT_', ''))] || null;
     injectCss();
     if (!root) { root = document.createElement('div'); root.id = 'rpgb-ovl'; document.body.appendChild(root); }
     root.style.display = 'flex';
@@ -130,9 +131,19 @@
     var c = cloud(); if (!c) return;
     shell('<div class="rpgb-sub">Zakládám místnost…</div>');
     c.createBattle(GAME, count, NAME).then(function (b) {
-      if (!b || !b.id) { shell('<div class="rpgb-sub">Nepodařilo se založit souboj.</div><button class="rpgb-btn sm" onclick="RPGBattle._menu()">← zpět</button>'); return; }
-      B = { id: b.id, code: b.code, role: 'host', questions: null, lastQi: -2, picked: -1, locked: false, onResult: onResult };
+      if (!b || !b.id) {
+        var errMsg = (b && b.error) ? esc(b.error) : 'Zkus to znovu nebo obnov stránku.';
+        shell('<div class="rpgb-h">❌ Chyba</div>' +
+          '<div class="rpgb-sub">Nepodařilo se založit souboj.<br><small style="color:#ff6b6b">' + errMsg + '</small></div>' +
+          '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle._menu()">← zpět</button>');
+        return;
+      }
+      B = { id: b.id, code: b.code, role: 'host', questions: null, lastQi: -2, picked: -1, locked: false };
       startPoll();
+    }).catch(function (err) {
+      shell('<div class="rpgb-h">❌ Chyba</div>' +
+        '<div class="rpgb-sub"><small style="color:#ff6b6b">' + esc(String(err)) + '</small></div>' +
+        '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle._menu()">← zpět</button>');
     });
   }
 
@@ -153,7 +164,7 @@
     shell('<div class="rpgb-sub">Připojuji…</div>');
     c.joinBattle(code, NAME).then(function (b) {
       if (!b || !b.id) { joinUI(); var e2 = document.getElementById('rpgb-codein'); if (e2) { e2.value = code; e2.style.borderColor = '#ff6b6b'; } return; }
-      B = { id: b.id, code: b.code, role: 'player', questions: null, lastQi: -2, picked: -1, locked: false, onResult: onResult };
+      B = { id: b.id, code: b.code, role: 'player', questions: null, lastQi: -2, picked: -1, locked: false };
       startPoll();
     });
   }
@@ -182,15 +193,26 @@
   // ════════════ LOBBY ════════════
   function renderLobby(st) {
     var players = st.players || [];
+    // Klíč = seznam jmen; změna = přibyl/odebral hráč → plný re-render
+    var pKey = players.map(function (p) { return p.user_id; }).sort().join(',');
+    if (B.lastLobbyKey === pKey && document.getElementById('rpgb-plycount')) {
+      // pouze aktualizuj počet a stav tlačítka, bez DOM bourání
+      var cnt = document.getElementById('rpgb-plycount');
+      if (cnt) cnt.textContent = players.length;
+      var btn = document.getElementById('rpgb-startbtn');
+      if (btn) btn.disabled = players.length < 1;
+      return;
+    }
+    B.lastLobbyKey = pKey;
     var inner = '<div class="rpgb-h">⏳ Čekárna</div>' +
       '<div class="rpgb-sub">' + (B.role === 'host' ? 'Nadiktuj kód spolužákům. Až se sejdou, spusť.' : 'Čekej, až host spustí souboj.') + '</div>' +
       '<div class="rpgb-code">' + esc(B.code) + '</div>' +
-      '<div class="rpgb-row"><span>HRÁČI</span><span>' + players.length + '</span></div>' +
+      '<div class="rpgb-row"><span>HRÁČI</span><span id="rpgb-plycount">' + players.length + '</span></div>' +
       players.map(function (p) {
         return '<div class="rpgb-ply' + (p.user_id === st.me ? ' me' : '') + '">👤 ' + esc(p.display_name) + (p.user_id === st.me ? ' (ty)' : '') + '</div>';
       }).join('');
     if (B.role === 'host') {
-      inner += '<button class="rpgb-btn go" style="margin-top:16px"' + (players.length < 1 ? ' disabled' : '') +
+      inner += '<button id="rpgb-startbtn" class="rpgb-btn go" style="margin-top:16px"' + (players.length < 1 ? ' disabled' : '') +
         ' onclick="RPGBattle._start()">▶️ Spustit souboj</button>';
     }
     inner += '<button class="rpgb-btn sm red" style="display:block;width:100%" onclick="RPGBattle._leave()">' +
@@ -299,12 +321,12 @@
       '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle.close()">Zavřít</button>';
     shell(inner);
     // Odměny: zavolej hru zpět s výsledky (XP/kredity/odznaky řeší hra, ne UI)
-    if (B && typeof B.onResult === 'function') {
+    if (B && typeof onResult === 'function') {
       var me = st.me;
       var myRow = (st.players || []).find(function (p) { return p.user_id === me; });
       var rank = players.findIndex(function (p) { return p.user_id === me; }) + 1;
       try {
-        B.onResult({
+        onResult({
           rank: rank || players.length,       // 1 = vítěz
           total: players.length,
           correct: myRow ? (myRow.correct_count || 0) : 0,

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -452,19 +452,21 @@ window.RPGCloud = (function () {
   // Tenké wrappery nad SECURITY DEFINER RPC funkcemi (viz phase7.sql).
   // Vše graceful: bez clienta/přihlášení vrací null/[]/false.
   async function createBattle(game, qcount, hostName) {
-    if (!client || !user) return null;
+    if (!client || !user) return { error: 'Nejsi přihlášen.' };
     try {
       const { data, error } = await client.rpc('create_battle',
         { p_game: game, p_qcount: qcount, p_host_name: hostName });
-      if (error) throw error; return data;
-    } catch (e) { console.warn('[RPGCloud] createBattle:', e); return null; }
+      if (error) return { error: error.message || String(error) };
+      return data;
+    } catch (e) { console.warn('[RPGCloud] createBattle:', e); return { error: String(e) }; }
   }
   async function joinBattle(code, name) {
-    if (!client || !user) return null;
+    if (!client || !user) return { error: 'Nejsi přihlášen.' };
     try {
       const { data, error } = await client.rpc('join_battle', { p_code: code, p_name: name });
-      if (error) throw error; return data;
-    } catch (e) { console.warn('[RPGCloud] joinBattle:', e); return null; }
+      if (error) return { error: error.message || String(error) };
+      return data;
+    } catch (e) { console.warn('[RPGCloud] joinBattle:', e); return { error: String(e) }; }
   }
   async function battleState(battleId) {
     if (!client || !user) return null;

--- a/projects/rpg-matematika.html
+++ b/projects/rpg-matematika.html
@@ -208,6 +208,25 @@ body::before{
   <div style="margin-bottom:8px"><span class="tag">TIP</span> <b>Přihlas se školním Google účtem</b> a postava se ti uloží do cloudu.</div>
   Pak ji máš u sebe na <b>všech zařízeních</b> — můžeš hrát doma i ve škole a navázat tam, kde jsi skončil. Učitel zároveň vidí pokrok celé třídy na jednom místě. Bez přihlášení se pokrok ukládá jen do tohoto prohlížeče (localStorage), takže na jiném počítači začínáš znovu.
  </div>
+
+ <!-- ══ ŽIVÝ SOUBOJ ══ -->
+ <div id="hub-battle" style="display:none;margin-top:20px">
+  <div style="background:linear-gradient(135deg,#0d1a1a,#081418);border:1px solid #19e6e6;border-radius:10px;padding:18px;position:relative;overflow:hidden">
+   <div style="position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,#19e6e6,#5dc8f0)"></div>
+   <div style="font-weight:700;font-size:16px;color:#19e6e6;letter-spacing:2px;margin-bottom:6px">⚔️ ŽIVÝ SOUBOJ</div>
+   <div style="font-size:13px;color:var(--muted);margin-bottom:14px">Vyber ročníky, z nichž budou otázky. Pak založ nebo se připoj.</div>
+   <div style="display:flex;gap:16px;flex-wrap:wrap;margin-bottom:16px">
+    <label style="display:flex;align-items:center;gap:7px;cursor:pointer;font-size:14px;color:var(--text)"><input type="checkbox" class="hb-grade" value="6" style="width:16px;height:16px;accent-color:#5dc8f0"> 🚀 6. roč.</label>
+    <label style="display:flex;align-items:center;gap:7px;cursor:pointer;font-size:14px;color:var(--text)"><input type="checkbox" class="hb-grade" value="7" style="width:16px;height:16px;accent-color:#f2c14e"> ⛏️ 7. roč.</label>
+    <label style="display:flex;align-items:center;gap:7px;cursor:pointer;font-size:14px;color:var(--text)"><input type="checkbox" class="hb-grade" value="8" style="width:16px;height:16px;accent-color:#f4d03f"> 🎓 8. roč.</label>
+    <label style="display:flex;align-items:center;gap:7px;cursor:pointer;font-size:14px;color:var(--text)"><input type="checkbox" class="hb-grade" value="9" style="width:16px;height:16px;accent-color:#19e6e6" checked> 💻 9. roč.</label>
+   </div>
+   <div style="display:flex;gap:8px;flex-wrap:wrap">
+    <button onclick="openHubBattle('host')" class="btn" style="flex:0 0 auto;background:transparent;color:#19e6e6;border-color:#19e6e6;font-size:13px;padding:10px 16px">🎮 Založit souboj</button>
+    <button onclick="openHubBattle('join')" class="btn ghost" style="flex:0 0 auto;font-size:13px;padding:10px 16px">🔑 Připojit se kódem</button>
+   </div>
+  </div>
+ </div>
 </div>
 
 <script>
@@ -444,6 +463,26 @@ RPGCloud.onChange(u=>{
   if(tl) tl.style.display = RPGCloud.isStaff() ? 'inline-block' : 'none';
   refreshLeaderboards();
 });
+</script>
+<script src="./rpg-battle-6.js"></script>
+<script src="./rpg-battle-7.js"></script>
+<script src="./rpg-battle-8.js"></script>
+<script src="./rpg-battle-9.js"></script>
+<script src="./rpg-battle-ui.js"></script>
+<script>
+if(window.RPGBattle) document.getElementById('hub-battle').style.display='';
+function openHubBattle(role){
+  if(!window.RPGBattle){alert('Živý souboj se nenačetl. Zkus obnovit stránku.');return;}
+  const grades=Array.from(document.querySelectorAll('.hb-grade:checked')).map(el=>el.value);
+  if(!grades.length){alert('Vyber aspoň jeden ročník.');return;}
+  const banks=grades.map(g=>window['RPG_BATTLE_'+g]).filter(Boolean);
+  if(!banks.length){alert('Banka otázek se nenačetla. Zkus obnovit stránku.');return;}
+  const bank=banks.length===1?banks[0]:banks;
+  const game=grades.length===1?'RPG_MAT_'+grades[0]:'RPG_MAT_MIX';
+  let playerName='HRDINA';
+  GAMES.forEach(g=>{try{const s=JSON.parse(localStorage.getItem(g.key));if(s&&s.name)playerName=s.name;}catch{}});
+  RPGBattle.open({game,name:playerName,bank,autoAction:role==='host'?'host':'join'});
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Výkon — odstraněn hlavní zdroj lagování

`backdrop-filter:blur(3px)` na překryvném okně souboje způsoboval, že **každé překreslení jakéhokoli potomka** spustilo plnou GPU kompozici přes celý viewport. Timer bar se překresloval každých 200 ms → 5× za sekundu šlo celé okno přes `backdrop-filter`. Projevilo se jako opožděný kurzor a zpomalení celé hry pod překryvem.

- **Odstraněno** `backdrop-filter:blur()` → neprůhledné pozadí `rgba(5,8,16,.97)`
- **Timer bar** přepnut z `transition:width` → `transform:scaleX()` s `transform-origin:left` — GPU-compositor track, žádný layout/paint

## Opravené bugy

- **Timer běžel dál po odpovědi** — interval se zastavoval až při `left <= 0`; teď se okamžitě clearuje při kliku hráče
- **Tlačítko ✕ překrývalo počítadlo odpovědí** — bylo `position:absolute` ve vrchní části karty a floatovalo přes `.rpgb-row` s počtem odpovědí; přesunuto do flexibilního hlavičkového pásu, mimo obsah

## Hub — sekce Živý souboj

`rpg-matematika.html` nově obsahuje panel se zaškrtávacími políčky ročníků (6/7/8/9). Tlačítka „Založit" / „Připojit se" přeskočí uvítací menu a přejdou rovnou na příslušnou obrazovku. Při výběru více ročníků se banky otázek sloučí přes PRNG shuffle — každý ročník přispěje svou sadou. Graceful: panel se zobrazí jen pokud se scripty úspěšně načtou.

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_