### PR TITLE
Boss spawn animace + pixel-art bojová scéna s hrdinou (pilot 9. ročník)

### DIFF
--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -149,17 +149,23 @@ body::before{
 @keyframes arena-pulse{0%,100%{opacity:.5}50%{opacity:1}}
 .bt-top::after{content:'';position:absolute;left:0;right:0;bottom:0;height:30px;background:repeating-linear-gradient(90deg,#2a2030 0 8px,#1a1525 8px 16px);border-top:2px solid #3a2a45;pointer-events:none}
 .bt-monster{font-size:110px;display:inline-block;margin-bottom:4px;transform-origin:center;filter:drop-shadow(0 6px 0 #0008) drop-shadow(0 0 14px #5dade233);will-change:transform,opacity,filter;line-height:1;position:relative;z-index:2}
-.bt-monster.enter{animation:mon-enter .55s steps(8) forwards}
+.bt-monster.enter{animation:mon-enter 1.05s steps(14) forwards}
 .bt-monster.idle{animation:mon-idle 1.6s steps(8) infinite}
 .bt-monster.idle-2{animation:mon-idle-2 2.2s steps(10) infinite}
 .bt-monster.hit{animation:mon-hit .5s steps(6) forwards}
 .bt-monster.defeat{animation:mon-defeat .9s steps(10) forwards}
 .bt-mname{font-family:var(--px);font-weight:700;font-size:15px;color:var(--red);letter-spacing:1.2px}
 @keyframes mon-enter{
- 0% {transform:translateX(180px) translateY(-40px) scale(.3) rotate(-25deg);opacity:0}
- 60% {transform:translateX(-12px) translateY(0) scale(1.15) rotate(8deg); opacity:1}
- 80% {transform:translateX(6px) translateY(-4px) scale(.95) rotate(-3deg);opacity:1}
- 100%{transform:translateX(0) translateY(0) scale(1) rotate(0); opacity:1}
+ 0%  {transform:translateY(-150px) scale(.2);opacity:0;filter:brightness(4) saturate(0)}
+ 10% {transform:translateY(-125px) scale(.38);opacity:.75;filter:brightness(3.2) saturate(.2)}
+ 16% {transform:translateY(-115px) scale(.42);opacity:.15;filter:brightness(3.2) saturate(.2)}
+ 24% {transform:translateY(-98px) scale(.52);opacity:.9;filter:brightness(2.6) saturate(.45)}
+ 31% {transform:translateY(-86px) scale(.58);opacity:.25;filter:brightness(2.6) saturate(.45)}
+ 42% {transform:translateY(-52px) scale(.78);opacity:1;filter:brightness(1.9) saturate(.7)}
+ 58% {transform:translateY(0) scale(1.28,.68);opacity:1;filter:brightness(1.5)}
+ 70% {transform:translateY(-16px) scale(.84,1.22);opacity:1;filter:brightness(1.2)}
+ 82% {transform:translateY(0) scale(1.1,.92);opacity:1;filter:brightness(1.05)}
+ 100%{transform:translateY(0) scale(1);opacity:1;filter:brightness(1)}
 }
 @keyframes mon-idle{
  0%,100%{transform:translateY(0) rotate(-2deg)}
@@ -1633,24 +1639,10 @@ function launchBattle(aid,mid){
  mon.className='bt-monster';
  void mon.offsetWidth;
  mon.classList.add('enter');
- setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
- setTimeout(introStrike,660);
+ setTimeout(()=>{top.classList.add('shake');spawnParticles();setTimeout(()=>top.classList.remove('shake'),400);},610);
+ setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},1070);
  renderTask();
  go('battle');
-}
-
-function introStrike(){
- const mon=document.getElementById('bt-mon');
- const top=document.getElementById('bt-top');
- const flash=document.getElementById('hit-flash');
- if(!mon||!top||!flash)return;
- mon.classList.remove('idle','idle-2');
- void mon.offsetWidth;
- mon.classList.add('hit');
- top.classList.add('shake');
- flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
- spawnParticles();
- setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -135,17 +135,23 @@ body::before{
 @keyframes arena-pulse{0%,100%{opacity:.5}50%{opacity:1}}
 .bt-top::after{content:'';position:absolute;left:0;right:0;bottom:0;height:30px;background:repeating-linear-gradient(90deg,#2a2030 0 8px,#1a1525 8px 16px);border-top:2px solid #3a2a45;pointer-events:none}
 .bt-monster{font-size:110px;display:inline-block;margin-bottom:4px;transform-origin:center;filter:drop-shadow(0 6px 0 #0008) drop-shadow(0 0 14px #5dade233);will-change:transform,opacity,filter;line-height:1;position:relative;z-index:2}
-.bt-monster.enter{animation:mon-enter .55s steps(8) forwards}
+.bt-monster.enter{animation:mon-enter 1.05s steps(14) forwards}
 .bt-monster.idle{animation:mon-idle 1.6s steps(8) infinite}
 .bt-monster.idle-2{animation:mon-idle-2 2.2s steps(10) infinite}
 .bt-monster.hit{animation:mon-hit .5s steps(6) forwards}
 .bt-monster.defeat{animation:mon-defeat .9s steps(10) forwards}
 .bt-mname{font-family:var(--px);font-weight:700;font-size:15px;color:var(--red);letter-spacing:1.2px}
 @keyframes mon-enter{
- 0% {transform:translateX(180px) translateY(-40px) scale(.3) rotate(-25deg);opacity:0}
- 60% {transform:translateX(-12px) translateY(0) scale(1.15) rotate(8deg); opacity:1}
- 80% {transform:translateX(6px) translateY(-4px) scale(.95) rotate(-3deg);opacity:1}
- 100%{transform:translateX(0) translateY(0) scale(1) rotate(0); opacity:1}
+ 0%  {transform:translateY(-150px) scale(.2);opacity:0;filter:brightness(4) saturate(0)}
+ 10% {transform:translateY(-125px) scale(.38);opacity:.75;filter:brightness(3.2) saturate(.2)}
+ 16% {transform:translateY(-115px) scale(.42);opacity:.15;filter:brightness(3.2) saturate(.2)}
+ 24% {transform:translateY(-98px) scale(.52);opacity:.9;filter:brightness(2.6) saturate(.45)}
+ 31% {transform:translateY(-86px) scale(.58);opacity:.25;filter:brightness(2.6) saturate(.45)}
+ 42% {transform:translateY(-52px) scale(.78);opacity:1;filter:brightness(1.9) saturate(.7)}
+ 58% {transform:translateY(0) scale(1.28,.68);opacity:1;filter:brightness(1.5)}
+ 70% {transform:translateY(-16px) scale(.84,1.22);opacity:1;filter:brightness(1.2)}
+ 82% {transform:translateY(0) scale(1.1,.92);opacity:1;filter:brightness(1.05)}
+ 100%{transform:translateY(0) scale(1);opacity:1;filter:brightness(1)}
 }
 @keyframes mon-idle{
  0%,100%{transform:translateY(0) rotate(-2deg)}
@@ -1645,24 +1651,10 @@ function launchBattle(aid,mid){
  mon.className='bt-monster';
  void mon.offsetWidth;
  mon.classList.add('enter');
- setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
- setTimeout(introStrike,660);
+ setTimeout(()=>{top.classList.add('shake');spawnParticles();setTimeout(()=>top.classList.remove('shake'),400);},610);
+ setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},1070);
  renderTask();
  go('battle');
-}
-
-function introStrike(){
- const mon=document.getElementById('bt-mon');
- const top=document.getElementById('bt-top');
- const flash=document.getElementById('hit-flash');
- if(!mon||!top||!flash)return;
- mon.classList.remove('idle','idle-2');
- void mon.offsetWidth;
- mon.classList.add('hit');
- top.classList.add('shake');
- flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
- spawnParticles();
- setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -149,17 +149,23 @@ body::before{
 @keyframes arena-pulse{0%,100%{opacity:.5}50%{opacity:1}}
 .bt-top::after{content:'';position:absolute;left:0;right:0;bottom:0;height:30px;background:repeating-linear-gradient(90deg,#2a2030 0 8px,#1a1525 8px 16px);border-top:2px solid #3a2a45;pointer-events:none}
 .bt-monster{font-size:110px;display:inline-block;margin-bottom:4px;transform-origin:center;filter:drop-shadow(0 6px 0 #0008) drop-shadow(0 0 14px #5dade233);will-change:transform,opacity,filter;line-height:1;position:relative;z-index:2}
-.bt-monster.enter{animation:mon-enter .55s steps(8) forwards}
+.bt-monster.enter{animation:mon-enter 1.05s steps(14) forwards}
 .bt-monster.idle{animation:mon-idle 1.6s steps(8) infinite}
 .bt-monster.idle-2{animation:mon-idle-2 2.2s steps(10) infinite}
 .bt-monster.hit{animation:mon-hit .5s steps(6) forwards}
 .bt-monster.defeat{animation:mon-defeat .9s steps(10) forwards}
 .bt-mname{font-family:var(--px);font-weight:700;font-size:15px;color:var(--red);letter-spacing:1.2px}
 @keyframes mon-enter{
- 0% {transform:translateX(180px) translateY(-40px) scale(.3) rotate(-25deg);opacity:0}
- 60% {transform:translateX(-12px) translateY(0) scale(1.15) rotate(8deg); opacity:1}
- 80% {transform:translateX(6px) translateY(-4px) scale(.95) rotate(-3deg);opacity:1}
- 100%{transform:translateX(0) translateY(0) scale(1) rotate(0); opacity:1}
+ 0%  {transform:translateY(-150px) scale(.2);opacity:0;filter:brightness(4) saturate(0)}
+ 10% {transform:translateY(-125px) scale(.38);opacity:.75;filter:brightness(3.2) saturate(.2)}
+ 16% {transform:translateY(-115px) scale(.42);opacity:.15;filter:brightness(3.2) saturate(.2)}
+ 24% {transform:translateY(-98px) scale(.52);opacity:.9;filter:brightness(2.6) saturate(.45)}
+ 31% {transform:translateY(-86px) scale(.58);opacity:.25;filter:brightness(2.6) saturate(.45)}
+ 42% {transform:translateY(-52px) scale(.78);opacity:1;filter:brightness(1.9) saturate(.7)}
+ 58% {transform:translateY(0) scale(1.28,.68);opacity:1;filter:brightness(1.5)}
+ 70% {transform:translateY(-16px) scale(.84,1.22);opacity:1;filter:brightness(1.2)}
+ 82% {transform:translateY(0) scale(1.1,.92);opacity:1;filter:brightness(1.05)}
+ 100%{transform:translateY(0) scale(1);opacity:1;filter:brightness(1)}
 }
 @keyframes mon-idle{
  0%,100%{transform:translateY(0) rotate(-2deg)}
@@ -1881,24 +1887,10 @@ function launchBattle(aid,mid){
  mon.className='bt-monster';
  void mon.offsetWidth;
  mon.classList.add('enter');
- setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
- setTimeout(introStrike,660);
+ setTimeout(()=>{top.classList.add('shake');spawnParticles();setTimeout(()=>top.classList.remove('shake'),400);},610);
+ setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},1070);
  renderTask();
  go('battle');
-}
-
-function introStrike(){
- const mon=document.getElementById('bt-mon');
- const top=document.getElementById('bt-top');
- const flash=document.getElementById('hit-flash');
- if(!mon||!top||!flash)return;
- mon.classList.remove('idle','idle-2');
- void mon.offsetWidth;
- mon.classList.add('hit');
- top.classList.add('shake');
- flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
- spawnParticles();
- setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -149,17 +149,23 @@ body::before{
 @keyframes arena-pulse{0%,100%{opacity:.5}50%{opacity:1}}
 .bt-top::after{content:'';position:absolute;left:0;right:0;bottom:0;height:30px;background:repeating-linear-gradient(90deg,#2a2030 0 8px,#1a1525 8px 16px);border-top:2px solid #3a2a45;pointer-events:none}
 .bt-monster{font-size:110px;display:inline-block;margin-bottom:4px;transform-origin:center;filter:drop-shadow(0 6px 0 #0008) drop-shadow(0 0 14px #5dade233);will-change:transform,opacity,filter;line-height:1;position:relative;z-index:2}
-.bt-monster.enter{animation:mon-enter .55s steps(8) forwards}
+.bt-monster.enter{animation:mon-enter 1.05s steps(14) forwards}
 .bt-monster.idle{animation:mon-idle 1.6s steps(8) infinite}
 .bt-monster.idle-2{animation:mon-idle-2 2.2s steps(10) infinite}
 .bt-monster.hit{animation:mon-hit .5s steps(6) forwards}
 .bt-monster.defeat{animation:mon-defeat .9s steps(10) forwards}
 .bt-mname{font-family:var(--px);font-weight:700;font-size:15px;color:var(--red);letter-spacing:1.2px}
 @keyframes mon-enter{
- 0% {transform:translateX(180px) translateY(-40px) scale(.3) rotate(-25deg);opacity:0}
- 60% {transform:translateX(-12px) translateY(0) scale(1.15) rotate(8deg); opacity:1}
- 80% {transform:translateX(6px) translateY(-4px) scale(.95) rotate(-3deg);opacity:1}
- 100%{transform:translateX(0) translateY(0) scale(1) rotate(0); opacity:1}
+ 0%  {transform:translateY(-150px) scale(.2);opacity:0;filter:brightness(4) saturate(0)}
+ 10% {transform:translateY(-125px) scale(.38);opacity:.75;filter:brightness(3.2) saturate(.2)}
+ 16% {transform:translateY(-115px) scale(.42);opacity:.15;filter:brightness(3.2) saturate(.2)}
+ 24% {transform:translateY(-98px) scale(.52);opacity:.9;filter:brightness(2.6) saturate(.45)}
+ 31% {transform:translateY(-86px) scale(.58);opacity:.25;filter:brightness(2.6) saturate(.45)}
+ 42% {transform:translateY(-52px) scale(.78);opacity:1;filter:brightness(1.9) saturate(.7)}
+ 58% {transform:translateY(0) scale(1.28,.68);opacity:1;filter:brightness(1.5)}
+ 70% {transform:translateY(-16px) scale(.84,1.22);opacity:1;filter:brightness(1.2)}
+ 82% {transform:translateY(0) scale(1.1,.92);opacity:1;filter:brightness(1.05)}
+ 100%{transform:translateY(0) scale(1);opacity:1;filter:brightness(1)}
 }
 @keyframes mon-idle{
  0%,100%{transform:translateY(0) rotate(-2deg)}
@@ -749,6 +755,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 
 <!-- rozšiřující banka úloh (nepovinná; bez ní hra běží na základním poolu) -->
 <script src="./rpg-tasks-9.js"></script>
+<script src="./rpg-sprites-9.js"></script>
 <script src="./rpg-learn-9.js"></script>
 <script>
 // ══════════════════════════════════════════
@@ -1544,6 +1551,7 @@ function updateCermatChip(){
 // SCREEN ROUTER
 // ══════════════════════════════════════════
 function go(name){
+ if(name!=='battle'&&window.RPGSprites9&&RPGSprites9.active())RPGSprites9.detach();
  document.querySelectorAll('.screen').forEach(s=>s.classList.remove('active'));
  document.getElementById('s-'+name).classList.add('active');
  window.scrollTo(0,0);
@@ -1769,27 +1777,19 @@ function launchBattle(aid,mid){
  mon.style.filter='';
  mon.style.fontSize='';
  document.getElementById('bt-mname').textContent=m.mname;
- mon.className='bt-monster';
- void mon.offsetWidth;
- mon.classList.add('enter');
- setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},560);
- setTimeout(introStrike,660);
+ if(window.RPGSprites9){
+  RPGSprites9.attach(top);
+  RPGSprites9.spawn(aid);
+  setTimeout(()=>{top.classList.add('shake');setTimeout(()=>top.classList.remove('shake'),400);},560);
+ }else{
+  mon.className='bt-monster';
+  void mon.offsetWidth;
+  mon.classList.add('enter');
+  setTimeout(()=>{top.classList.add('shake');spawnParticles();setTimeout(()=>top.classList.remove('shake'),400);},610);
+  setTimeout(()=>{mon.classList.remove('enter');mon.classList.add(Math.random()<.5?'idle':'idle-2');},1070);
+ }
  renderTask();
  go('battle');
-}
-
-function introStrike(){
- const mon=document.getElementById('bt-mon');
- const top=document.getElementById('bt-top');
- const flash=document.getElementById('hit-flash');
- if(!mon||!top||!flash)return;
- mon.classList.remove('idle','idle-2');
- void mon.offsetWidth;
- mon.classList.add('hit');
- top.classList.add('shake');
- flash.classList.remove('go');void flash.offsetWidth;flash.classList.add('go');
- spawnParticles();
- setTimeout(()=>{mon.classList.remove('hit');top.classList.remove('shake');mon.classList.add(Math.random()<.5?'idle':'idle-2');},550);
 }
 
 function retryMission(){
@@ -2039,9 +2039,13 @@ function damageMonster(xpGain,isCrit){
  const top=document.getElementById('bt-top');
  const spark=document.getElementById('dmg-spark');
  const flash=document.getElementById('hit-flash');
- mon.classList.remove('idle','idle-2');
- void mon.offsetWidth;
- mon.classList.add('hit');
+ const spriteOn=window.RPGSprites9&&RPGSprites9.active();
+ if(spriteOn){RPGSprites9.heroAttack(isCrit);}
+ else{
+  mon.classList.remove('idle','idle-2');
+  void mon.offsetWidth;
+  mon.classList.add('hit');
+ }
  top.classList.add(isCrit?'big-shake':'shake');
  // flash
  flash.classList.remove('go');
@@ -2060,7 +2064,8 @@ function damageMonster(xpGain,isCrit){
  mon.classList.remove('hit');
  top.classList.remove('shake','big-shake');
  const allDn=BT.tasks.every((_,i)=>S.done[`${BT.mid}-${i}`]);
- if(!allDn) mon.classList.add(Math.random()<.5?'idle':'idle-2');
+ if(spriteOn){if(allDn)RPGSprites9.defeat();}
+ else if(!allDn) mon.classList.add(Math.random()<.5?'idle':'idle-2');
  else mon.classList.add('defeat');
  },550);
 }
@@ -2070,6 +2075,17 @@ function monsterAttack(){
  const top=document.getElementById('bt-top');
  const proj=document.getElementById('proj');
  const inp=document.getElementById('bt-ans');
+ if(window.RPGSprites9&&RPGSprites9.active()){
+  RPGSprites9.bossAttack();
+  setTimeout(()=>{
+   inp.classList.remove('player-hit');
+   void inp.offsetWidth;
+   inp.classList.add('player-hit');
+   top.classList.add('shake');
+   setTimeout(()=>top.classList.remove('shake'),400);
+  },1000);
+  return;
+ }
  mon.classList.remove('idle','idle-2');
  void mon.offsetWidth;
  mon.classList.add('charge');

--- a/projects/rpg-sprites-9.js
+++ b/projects/rpg-sprites-9.js
@@ -1,0 +1,640 @@
+/* ════════════════════════════════════════════════════════════════════
+   RPG Matematika 9 — pixel-art bojová scéna (canvas engine, pilot)
+   ────────────────────────────────────────────────────────────────────
+   Kreslí hrdinu + bosse jako pixel-art sprity na <canvas> místo emoji.
+   Graceful: když se modul nenačte, hra běží dál na emoji animacích.
+
+   API (window.RPGSprites9):
+     attach(topEl)          – vloží canvas do arény, skryje emoji bosse
+     spawn(areaId)          – vstup bosse (materializace + dopad) a hrdiny
+     heroAttack(isCrit)     – náhodný útok hrdiny (meč/kouzlo/střela) + zásah bosse
+     bossAttack()           – nabití bosse + projektil na hrdinu
+     defeat()               – exploze bosse
+     detach()               – zastaví smyčku (návrat na mapu)
+     active()               – je engine připojený?
+   Respektuje .reduced-motion na <html> (statická scéna, žádný pohyb).
+   ════════════════════════════════════════════════════════════════════ */
+window.RPGSprites9 = (function () {
+  'use strict';
+
+  /* ── palety ── */
+  const PAL_HERO = {
+    K:'#0a0c12', J:'#22335c', j:'#16223f', C:'#19e6e6', c:'#0e8a8a',
+    G:'#5a6a85', B:'#23232e', W:'#e8ecf5', Y:'#f4d03f'
+  };
+
+  /* ── hrdina (14×16, kouká doprava) ── */
+  const HERO_IDLE = [[
+    '....KKKKK.....',
+    '...KJJJJJK....',
+    '..KJJJJJJJK...',
+    '..KJCCCCCJK...',
+    '..KJcccccJK...',
+    '...KJJJJJK....',
+    '..KGJJJJJGK...',
+    '.KJJJJJJJJJK..',
+    '.KJjJJJJJjJK..',
+    '.KJjJJJJJjJK..',
+    '..KjJJJJJjK...',
+    '...KjJJJjK....',
+    '...KBJ.JBK....',
+    '...KB...BK....',
+    '...KB...BK....',
+    '..KBB...BBK...'
+  ],[
+    '..............',
+    '....KKKKK.....',
+    '...KJJJJJK....',
+    '..KJJJJJJJK...',
+    '..KJCCCCCJK...',
+    '..KJcccccJK...',
+    '...KJJJJJK....',
+    '..KGJJJJJGK...',
+    '.KJJJJJJJJJK..',
+    '.KJjJJJJJjJK..',
+    '..KjJJJJJjK...',
+    '...KjJJJjK....',
+    '...KBJ.JBK....',
+    '...KB...BK....',
+    '...KB...BK....',
+    '..KBB...BBK...'
+  ]];
+  const HERO_SLASH = [
+    '....KKKKK.....',
+    '...KJJJJJK....',
+    '..KJJJJJJJK...',
+    '..KJCCCCCJK...',
+    '..KJcccccJK...',
+    '...KJJJJJK....',
+    '..KGJJJJJGKWW.',
+    '.KJJJJJJJJKWW.',
+    '.KJjJJJJJJKW..',
+    '.KJjJJJJJjK...',
+    '..KjJJJJJjK...',
+    '...KjJJJjK....',
+    '...KBJ.JBK....',
+    '...KB...BK....',
+    '...KB...BK....',
+    '..KBB...BBK...'
+  ];
+  const HERO_CAST = [
+    '....KKKKK..C..',
+    '...KJJJJJK.CC.',
+    '..KJJJJJJJKC..',
+    '..KJCCCCCJK...',
+    '..KJcccccJKK..',
+    '...KJJJJJKJK..',
+    '..KGJJJJJGJK..',
+    '.KJJJJJJJJJK..',
+    '.KJjJJJJJjK...',
+    '.KJjJJJJJjK...',
+    '..KjJJJJJjK...',
+    '...KjJJJjK....',
+    '...KBJ.JBK....',
+    '...KB...BK....',
+    '...KB...BK....',
+    '..KBB...BBK...'
+  ];
+  const HERO_SHOOT = [
+    '....KKKKK.....',
+    '...KJJJJJK....',
+    '..KJJJJJJJK...',
+    '..KJCCCCCJK...',
+    '..KJcccccJK...',
+    '...KJJJJJK....',
+    '..KGJJJJJGKKK.',
+    '.KJJJJJJJJGGK.',
+    '.KJjJJJJJJKKK.',
+    '.KJjJJJJJjK...',
+    '..KjJJJJJjK...',
+    '...KjJJJjK....',
+    '...KBJ.JBK....',
+    '...KB...BK....',
+    '...KB...BK....',
+    '..KBB...BBK...'
+  ];
+  const HERO_HIT = [
+    '....KKKKK.....',
+    '...KJJJJJK....',
+    '..KJJJJJJJK...',
+    '..KJWWWWWJK...',
+    '..KJWWWWWJK...',
+    '...KJJJJJK....',
+    '.KGJJJJJGK....',
+    'KJJJJJJJJJK...',
+    'KJjJJJJJjJK...',
+    'KJjJJJJJjJK...',
+    '.KjJJJJJjK....',
+    '..KjJJJjK.....',
+    '..KBJ.JBK.....',
+    '..KB...BK.....',
+    '..KB...BK.....',
+    '.KBB...BBK....'
+  ];
+
+  /* ── bossové: 7 archetypů (oblast 1–7), 18×16, koukají doleva ── */
+  // společné znaky: K outline, A akcent (mění se per oblast), a tmavší akcent,
+  // M tělo, m tělo stín, W bílá, R červené oko
+  const BOSS_PALS = {
+    1:{A:'#19e6e6',a:'#0d7a7a',M:'#3a4a66',m:'#28354d'},   // strážní bot — cyan
+    2:{A:'#f4d03f',a:'#9a7d10',M:'#5c4a22',m:'#3d3217'},   // reaktor — žlutá
+    3:{A:'#39ff9e',a:'#157a4a',M:'#2d4a3a',m:'#1d3328'},   // procesor — zelená
+    4:{A:'#ff5dd5',a:'#8a2a72',M:'#4a2d4a',m:'#331d33'},   // glitch — magenta
+    5:{A:'#5dade2',a:'#28628f',M:'#2d3a4a',m:'#1d2833'},   // síť — modrá
+    6:{A:'#45e0c0',a:'#1d7a66',M:'#2d4a44',m:'#1d332f'},   // monitor — teal
+    7:{A:'#ff5d7f',a:'#8f2a44',M:'#4a2d35',m:'#331d23'}    // jádro — červená
+  };
+  const COMMON = { K:'#0a0c12', W:'#e8ecf5', R:'#ff3355' };
+
+  const BOSS_SPRITES = {
+    1: [[ // strážní bot — hranatý robot, 2 idle snímky
+      '...KKKKKKKKKK.....',
+      '..KMMMMMMMMMMK....',
+      '..KMKKKKKKKKMK....',
+      '..KMKAAKKAAKMK....',
+      '..KMKAAKKAAKMK....',
+      '..KMKKKKKKKKMK....',
+      '..KmMMMMMMMMmK....',
+      '...KKKMMMMKKK.....',
+      '..KAAKMmmMKAAK....',
+      '.KMMMKMmmMKMMMK...',
+      '.KmmmKMMMMKmmmK...',
+      '.KKKKKMMMMKKKKK...',
+      '....KMMKKMMK......',
+      '....KMMK.KMMK.....',
+      '....KmmK.KmmK.....',
+      '...KKKKK.KKKKK....'
+    ],[
+      '..................',
+      '...KKKKKKKKKK.....',
+      '..KMMMMMMMMMMK....',
+      '..KMKKKKKKKKMK....',
+      '..KMKAAKKAAKMK....',
+      '..KMKAAKKAAKMK....',
+      '..KMKKKKKKKKMK....',
+      '..KmMMMMMMMMmK....',
+      '...KKKMMMMKKK.....',
+      '..KAAKMmmMKAAK....',
+      '.KMMMKMmmMKMMMK...',
+      '.KmmmKMMMMKmmmK...',
+      '.KKKKKMMMMKKKKK...',
+      '....KMMKKMMK......',
+      '....KMMK.KMMK.....',
+      '...KKKKK.KKKKK....'
+    ]],
+    2: [[ // reaktorové jádro — pulzující orb s prstenci
+      '......KKKKKK......',
+      '....KKAAAAAAKK....',
+      '...KAAaaaaaaAAK...',
+      '..KAaaMMMMMMaaAK..',
+      '.KAaMMWWWWMMMMaAK.',
+      '.KAaMWWAAWWMMMaAK.',
+      'KAaMMWAAAAWMMMMaAK',
+      'KAaMMWAAAAWMMMMaAK',
+      'KAaMMWWAAWWMMMMaAK',
+      '.KAaMMWWWWMMMMaAK.',
+      '.KAaaMMMMMMMMaaAK.',
+      '..KAaaaaaaaaaaAK..',
+      '...KAAaaaaaaAAK...',
+      '....KKAAAAAAKK....',
+      '......KKKKKK......',
+      '..................'
+    ],[
+      '......KKKKKK......',
+      '....KKAAAAAAKK....',
+      '...KAAaaaaaaAAK...',
+      '..KAaaMMMMMMaaAK..',
+      '.KAaMMMWWWWMMMaAK.',
+      '.KAaMMWWAAWWMMaAK.',
+      'KAaMMMWAAAAWMMMaAK',
+      'KAaMMMWAAAAWMMMaAK',
+      'KAaMMMWWAAWWMMMaAK',
+      '.KAaMMMWWWWMMMaAK.',
+      '.KAaaMMMMMMMMaaAK.',
+      '..KAaaaaaaaaaaAK..',
+      '...KAAaaaaaaAAK...',
+      '....KKAAAAAAKK....',
+      '......KKKKKK......',
+      '..................'
+    ]],
+    3: [[ // procesorový golem — čip s nohama
+      '..KK..........KK..',
+      '..KAK........KAK..',
+      '...KAK......KAK...',
+      '..KKKKKKKKKKKKKK..',
+      '.KMMMMMMMMMMMMMMK.',
+      '.KMKKKKKKKKKKKKMK.',
+      '.KMKAAKAAKAAKAKMK.',
+      '.KMKKKKKKKKKKKKMK.',
+      '.KMKAKAAKAAKAAKMK.',
+      '.KMKKKKKKKKKKKKMK.',
+      '.KmMMMMMMMMMMMMmK.',
+      '..KKKKKKKKKKKKKK..',
+      '...KAK......KAK...',
+      '..KAK........KAK..',
+      '..KK..........KK..',
+      '..................'
+    ],[
+      '..KK..........KK..',
+      '...KAK......KAK...',
+      '..KAK........KAK..',
+      '..KKKKKKKKKKKKKK..',
+      '.KMMMMMMMMMMMMMMK.',
+      '.KMKKKKKKKKKKKKMK.',
+      '.KMKAKAAKAAKAAKMK.',
+      '.KMKKKKKKKKKKKKMK.',
+      '.KMKAAKAAKAKAAKMK.',
+      '.KMKKKKKKKKKKKKMK.',
+      '.KmMMMMMMMMMMMMmK.',
+      '..KKKKKKKKKKKKKK..',
+      '..KAK........KAK..',
+      '...KAK......KAK...',
+      '..KK..........KK..',
+      '..................'
+    ]],
+    4: [[ // glitch wraith — roztrhaný duch
+      '.....KKKKKKK......',
+      '...KKMMMMMMMKK....',
+      '..KMMMMMMMMMMMK...',
+      '.KMMRRKMMMKRRMMK..',
+      '.KMMRRKMMMKRRMMK..',
+      '.KMMMMMMMMMMMMMK..',
+      '..KMMMKKKKKMMMK...',
+      '.KMMMMMMMMMMMMMK..',
+      'KAAKMMMMMMMMMKAAK.',
+      '.KKMMMKMMMKMMMKK..',
+      '..KMMK.KMK.KMMK...',
+      '..KMK...K...KMK...',
+      '...K..KAK.K..K....',
+      '......K.K.A.......',
+      '....A.....K.......',
+      '..................'
+    ],[
+      '.....KKKKKKK......',
+      '...KKMMMMMMMKK....',
+      '..KMMMMMMMMMMMK...',
+      '.KMMRRKMMMKRRMMK..',
+      '.KMMRRKMMMKRRMMK..',
+      '.KMMMMMMMMMMMMMK..',
+      '..KMMMKKKKKMMMK...',
+      '.KMMMMMMMMMMMMMK..',
+      'KAAKMMMMMMMMMKAAK.',
+      '.KKMMKMMMMKMMMKK..',
+      '..KMK.KMMK..KMK...',
+      '..KK...KK....K....',
+      '....K.A...KA......',
+      '...A....K....K....',
+      '......K....A......',
+      '..................'
+    ]],
+    5: [[ // síťový pavouk — spider bot
+      '.KK.....KK.....KK.',
+      '..KK...KAK....KK..',
+      '...KK..KAK...KK...',
+      '....KKKKKKKKKK....',
+      '...KKMMMMMMMKK....',
+      '..KMMMMMMMMMMMK...',
+      '.KMMKAAKMKAAKMMK..',
+      '.KMMKAAKMKAAKMMK..',
+      '.KMMMMMMMMMMMMK...',
+      '..KmMMKKKKKMMmK...',
+      '...KKKMMMMMKKK....',
+      '..KK..KMMMK..KK...',
+      '.KK...KKKKK...KK..',
+      'KK...KK...KK...KK.',
+      'K....K.....K....K.',
+      '..................'
+    ],[
+      '.KK.....KK.....KK.',
+      '..KK...KAK....KK..',
+      '...KK..KAK...KK...',
+      '....KKKKKKKKKK....',
+      '...KKMMMMMMMKK....',
+      '..KMMMMMMMMMMMK...',
+      '.KMMKAAKMKAAKMMK..',
+      '.KMMKAAKMKAAKMMK..',
+      '.KMMMMMMMMMMMMK...',
+      '..KmMMKKKKKMMmK...',
+      '...KKKMMMMMKKK....',
+      '...KK.KMMMK.KK....',
+      '..KK..KKKKK..KK...',
+      '.KK..KK...KK..KK..',
+      '.K...K.....K...K..',
+      '..................'
+    ]],
+    6: [[ // monitor — CRT hlava s anténou
+      '........KAK.......',
+      '........KAK.......',
+      '....KKKKKKKKKK....',
+      '..KKMMMMMMMMMMKK..',
+      '.KMMKKKKKKKKKKMMK.',
+      '.KMKAAAAAAAAAAKMK.',
+      '.KMKAWAAAAAWAAKMK.',
+      '.KMKAAAAAAAAAAKMK.',
+      '.KMKAAKAAAKAAAKMK.',
+      '.KMKAAAAAAAAAAKMK.',
+      '.KMMKKKKKKKKKKMMK.',
+      '..KKMMMMMMMMMMKK..',
+      '....KKKKKKKKKK....',
+      '.....KMK..KMK.....',
+      '.....KmK..KmK.....',
+      '....KKKK..KKKK....'
+    ],[
+      '........KAK.......',
+      '........KAK.......',
+      '....KKKKKKKKKK....',
+      '..KKMMMMMMMMMMKK..',
+      '.KMMKKKKKKKKKKMMK.',
+      '.KMKAAAAAAAAAAKMK.',
+      '.KMKAAWAAAAAWAKMK.',
+      '.KMKAAAAAAAAAAKMK.',
+      '.KMKAAAKAAAKAAKMK.',
+      '.KMKAAAAAAAAAAKMK.',
+      '.KMMKKKKKKKKKKMMK.',
+      '..KKMMMMMMMMMMKK..',
+      '....KKKKKKKKKK....',
+      '.....KMK..KMK.....',
+      '.....KmK..KmK.....',
+      '....KKKK..KKKK....'
+    ]],
+    7: [[ // jádro systému — velké oko v mech. schránce
+      '....KKKKKKKKKK....',
+      '..KKMMMMMMMMMMKK..',
+      '.KMMMKKKKKKKKMMMK.',
+      '.KMKKAAAAAAAAKKMK.',
+      'KMKAAaaaaaaaaAAKMK',
+      'KMKAaWWWWWWWWaAKMK',
+      'KMKAaWWRRRRWWaAKMK',
+      'KMKAaWRRRRRRWaAKMK',
+      'KMKAaWRRKKRRWaAKMK',
+      'KMKAaWWRRRRWWaAKMK',
+      'KMKAaWWWWWWWWaAKMK',
+      '.KMKAAaaaaaaAAKMK.',
+      '.KMKKAAAAAAAAKKMK.',
+      '.KMMMKKKKKKKKMMMK.',
+      '..KKMMMMMMMMMMKK..',
+      '....KKKKKKKKKK....'
+    ],[
+      '....KKKKKKKKKK....',
+      '..KKMMMMMMMMMMKK..',
+      '.KMMMKKKKKKKKMMMK.',
+      '.KMKKAAAAAAAAKKMK.',
+      'KMKAAaaaaaaaaAAKMK',
+      'KMKAaWWWWWWWWaAKMK',
+      'KMKAaWWWWWWWWaAKMK',
+      'KMKAaWWRRRRWWaAKMK',
+      'KMKAaWRRKKRRWaAKMK',
+      'KMKAaWWRRRRWWaAKMK',
+      'KMKAaWWWWWWWWaAKMK',
+      '.KMKAAaaaaaaAAKMK.',
+      '.KMKKAAAAAAAAKKMK.',
+      '.KMMMKKKKKKKKMMMK.',
+      '..KKMMMMMMMMMMKK..',
+      '....KKKKKKKKKK....'
+    ]]
+  };
+
+  /* ── engine ── */
+  let cv = null, ctx = null, raf = 0, lastT = 0, tick = 0;
+  let curArea = 1, hiddenEmoji = null;
+  // stavový automat hrdiny/bosse: 'idle'|'enter'|'slash'|'cast'|'shoot'|'hit'|'charge'|'defeat'|'gone'
+  const ST = {
+    hero: { mode: 'idle', t: 0 },
+    boss: { mode: 'gone', t: 0, flash: 0 },
+    fx: []   // {kind:'orb'|'bolt'|'slasharc'|'boom'|'bossproj'|'spark', x,y,t,...}
+  };
+  const SCALE = 5;          // 1 sprite px = 5 canvas px (hrdina)
+  const BSCALE = 6;         // boss je větší
+  const FRAME_MS = 130;     // rychlost přepínání snímků
+
+  const rm = () => document.documentElement.classList.contains('reduced-motion');
+
+  function attach(topEl) {
+    if (cv && cv.isConnected) return;
+    cv = document.createElement('canvas');
+    cv.id = 'bt-arena';
+    cv.style.cssText = 'display:block;width:100%;height:200px;image-rendering:pixelated;position:relative;z-index:2';
+    const mon = document.getElementById('bt-mon');
+    if (mon) { mon.style.display = 'none'; hiddenEmoji = mon; }
+    topEl.insertBefore(cv, topEl.querySelector('.bt-mname'));
+    resize();
+    ctx = cv.getContext('2d');
+    ctx.imageSmoothingEnabled = false;
+    if (!raf) loop(performance.now());
+  }
+  function detach() {
+    if (raf) { cancelAnimationFrame(raf); raf = 0; }
+    if (cv && cv.parentNode) cv.parentNode.removeChild(cv);
+    if (hiddenEmoji) { hiddenEmoji.style.display = ''; hiddenEmoji = null; }
+    cv = null; ctx = null;
+    ST.fx.length = 0;
+  }
+  const active = () => !!(cv && cv.isConnected);
+
+  function resize() {
+    if (!cv) return;
+    const w = cv.clientWidth || 600;
+    cv.width = w; cv.height = 200;
+  }
+
+  function drawSprite(grid, pal, x, y, scale, flipX, flash) {
+    for (let r = 0; r < grid.length; r++) {
+      const row = grid[r];
+      for (let c = 0; c < row.length; c++) {
+        const ch = row[c];
+        if (ch === '.') continue;
+        const col = flash ? '#ffffff' : (pal[ch] || COMMON[ch] || '#f0f');
+        ctx.fillStyle = col;
+        const px = flipX ? x + (row.length - 1 - c) * scale : x + c * scale;
+        ctx.fillRect(px, y + r * scale, scale, scale);
+      }
+    }
+  }
+
+  /* pozice: hrdina vlevo dole, boss vpravo */
+  function heroPos() { return { x: Math.round(cv.width * 0.12), y: 200 - 16 * SCALE - 14 }; }
+  function bossPos() { return { x: Math.round(cv.width * 0.58), y: 200 - 16 * BSCALE - 14 }; }
+
+  function heroGrid() {
+    const m = ST.hero.mode;
+    if (m === 'slash') return HERO_SLASH;
+    if (m === 'cast')  return HERO_CAST;
+    if (m === 'shoot') return HERO_SHOOT;
+    if (m === 'hit')   return HERO_HIT;
+    return HERO_IDLE[tick % 2];
+  }
+
+  function render(now) {
+    if (!ctx) return;
+    ctx.clearRect(0, 0, cv.width, cv.height);
+    const hp = heroPos(), bp = bossPos();
+    const pal = Object.assign({}, COMMON, BOSS_PALS[curArea] || BOSS_PALS[1]);
+    // ── boss ──
+    const b = ST.boss;
+    if (b.mode !== 'gone') {
+      let by = bp.y, bx = bp.x, alpha = 1, bscale = BSCALE;
+      if (b.mode === 'enter' && !rm()) {
+        const p = Math.min(1, b.t / 900);            // 0→1 průběh vstupu
+        if (p < 0.55) {                               // pád shora + blikání
+          by = bp.y - (1 - p / 0.55) * 130;
+          alpha = (Math.floor(b.t / 70) % 3 === 0) ? 0.25 : 0.9;
+          bscale = BSCALE * (0.4 + 0.6 * (p / 0.55));
+        } else if (p < 0.75) {                        // dopad — squash
+          bscale = BSCALE; by = bp.y + 4;
+        }
+        if (p >= 1) { b.mode = 'idle'; b.t = 0; }
+      } else if (b.mode === 'enter') { b.mode = 'idle'; }
+      if (b.mode === 'charge' && !rm()) {
+        bx += Math.sin(b.t / 30) * 3;
+        if (b.t > 650) { b.mode = 'idle'; b.t = 0; }
+      } else if (b.mode === 'charge') { if (b.t > 650) { b.mode = 'idle'; b.t = 0; } }
+      if (b.mode === 'defeat') {
+        const p = Math.min(1, b.t / 900);
+        alpha = 1 - p; by = bp.y + p * 30;
+        if (p >= 1) b.mode = 'gone';
+      }
+      const frames = BOSS_SPRITES[curArea] || BOSS_SPRITES[1];
+      const grid = frames[rm() ? 0 : tick % frames.length];
+      ctx.globalAlpha = alpha;
+      const off = (b.flash > 0 && !rm()) ? (b.t % 2 ? 2 : -2) : 0;
+      drawSprite(grid, pal, bx + off, by, bscale, false, b.flash > 0);
+      ctx.globalAlpha = 1;
+      if (b.flash > 0) b.flash -= 16;
+      // telegraf útoku: blikající ! nad bossem
+      if (b.mode === 'charge' && !rm() && Math.floor(b.t / 110) % 2 === 0) {
+        ctx.fillStyle = '#ff3355';
+        const ex = bx + 9 * bscale - 4, ey = by - 34;
+        ctx.fillRect(ex, ey, 8, 18);
+        ctx.fillRect(ex, ey + 22, 8, 8);
+      }
+    }
+    // ── hrdina ──
+    const h = ST.hero;
+    let hx = hp.x;
+    if (h.mode === 'slash' && !rm()) {
+      const p = Math.min(1, h.t / 520);               // výpad k bossovi a zpět
+      const dash = p < 0.5 ? p * 2 : (1 - p) * 2;
+      hx = hp.x + dash * (bp.x - hp.x - 15 * SCALE);
+    }
+    drawSprite(heroGrid(), PAL_HERO, hx, hp.y, SCALE, false, h.mode === 'hit');
+    // ── efekty ──
+    for (let i = ST.fx.length - 1; i >= 0; i--) {
+      const f = ST.fx[i];
+      f.t += 16;
+      if (f.kind === 'orb' || f.kind === 'bolt') {
+        const dur = f.kind === 'orb' ? 420 : 260;
+        const p = Math.min(1, f.t / dur);
+        const x = f.x0 + (f.x1 - f.x0) * p;
+        const y = f.y0 + (f.y1 - f.y0) * p - (f.kind === 'orb' ? Math.sin(p * Math.PI) * 36 : 0);
+        ctx.fillStyle = f.kind === 'orb' ? '#19e6e6' : '#f4d03f';
+        const s = f.kind === 'orb' ? 10 : 6;
+        ctx.fillRect(x - s / 2, y - s / 2, s, s);
+        ctx.fillStyle = f.kind === 'orb' ? 'rgba(25,230,230,.4)' : 'rgba(244,208,63,.4)';
+        ctx.fillRect(x - s, y - s, s * 2, s * 2);
+        if (p >= 1) { ST.fx.splice(i, 1); impact(f); }
+      } else if (f.kind === 'bossproj') {
+        const p = Math.min(1, f.t / 480);
+        const x = f.x0 + (f.x1 - f.x0) * p;
+        const y = f.y0 + (f.y1 - f.y0) * p;
+        ctx.fillStyle = '#ff3355';
+        ctx.fillRect(x - 5, y - 5, 10, 10);
+        ctx.fillStyle = 'rgba(255,51,85,.4)';
+        ctx.fillRect(x - 9, y - 9, 18, 18);
+        if (p >= 1) {
+          ST.fx.splice(i, 1);
+          ST.hero.mode = 'hit'; ST.hero.t = 0;
+          setTimeout(() => { if (ST.hero.mode === 'hit') { ST.hero.mode = 'idle'; ST.hero.t = 0; } }, 420);
+        }
+      } else if (f.kind === 'slasharc') {
+        const p = Math.min(1, f.t / 240);
+        ctx.strokeStyle = 'rgba(232,236,245,' + (1 - p) + ')';
+        ctx.lineWidth = 5;
+        ctx.beginPath();
+        ctx.arc(f.x, f.y, 26 + p * 22, -1.1 + p, 0.9 + p);
+        ctx.stroke();
+        if (p >= 1) ST.fx.splice(i, 1);
+      } else if (f.kind === 'boom') {
+        const p = Math.min(1, f.t / 380);
+        for (let k = 0; k < 8; k++) {
+          const ang = k / 8 * Math.PI * 2;
+          const d = p * 38;
+          ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
+          ctx.fillRect(f.x + Math.cos(ang) * d - 3, f.y + Math.sin(ang) * d - 3, 6, 6);
+        }
+        if (p >= 1) ST.fx.splice(i, 1);
+      }
+    }
+  }
+
+  function impact(f) {
+    ST.boss.flash = 130; ST.boss.t = 0;
+    ST.fx.push({ kind: 'boom', x: f.x1, y: f.y1, t: 0, rgb: f.kind === 'orb' ? '25,230,230' : '244,208,63' });
+  }
+
+  function loop(now) {
+    raf = requestAnimationFrame(loop);
+    const dt = Math.min(64, now - lastT); lastT = now;
+    if (!ctx) return;
+    if (now - (loop._ft || 0) > FRAME_MS) { tick++; loop._ft = now; }
+    ST.hero.t += dt; ST.boss.t += dt;
+    render(now);
+  }
+
+  /* ── veřejné akce ── */
+  function spawn(areaId) {
+    curArea = Math.max(1, Math.min(7, areaId | 0));
+    resize();
+    ST.boss.mode = rm() ? 'idle' : 'enter';
+    ST.boss.t = 0; ST.boss.flash = 0;
+    ST.hero.mode = 'idle'; ST.hero.t = 0;
+    ST.fx.length = 0;
+  }
+
+  const ATTACKS = ['slash', 'cast', 'shoot'];
+  let lastAtk = '';
+  function heroAttack() {
+    if (!active()) return;
+    // náhodný útok, ale ne 2× stejný po sobě
+    let kind = ATTACKS[Math.floor(Math.random() * ATTACKS.length)];
+    if (kind === lastAtk) kind = ATTACKS[(ATTACKS.indexOf(kind) + 1) % ATTACKS.length];
+    lastAtk = kind;
+    const hp = heroPos(), bp = bossPos();
+    const bcx = bp.x + 9 * BSCALE, bcy = bp.y + 8 * BSCALE;
+    if (rm()) { ST.boss.flash = 130; ST.boss.t = 0; return; }
+    ST.hero.mode = kind === 'cast' ? 'cast' : kind === 'shoot' ? 'shoot' : 'slash';
+    ST.hero.t = 0;
+    if (kind === 'slash') {
+      setTimeout(() => { ST.fx.push({ kind: 'slasharc', x: bcx - 20, y: bcy, t: 0 }); ST.boss.flash = 130; ST.boss.t = 0; ST.fx.push({ kind: 'boom', x: bcx, y: bcy, t: 0, rgb: '232,236,245' }); }, 260);
+      setTimeout(() => { if (ST.hero.mode === 'slash') { ST.hero.mode = 'idle'; ST.hero.t = 0; } }, 540);
+    } else if (kind === 'cast') {
+      ST.fx.push({ kind: 'orb', x0: hp.x + 13 * SCALE, y0: hp.y + 2 * SCALE, x1: bcx, y1: bcy, t: 0 });
+      setTimeout(() => { if (ST.hero.mode === 'cast') { ST.hero.mode = 'idle'; ST.hero.t = 0; } }, 460);
+    } else {
+      ST.fx.push({ kind: 'bolt', x0: hp.x + 13 * SCALE, y0: hp.y + 8 * SCALE, x1: bcx, y1: bcy, t: 0 });
+      setTimeout(() => { if (ST.hero.mode === 'shoot') { ST.hero.mode = 'idle'; ST.hero.t = 0; } }, 320);
+    }
+  }
+
+  function bossAttack() {
+    if (!active()) return;
+    const hp = heroPos(), bp = bossPos();
+    if (rm()) { ST.hero.mode = 'hit'; setTimeout(() => { ST.hero.mode = 'idle'; }, 300); return; }
+    ST.boss.mode = 'charge'; ST.boss.t = 0;
+    setTimeout(() => {
+      ST.fx.push({ kind: 'bossproj', x0: bp.x + 4 * BSCALE, y0: bp.y + 8 * BSCALE, x1: hp.x + 7 * SCALE, y1: hp.y + 8 * SCALE, t: 0 });
+    }, 520);
+  }
+
+  function defeat() {
+    if (!active()) return;
+    const bp = bossPos();
+    ST.boss.mode = 'defeat'; ST.boss.t = 0;
+    const pal = BOSS_PALS[curArea] || BOSS_PALS[1];
+    const rgb = parseInt(pal.A.slice(1), 16);
+    ST.fx.push({ kind: 'boom', x: bp.x + 9 * BSCALE, y: bp.y + 8 * BSCALE, t: 0, rgb: ((rgb >> 16) & 255) + ',' + ((rgb >> 8) & 255) + ',' + (rgb & 255) });
+  }
+
+  window.addEventListener('resize', resize);
+
+  return { attach, detach, active, spawn, heroAttack, bossAttack, defeat };
+})();


### PR DESCRIPTION
## Summary

**1. Vstup do místnosti bez úvodního útoku (všechny 4 hry)**
- Odstraněn `introStrike` — po vstupu už boss nedostane ránu zdarma
- Nová vstupní animace bosse: materializace s blikáním, pád shora, squash-stretch dopad s otřesem obrazovky a částicemi (à la Terraria boss spawn)

**2. Canvas pixel-art bojová scéna — pilot na 9. ročníku**
- Nový modul `projects/rpg-sprites-9.js` — pixel-art engine kreslený na `<canvas>` (žádné externí obrázky, sprity definované v kódu)
- **Hrdina** (hacker s kyber vizorem) vlevo, **boss** vpravo — 7 archetypů podle oblasti: strážní bot, reaktorové jádro, procesorový golem, glitch wraith, síťový pavouk, CRT monitor, oko jádra systému
- **Střídání útoků hrdiny:** výpad s mečem + slash oblouk / kouzelný orb / energetická střela — náhodně, nikdy 2× stejný po sobě
- Boss před útokem **telegrafuje** blikajícím `!`, pak vystřelí projektil na hrdinu
- **Graceful degradation:** bez modulu hra jede na původních emoji animacích
- **Reduced-motion:** statická scéna bez pohybu

## Test plan
- [x] Playwright: celá mise 6/6 úloh → vítězství → návrat do oblasti, canvas korektně odpojen, 0 JS chyb
- [x] Správná odpověď → útok hrdiny + flash bosse; špatná → telegraf + projektil + ztráta srdce
- [x] Reduced-motion: statická scéna
- [x] tests/rpg-ach (11 ✅), tests/rpg-train (12 ✅), tests/rpg-wallet (27 ✅)
- [x] Vizuální kontrola ve hře (Vojta)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_