### PR TITLE
Add Supabase MCP server to project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=ovajoalbyofenjbbyhcy"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 travels/images/ua_2017/originals/
 travels/images/cr_bh_2018/originals/
 .claude/
+!.claude/settings.json


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.json` with project-scoped Supabase MCP server (HTTP transport, projekt `ovajoalbyofenjbbyhcy`)
- Adds `.gitignore` exception `!.claude/settings.json` so the config file is tracked (auth tokens/sessions stay ignored)

## After merge

Run authentication once in a local terminal:
```
claude /mcp
```
Select `supabase` → Authenticate. After that Claude Code sessions can query tables, inspect schema, and run SQL directly against the live Supabase project.

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_