### PR TITLE
Oprava: zámek vstupu po porážce bosse, jediná nápověda (jen postup), záporné MC distraktory

### DIFF
--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -571,7 +571,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="tr-hint-box" class="hint-box"></div>
  <div id="tr-fb" class="feedback"></div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="tr-next-btn" style="display:none" onclick="trNext()">DALŠÍ ÚKOL →</button>
  </div>
  </div>
@@ -651,7 +651,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
   <textarea id="bt-explain-txt" rows="2" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="next-btn" style="display:none" onclick="nextTask()">DÁLE →</button>
  </div>
  <div class="fail-overlay" id="fail-overlay">
@@ -1612,7 +1612,7 @@ const ITEM_DEFS={
 function launchBattle(aid,mid){
  const ar=AREAS.find(a=>a.id===aid);
  const m=ar.missions.find(x=>x.id===mid);
- BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;
+ BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;BT.bossDefeated=false;
  BT.hp=MAX_PLAYER_HP;BT.maxHp=MAX_PLAYER_HP;
  BT.phase=1;BT.items=[];BT.timerFrozen=false;
  if(BT.freezeTimeout){clearTimeout(BT.freezeTimeout);BT.freezeTimeout=null;}
@@ -1789,7 +1789,7 @@ function renderTask(){
  document.getElementById('bt-fb').className='feedback';
  document.getElementById('hint-box').textContent='';
  document.getElementById('hint-box').classList.remove('show');
- document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA 1/2';
+ document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA';
  document.getElementById('hint-btn').disabled=false;
  document.getElementById('next-btn').style.display='none';
  document.getElementById('bt-explain').style.display='none';
@@ -1820,6 +1820,7 @@ function renderMC(t){
  const correct=String(t.ans);
  const cn=parseFloat(correct.replace(',','.'));
  const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==correct)opts.add(opp);}
  let tries=0;
  while(opts.size<4 && tries<30){
  tries++;
@@ -1846,6 +1847,7 @@ function renderMC(t){
 }
 
 function submitMC(opt,btn){
+ if(BT.bossDefeated)return;
  stopTimer();
  const t=BT.curTask;
  const ok=checkAns(opt,t.ans);
@@ -2078,6 +2080,7 @@ function useItem(type){
 }
 
 function submitAnswer(){
+ if(BT.bossDefeated)return;
  const t=BT.curTask;
  const inp=document.getElementById('bt-ans').value;
  if(!inp.trim())return;
@@ -2115,22 +2118,19 @@ function submitAnswer(){
 }
 
 function showHint(){
+ // jediná nápověda: jen postup, nikdy výsledek
  const t=BT.curTask;
- const maxHints=Math.min(2,t.hints.length); // only 2 levels
- if(BT.hl>=maxHints)return;
+ if(BT.hl>0)return;
  BT.missionHinted=true;
  const hb=document.getElementById('hint-box');
- const colors=['var(--green)','var(--gold)'];
- hb.style.borderColor=colors[BT.hl];
- hb.style.color=BT.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=BT.hl===1?'#1a1500':'#0f1a0f';
- const hintText=(t.hints[BT.hl]&&t.hints[BT.hl].trim())?t.hints[BT.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(BT.hl+1)+'/2:\n'+hintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const hintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+hintText;
  hb.classList.add('show');
- BT.hl++;
- const btn=document.getElementById('hint-btn');
- if(BT.hl>=maxHints){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
- else btn.textContent='💡 NÁPOVĚDA '+(BT.hl+1)+'/2';
+ BT.hl=1;
+ document.getElementById('hint-btn').disabled=true;
 }
 
 function nextTask(){
@@ -2152,6 +2152,11 @@ function checkMissionComplete(){
  const m=ar.missions.find(x=>x.id===BT.mid);
  const allDn=BT.tasks.every((_,i)=>S.done[`${m.id}-${i}`]);
  if(allDn){
+ BT.bossDefeated=true;
+ const ans=document.getElementById('bt-ans');if(ans)ans.disabled=true;
+ const hintBtn=document.getElementById('hint-btn');if(hintBtn)hintBtn.disabled=true;
+ document.querySelectorAll('#mc-grid .mc-btn').forEach(b=>b.disabled=true);
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=true);
  if(!S.creditsClaimed)S.creditsClaimed={};
  if(!S.creditsClaimed[BT.mid]){S.creditsClaimed[BT.mid]=true;earnCredits(15);}
  // boss poražen — vítězná sekvence (synchro s defeat animací)
@@ -2324,7 +2329,7 @@ function trRender(){
  const hb=document.getElementById('tr-hint-box');hb.textContent='';hb.classList.remove('show');
  document.getElementById('tr-next-btn').style.display='none';
  const hbtn=document.getElementById('tr-hint-btn');
- hbtn.textContent='💡 NÁPOVĚDA 1/2';hbtn.disabled=false;
+ hbtn.textContent='💡 NÁPOVĚDA';hbtn.disabled=false;
  if(TR.m.mc){
   document.getElementById('tr-input-row').style.display='none';
   document.getElementById('tr-yn-row').style.display='none';
@@ -2344,7 +2349,9 @@ function trRenderMC(t){
  const grid=document.getElementById('tr-mc');
  grid.style.display='grid';
  const correct=String(t.ans),cn=parseFloat(correct.replace(',','.'));
- const opts=new Set([correct]);let tries=0;
+ const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==correct)opts.add(opp);}
+ let tries=0;
  while(opts.size<4 && tries<30){tries++;let alt;
   if(!isNaN(cn)){const delta=ri(-5,5)||ri(1,3);let v=Math.round((cn+delta)*100)/100;if(Number.isInteger(cn)&&Math.abs(cn)<200)v=cn+delta;alt=String(v);}
   else alt=correct==='ANO'?'NE':'ANO';
@@ -2455,19 +2462,18 @@ function trWrong(given){
 }
 
 function trHint(){
- const t=TR.task;const maxH=Math.min(2,t.hints.length);
- if(TR.hl>=maxH)return;
+ // jediná nápověda: jen postup, nikdy výsledek
+ const t=TR.task;
+ if(TR.hl>0)return;
  const hb=document.getElementById('tr-hint-box');
- hb.style.borderColor=TR.hl===1?'var(--gold)':'var(--green)';
- hb.style.color=TR.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=TR.hl===1?'#1a1500':'#0f1a0f';
- const trHintText=(t.hints[TR.hl]&&t.hints[TR.hl].trim())?t.hints[TR.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(TR.hl+1)+'/2:\n'+trHintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const trHintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+trHintText;
  hb.classList.add('show');
- TR.hl++;
- const btn=document.getElementById('tr-hint-btn');
- btn.textContent='💡 NÁPOVĚDA '+Math.min(TR.hl+1,2)+'/2';
- if(TR.hl>=maxH){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
+ TR.hl=1;
+ document.getElementById('tr-hint-btn').disabled=true;
 }
 
 function trNext(){trDraw();}

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -572,7 +572,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="tr-hint-box" class="hint-box"></div>
  <div id="tr-fb" class="feedback"></div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="tr-next-btn" style="display:none" onclick="trNext()">DALŠÍ ÚKOL →</button>
  </div>
  </div>
@@ -651,7 +651,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
   <textarea id="bt-explain-txt" rows="2" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="next-btn" style="display:none" onclick="nextTask()">DÁLE →</button>
  </div>
  <div class="fail-overlay" id="fail-overlay">
@@ -1624,7 +1624,7 @@ const ITEM_DEFS={
 function launchBattle(aid,mid){
  const ar=AREAS.find(a=>a.id===aid);
  const m=ar.missions.find(x=>x.id===mid);
- BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;
+ BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;BT.bossDefeated=false;
  BT.hp=MAX_PLAYER_HP;BT.maxHp=MAX_PLAYER_HP;
  BT.phase=1;BT.items=[];BT.timerFrozen=false;
  if(BT.freezeTimeout){clearTimeout(BT.freezeTimeout);BT.freezeTimeout=null;}
@@ -1801,7 +1801,7 @@ function renderTask(){
  document.getElementById('bt-fb').className='feedback';
  document.getElementById('hint-box').textContent='';
  document.getElementById('hint-box').classList.remove('show');
- document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA 1/2';
+ document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA';
  document.getElementById('hint-btn').disabled=false;
  document.getElementById('next-btn').style.display='none';
  document.getElementById('bt-explain').style.display='none';
@@ -1832,6 +1832,7 @@ function renderMC(t){
  const correct=String(t.ans);
  const cn=parseFloat(correct.replace(',','.'));
  const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==correct)opts.add(opp);}
  let tries=0;
  while(opts.size<4 && tries<30){
  tries++;
@@ -1858,6 +1859,7 @@ function renderMC(t){
 }
 
 function submitMC(opt,btn){
+ if(BT.bossDefeated)return;
  stopTimer();
  const t=BT.curTask;
  const ok=checkAns(opt,t.ans);
@@ -2090,6 +2092,7 @@ function useItem(type){
 }
 
 function submitAnswer(){
+ if(BT.bossDefeated)return;
  const t=BT.curTask;
  const inp=document.getElementById('bt-ans').value;
  if(!inp.trim())return;
@@ -2127,22 +2130,19 @@ function submitAnswer(){
 }
 
 function showHint(){
+ // jediná nápověda: jen postup, nikdy výsledek
  const t=BT.curTask;
- const maxHints=Math.min(2,t.hints.length); // only 2 levels
- if(BT.hl>=maxHints)return;
+ if(BT.hl>0)return;
  BT.missionHinted=true;
  const hb=document.getElementById('hint-box');
- const colors=['var(--green)','var(--gold)'];
- hb.style.borderColor=colors[BT.hl];
- hb.style.color=BT.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=BT.hl===1?'#1a1500':'#0f1a0f';
- const hintText=(t.hints[BT.hl]&&t.hints[BT.hl].trim())?t.hints[BT.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(BT.hl+1)+'/2:\n'+hintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const hintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+hintText;
  hb.classList.add('show');
- BT.hl++;
- const btn=document.getElementById('hint-btn');
- if(BT.hl>=maxHints){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
- else btn.textContent='💡 NÁPOVĚDA '+(BT.hl+1)+'/2';
+ BT.hl=1;
+ document.getElementById('hint-btn').disabled=true;
 }
 
 function nextTask(){
@@ -2164,6 +2164,11 @@ function checkMissionComplete(){
  const m=ar.missions.find(x=>x.id===BT.mid);
  const allDn=BT.tasks.every((_,i)=>S.done[`${m.id}-${i}`]);
  if(allDn){
+ BT.bossDefeated=true;
+ const ans=document.getElementById('bt-ans');if(ans)ans.disabled=true;
+ const hintBtn=document.getElementById('hint-btn');if(hintBtn)hintBtn.disabled=true;
+ document.querySelectorAll('#mc-grid .mc-btn').forEach(b=>b.disabled=true);
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=true);
  if(!S.creditsClaimed)S.creditsClaimed={};
  if(!S.creditsClaimed[BT.mid]){S.creditsClaimed[BT.mid]=true;earnCredits(15);}
  // boss poražen — vítězná sekvence (synchro s defeat animací)
@@ -2333,7 +2338,7 @@ function trRender(){
  const hb=document.getElementById('tr-hint-box');hb.textContent='';hb.classList.remove('show');
  document.getElementById('tr-next-btn').style.display='none';
  const hbtn=document.getElementById('tr-hint-btn');
- hbtn.textContent='💡 NÁPOVĚDA 1/2';hbtn.disabled=false;
+ hbtn.textContent='💡 NÁPOVĚDA';hbtn.disabled=false;
  if(TR.m.mc){
   document.getElementById('tr-input-row').style.display='none';
   document.getElementById('tr-yn-row').style.display='none';
@@ -2353,7 +2358,9 @@ function trRenderMC(t){
  const grid=document.getElementById('tr-mc');
  grid.style.display='grid';
  const correct=t.ans,cn=parseFloat(String(correct).replace(',','.'));
- const opts=new Set([correct]);let tries=0;
+ const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==String(correct))opts.add(opp);}
+ let tries=0;
  while(opts.size<4 && tries<30){tries++;let alt;
   if(!isNaN(cn)){const delta=ri(-5,5)||ri(1,3);let v=Math.round((cn+delta)*100)/100;if(Number.isInteger(cn)&&Math.abs(cn)<200)v=cn+delta;alt=String(v);}
   else alt=correct==='ANO'?'NE':'ANO';
@@ -2464,19 +2471,18 @@ function trWrong(given){
 }
 
 function trHint(){
- const t=TR.task;const maxH=Math.min(2,t.hints.length);
- if(TR.hl>=maxH)return;
+ // jediná nápověda: jen postup, nikdy výsledek
+ const t=TR.task;
+ if(TR.hl>0)return;
  const hb=document.getElementById('tr-hint-box');
- hb.style.borderColor=TR.hl===1?'var(--gold)':'var(--green)';
- hb.style.color=TR.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=TR.hl===1?'#1a1500':'#0f1a0f';
- const trHintText=(t.hints[TR.hl]&&t.hints[TR.hl].trim())?t.hints[TR.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(TR.hl+1)+'/2:\n'+trHintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const trHintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+trHintText;
  hb.classList.add('show');
- TR.hl++;
- const btn=document.getElementById('tr-hint-btn');
- btn.textContent='💡 NÁPOVĚDA '+Math.min(TR.hl+1,2)+'/2';
- if(TR.hl>=maxH){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
+ TR.hl=1;
+ document.getElementById('tr-hint-btn').disabled=true;
 }
 
 function trNext(){trDraw();}

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -572,7 +572,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="tr-hint-box" class="hint-box"></div>
  <div id="tr-fb" class="feedback"></div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="tr-next-btn" style="display:none" onclick="trNext()">DALŠÍ ÚKOL →</button>
  </div>
  </div>
@@ -651,7 +651,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
   <textarea id="bt-explain-txt" rows="2" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="next-btn" style="display:none" onclick="nextTask()">DÁLE →</button>
  </div>
  <div class="fail-overlay" id="fail-overlay">
@@ -1837,7 +1837,7 @@ const ITEM_DEFS={
 function launchBattle(aid,mid){
  const ar=AREAS.find(a=>a.id===aid);
  const m=ar.missions.find(x=>x.id===mid);
- BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;
+ BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;BT.bossDefeated=false;
  BT.hp=MAX_PLAYER_HP;BT.maxHp=MAX_PLAYER_HP;
  BT.phase=1;BT.items=[];BT.timerFrozen=false;
  if(BT.freezeTimeout){clearTimeout(BT.freezeTimeout);BT.freezeTimeout=null;}
@@ -2011,7 +2011,7 @@ function renderTask(){
  document.getElementById('bt-fb').className='feedback';
  document.getElementById('hint-box').textContent='';
  document.getElementById('hint-box').classList.remove('show');
- document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA 1/2';
+ document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA';
  document.getElementById('hint-btn').disabled=false;
  document.getElementById('next-btn').style.display='none';
  document.getElementById('bt-explain').style.display='none';
@@ -2042,6 +2042,7 @@ function renderMC(t){
  const correct=t.ans;
  const cn=parseFloat(correct.replace(',','.'));
  const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==correct)opts.add(opp);}
  let tries=0;
  while(opts.size<4 && tries<30){
  tries++;
@@ -2068,6 +2069,7 @@ function renderMC(t){
 }
 
 function submitMC(opt,btn){
+ if(BT.bossDefeated)return;
  stopTimer();
  const t=BT.curTask;
  const ok=checkAns(opt,t.ans);
@@ -2300,6 +2302,7 @@ function useItem(type){
 }
 
 function submitAnswer(){
+ if(BT.bossDefeated)return;
  const t=BT.curTask;
  const inp=document.getElementById('bt-ans').value;
  if(!inp.trim())return;
@@ -2337,22 +2340,19 @@ function submitAnswer(){
 }
 
 function showHint(){
+ // jediná nápověda: jen postup, nikdy výsledek
  const t=BT.curTask;
- const maxHints=Math.min(2,t.hints.length); // only 2 levels
- if(BT.hl>=maxHints)return;
+ if(BT.hl>0)return;
  BT.missionHinted=true;
  const hb=document.getElementById('hint-box');
- const colors=['var(--green)','var(--gold)'];
- hb.style.borderColor=colors[BT.hl];
- hb.style.color=BT.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=BT.hl===1?'#1a1500':'#0f1a0f';
- const hintText=(t.hints[BT.hl]&&t.hints[BT.hl].trim())?t.hints[BT.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(BT.hl+1)+'/2:\n'+hintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const hintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+hintText;
  hb.classList.add('show');
- BT.hl++;
- const btn=document.getElementById('hint-btn');
- if(BT.hl>=maxHints){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
- else btn.textContent='💡 NÁPOVĚDA '+(BT.hl+1)+'/2';
+ BT.hl=1;
+ document.getElementById('hint-btn').disabled=true;
 }
 
 function nextTask(){
@@ -2374,6 +2374,11 @@ function checkMissionComplete(){
  const m=ar.missions.find(x=>x.id===BT.mid);
  const allDn=BT.tasks.every((_,i)=>S.done[`${m.id}-${i}`]);
  if(allDn){
+ BT.bossDefeated=true;
+ const ans=document.getElementById('bt-ans');if(ans)ans.disabled=true;
+ const hintBtn=document.getElementById('hint-btn');if(hintBtn)hintBtn.disabled=true;
+ document.querySelectorAll('#mc-grid .mc-btn').forEach(b=>b.disabled=true);
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=true);
  if(!S.creditsClaimed)S.creditsClaimed={};
  if(!S.creditsClaimed[BT.mid]){S.creditsClaimed[BT.mid]=true;earnCredits(15);}
  // boss poražen — vítězná sekvence (synchro s defeat animací)
@@ -2566,7 +2571,7 @@ function trRender(){
  const hb=document.getElementById('tr-hint-box');hb.textContent='';hb.classList.remove('show');
  document.getElementById('tr-next-btn').style.display='none';
  const hbtn=document.getElementById('tr-hint-btn');
- hbtn.textContent='💡 NÁPOVĚDA 1/2';hbtn.disabled=false;
+ hbtn.textContent='💡 NÁPOVĚDA';hbtn.disabled=false;
  if(TR.m.mc){
   document.getElementById('tr-input-row').style.display='none';
   document.getElementById('tr-yn-row').style.display='none';
@@ -2586,7 +2591,9 @@ function trRenderMC(t){
  const grid=document.getElementById('tr-mc');
  grid.style.display='grid';
  const correct=t.ans,cn=parseFloat(String(correct).replace(',','.'));
- const opts=new Set([correct]);let tries=0;
+ const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==String(correct))opts.add(opp);}
+ let tries=0;
  while(opts.size<4 && tries<30){tries++;let alt;
   if(!isNaN(cn)){const delta=ri(-5,5)||ri(1,3);let v=Math.round((cn+delta)*100)/100;if(Number.isInteger(cn)&&Math.abs(cn)<200)v=cn+delta;alt=String(v);}
   else alt=correct==='ANO'?'NE':'ANO';
@@ -2697,19 +2704,18 @@ function trWrong(given){
 }
 
 function trHint(){
- const t=TR.task;const maxH=Math.min(2,t.hints.length);
- if(TR.hl>=maxH)return;
+ // jediná nápověda: jen postup, nikdy výsledek
+ const t=TR.task;
+ if(TR.hl>0)return;
  const hb=document.getElementById('tr-hint-box');
- hb.style.borderColor=TR.hl===1?'var(--gold)':'var(--green)';
- hb.style.color=TR.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=TR.hl===1?'#1a1500':'#0f1a0f';
- const trHintText=(t.hints[TR.hl]&&t.hints[TR.hl].trim())?t.hints[TR.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(TR.hl+1)+'/2:\n'+trHintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const trHintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+trHintText;
  hb.classList.add('show');
- TR.hl++;
- const btn=document.getElementById('tr-hint-btn');
- btn.textContent='💡 NÁPOVĚDA '+Math.min(TR.hl+1,2)+'/2';
- if(TR.hl>=maxH){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
+ TR.hl=1;
+ document.getElementById('tr-hint-btn').disabled=true;
 }
 
 function trNext(){trDraw();}

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -589,7 +589,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
   <textarea id="bt-explain-txt" rows="2" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="next-btn" style="display:none" onclick="nextTask()">DÁLE →</button>
  </div>
  <div class="fail-overlay" id="fail-overlay">
@@ -657,7 +657,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="tr-hint-box" class="hint-box"></div>
  <div id="tr-fb" class="feedback"></div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
- <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA 1/2</button>
+ <button class="btn sm b" id="tr-hint-btn" onclick="trHint()">💡 NÁPOVĚDA</button>
  <button class="btn sm g" id="tr-next-btn" style="display:none" onclick="trNext()">DALŠÍ ÚKOL →</button>
  </div>
  </div>
@@ -1130,7 +1130,7 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const a=ri(4,18),b=ri(4,18);return{text:`Vypočítej:\n(-${a}) + (-${b}) =`,ans:String(-a-b),hints:[`Záporné + záporné = ještě zápornější.`,`-(${a} + ${b})`],skill:'calc'};})(),
-   (()=>{const a=ri(3,12),b=ri(3,12);return{text:`Vypočítej:\n${a} - (-${b}) =`,ans:String(a+b),hints:[`Minus a minus dává plus.`,`${a} + ${b}`],skill:'calc'};})(),
+   (()=>{const a=ri(3,12),b=ri(3,12);return{text:`Vypočítej:\n${a} - (-${b}) =`,ans:String(a+b),hints:[`Dvě mínusová znaménka HNED VEDLE SEBE se ruší na plus. (Platí jen vedle sebe nebo při násobení/dělení.)`,`${a} + ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(3,12),b=ri(3,9);return{text:`Vypočítej:\n(-${a}) × ${b} =`,ans:String(-a*b),hints:[`Mínus × plus = mínus.`,`-(${a} × ${b})`],skill:'calc'};})(),
    (()=>{const a=ri(3,12),b=ri(3,9);return{text:`Vypočítej:\n(-${a}) × (-${b}) =`,ans:String(a*b),hints:[`Mínus × mínus = plus.`,`${a} × ${b}`],skill:'calc'};})(),
    (()=>{const b=ri(3,8),q=ri(3,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ ${b} =`,ans:String(-q),hints:[`Mínus ÷ plus = mínus.`,`-(${a} ÷ ${b})`],skill:'calc'};})(),
@@ -1370,7 +1370,7 @@ const AREAS = [
    (()=>{const k=ri(2,5),q=ri(2,8);return{text:`y = ${k}x + ${q}\nV jakém bodě protíná osu y? (napiš jen y-ovou souřadnici)`,ans:String(q),hints:[`Pro x = 0 je y = q.`,`Výsledek: ${q}`],skill:'anal'};})(),
    (()=>{const k=ri(2,4),x0=ri(2,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nV jakém bodě protíná osu x? (napiš jen x-ovou souřadnici)`,ans:String(x0),hints:[`Polož y = 0.`,`x = ${-q} ÷ ${k}`],skill:'anal'};})(),
    (()=>{const q=ri(2,8);return{text:`Je funkce y = ${q} (konstantní) rostoucí?\nNapiš ANO / NE.`,ans:'NE',hints:[`Konstantní funkce není rostoucí ani klesající (k = 0).`,`Výsledek: NE`],skill:'anal'};})(),
-   (()=>{const k=ri(2,4),q=ri(1,5),x=ri(2,5),y=k*x+q;return{text:`Prochází graf funkce y = ${k}x + ${q} bodem [${x}, ${y}]?\nNapiš ANO / NE.`,ans:'ANO',hints:[`Dosaď x = ${x}: ${k}·${x} + ${q} = ${y}. Sedí?`,`Výsledek: ANO`],skill:'anal'};})()
+   (()=>{const k=ri(2,4),q=ri(1,5),x=ri(2,5),y=k*x+q;return{text:`Prochází graf funkce y = ${k}x + ${q} bodem [${x}, ${y}]?\nNapiš ANO / NE.`,ans:'ANO',hints:[`Dosaď x = ${x} do předpisu a porovnej, jestli vyjde ${y}.`,``],skill:'anal'};})()
   ]
  },
  {
@@ -1822,7 +1822,7 @@ const ITEM_DEFS={
 function launchBattle(aid,mid){
  const ar=AREAS.find(a=>a.id===aid);
  const m=ar.missions.find(x=>x.id===mid);
- BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;
+ BT.aid=aid;BT.mid=mid;BT.combo=0;BT.missionHinted=false;BT.bossDefeated=false;
  BT.hp=MAX_PLAYER_HP;BT.maxHp=MAX_PLAYER_HP;
  BT.phase=1;BT.items=[];BT.timerFrozen=false;BT._bid=(BT._bid||0)+1;
  if(BT.freezeTimeout){clearTimeout(BT.freezeTimeout);BT.freezeTimeout=null;}
@@ -1980,7 +1980,7 @@ function onTimeOut(){
  damagePlayer();
  // hide hint/next, let player retry on this task
  setTimeout(()=>{
- if(BT.hp>0){
+ if(BT.hp>0&&!BT.bossDefeated){
  // re-enable input and restart timer for same task
  const inp=document.getElementById('bt-ans');
  if(inp){inp.disabled=false;inp.value='';inp.focus();}
@@ -2013,7 +2013,7 @@ function renderTask(){
  document.getElementById('bt-fb').className='feedback';
  document.getElementById('hint-box').textContent='';
  document.getElementById('hint-box').classList.remove('show');
- document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA 1/2';
+ document.getElementById('hint-btn').textContent='💡 NÁPOVĚDA';
  document.getElementById('hint-btn').disabled=false;
  document.getElementById('next-btn').style.display='none';
  const atkBtn=document.getElementById('attack-btn');if(atkBtn)atkBtn.disabled=false;
@@ -2045,6 +2045,8 @@ function renderMC(t){
  const correct=t.ans;
  const cn=parseFloat(correct.replace(',','.'));
  const opts=new Set([correct]);
+ // always include opposite-sign distractor so sign errors are testable
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==correct)opts.add(opp);}
  let tries=0;
  while(opts.size<4 && tries<30){
  tries++;
@@ -2071,6 +2073,7 @@ function renderMC(t){
 }
 
 function submitMC(opt,btn){
+ if(BT.bossDefeated)return;
  stopTimer();
  const t=BT.curTask;
  const ok=checkAns(opt,t.ans);
@@ -2289,6 +2292,7 @@ function useItem(type){
 }
 
 function submitAnswer(){
+ if(BT.bossDefeated)return;
  const t=BT.curTask;
  const inp=document.getElementById('bt-ans').value;
  if(!inp.trim())return;
@@ -2327,22 +2331,20 @@ function submitAnswer(){
 }
 
 function showHint(){
+ // jediná nápověda: jen postup, nikdy výsledek
  const t=BT.curTask;
- const maxHints=Math.min(2,t.hints.length); // only 2 levels
- if(BT.hl>=maxHints)return;
+ if(BT.hl>0)return;
  BT.missionHinted=true;
  const hb=document.getElementById('hint-box');
- const colors=['var(--green)','var(--gold)'];
- hb.style.borderColor=colors[BT.hl];
- hb.style.color=BT.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=BT.hl===1?'#1a1500':'#0f1a0f';
- const hintText=(t.hints[BT.hl]&&t.hints[BT.hl].trim())?t.hints[BT.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(BT.hl+1)+'/2:\n'+hintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const hintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+hintText;
  hb.classList.add('show');
- BT.hl++;
+ BT.hl=1;
  const btn=document.getElementById('hint-btn');
- if(BT.hl>=maxHints){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
- else btn.textContent='💡 NÁPOVĚDA '+(BT.hl+1)+'/2';
+ btn.disabled=true;
 }
 
 function nextTask(){
@@ -2364,6 +2366,13 @@ function checkMissionComplete(){
  const m=ar.missions.find(x=>x.id===BT.mid);
  const allDn=BT.tasks.every((_,i)=>S.done[`${m.id}-${i}`]);
  if(allDn){
+ BT.bossDefeated=true;
+ // lock all input permanently on boss death
+ const atkBtn=document.getElementById('attack-btn');if(atkBtn)atkBtn.disabled=true;
+ const ans=document.getElementById('bt-ans');if(ans)ans.disabled=true;
+ const hintBtn=document.getElementById('hint-btn');if(hintBtn)hintBtn.disabled=true;
+ document.querySelectorAll('#mc-grid .mc-btn').forEach(b=>b.disabled=true);
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=true);
  // boss poražen — vítězná sekvence (synchro s defeat animací)
  setTimeout(victoryBurst,650);
  evalAch({flawlessMission:!BT.missionHinted,wonAtOneHp:BT.hp===1});
@@ -2442,7 +2451,7 @@ function trRender(){
  const hb=document.getElementById('tr-hint-box');hb.textContent='';hb.classList.remove('show');
  document.getElementById('tr-next-btn').style.display='none';
  const hbtn=document.getElementById('tr-hint-btn');
- hbtn.textContent='💡 NÁPOVĚDA 1/2';hbtn.disabled=false;
+ hbtn.textContent='💡 NÁPOVĚDA';hbtn.disabled=false;
  if(TR.m.mc){
   document.getElementById('tr-input-row').style.display='none';
   document.getElementById('tr-yn-row').style.display='none';
@@ -2462,7 +2471,9 @@ function trRenderMC(t){
  const grid=document.getElementById('tr-mc');
  grid.style.display='grid';
  const correct=t.ans,cn=parseFloat(String(correct).replace(',','.'));
- const opts=new Set([correct]);let tries=0;
+ const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==correct)opts.add(opp);}
+ let tries=0;
  while(opts.size<4 && tries<30){tries++;let alt;
   if(!isNaN(cn)){const delta=ri(-5,5)||ri(1,3);let v=Math.round((cn+delta)*100)/100;if(Number.isInteger(cn)&&Math.abs(cn)<200)v=cn+delta;alt=String(v);}
   else alt=correct==='ANO'?'NE':'ANO';
@@ -2573,19 +2584,18 @@ function trWrong(given){
 }
 
 function trHint(){
- const t=TR.task;const maxH=Math.min(2,t.hints.length);
- if(TR.hl>=maxH)return;
+ // jediná nápověda: jen postup, nikdy výsledek
+ const t=TR.task;
+ if(TR.hl>0)return;
  const hb=document.getElementById('tr-hint-box');
- hb.style.borderColor=TR.hl===1?'var(--gold)':'var(--green)';
- hb.style.color=TR.hl===1?'#ffd966':'#7fe87f';
- hb.style.background=TR.hl===1?'#1a1500':'#0f1a0f';
- const trHintText=(t.hints[TR.hl]&&t.hints[TR.hl].trim())?t.hints[TR.hl]:('Výsledek: '+t.ans);
- hb.textContent='💡 Nápověda '+(TR.hl+1)+'/2:\n'+trHintText;
+ hb.style.borderColor='var(--green)';
+ hb.style.color='#7fe87f';
+ hb.style.background='#0f1a0f';
+ const trHintText=(t.hints&&t.hints[0]&&String(t.hints[0]).trim())?t.hints[0]:'Rozděl si příklad na menší kroky a postupuj po jednom.';
+ hb.textContent='💡 Nápověda:\n'+trHintText;
  hb.classList.add('show');
- TR.hl++;
- const btn=document.getElementById('tr-hint-btn');
- btn.textContent='💡 NÁPOVĚDA '+Math.min(TR.hl+1,2)+'/2';
- if(TR.hl>=maxH){btn.disabled=true;btn.textContent='💡 NÁPOVĚDA 2/2';}
+ TR.hl=1;
+ document.getElementById('tr-hint-btn').disabled=true;
 }
 
 function trNext(){trDraw();}
@@ -2738,7 +2748,9 @@ function twRenderMC(t){
  const grid=document.getElementById('tw-mc');
  grid.style.display='grid';
  const correct=t.ans,cn=parseFloat(String(correct).replace(',','.'));
- const opts=new Set([correct]);let tries=0;
+ const opts=new Set([correct]);
+ if(!isNaN(cn)&&cn!==0){const opp=String(-cn);if(opp!==String(correct))opts.add(opp);}
+ let tries=0;
  while(opts.size<4&&tries<30){tries++;let alt;
   if(!isNaN(cn)){const delta=ri(-5,5)||ri(1,3);let v=Math.round((cn+delta)*100)/100;if(Number.isInteger(cn)&&Math.abs(cn)<200)v=cn+delta;alt=String(v);}
   else alt=correct==='ANO'?'NE':'ANO';

--- a/projects/rpg-tasks-6.js
+++ b/projects/rpg-tasks-6.js
@@ -346,7 +346,7 @@ function gen_6_2(){
   const e=ri(2,6),se=6*e*e;
   tasks.push({text:`Krychle má povrch ${se} cm². Jaká je délka hrany?`,ans:e,hints:['a = √(S/6).',`= ${e} cm`],skill:'geo'});
   const f=ri(2,7);
-  tasks.push({text:`Kolik stěn má krychle?`,ans:6,hints:['Krychle = 6 čtvercových stěn.','6'],skill:'geo'});
+  tasks.push({text:`Kolik stěn má krychle?`,ans:6,hints:['Vezmi si kostku a počítej stěny po dvojicích — protilehlé.',''],skill:'geo'});
   const g=ri(2,6);
   tasks.push({text:`Obsah jedné stěny krychle s hranou ${g} cm?`,ans:g*g,hints:['Stěna je čtverec a².',`= ${g*g} cm²`],skill:'geo'});
   const h=ri(3,7),i=ri(2,6);
@@ -363,10 +363,10 @@ function gen_6_3(){
   tasks.push({text:`Kolik ml je ${b} litrů? (1 l = 1000 ml)`,ans:b*1000,hints:['1 l = 1000 ml.',`= ${b*1000} ml`],skill:'calc'});
   const c=ri(2,9);
   tasks.push({text:`Kolik cm³ je ${c} litrů? (1 l = 1000 cm³)`,ans:c*1000,hints:['1 l = 1000 cm³.',`= ${c*1000} cm³`],skill:'calc'});
-  tasks.push({text:`Kolik stěn má síť krychle?`,ans:6,hints:['Síť krychle = 6 čtverců.','6'],skill:'geo'});
+  tasks.push({text:`Kolik stěn má síť krychle?`,ans:6,hints:['Síť má tolik čtverců, kolik má krychle stěn — spočítej je na kostce.',''],skill:'geo'});
   const d=ri(2,8)*1000;
   tasks.push({text:`Kolik m³ je ${d} litrů? (1000 l = 1 m³)`,ans:d/1000,hints:['Děl 1000.',`= ${d/1000} m³`],skill:'calc'});
-  tasks.push({text:`Kolik hran má krychle?`,ans:12,hints:['Krychle má 12 hran.','12'],skill:'geo'});
+  tasks.push({text:`Kolik hran má krychle?`,ans:12,hints:['Počítej hrany po skupinách: dolní podstava, horní podstava, svislé.',''],skill:'geo'});
   return tasks;
 }
 

--- a/projects/rpg-tasks-7.js
+++ b/projects/rpg-tasks-7.js
@@ -102,7 +102,7 @@ function gen_2_1(){
   // numerická MC
   const h=ri(2,9),i=ri(3,12);
   const g3=gcd(h,i);
-  tasks.push({text:`Výsledek krácení ${h}/${i} na základní tvar: čitatel?`,ans:h/g3,hints:['NSD('+h+','+i+') = '+g3,''+h/g3+'/'+i/g3],skill:'calc'});
+  tasks.push({text:`Výsledek krácení ${h}/${i} na základní tvar: čitatel?`,ans:h/g3,hints:['Najdi NSD čitatele a jmenovatele a oběma jím vyděl.',''+h/g3+'/'+i/g3],skill:'calc'});
   const m=ri(3,8),n=ri(3,8);
   tasks.push({text:`Rozšiř ${m}/${n} číslem 3. Nový čitatel?`,ans:m*3,hints:['Čitatel × 3.',''+m+' × 3 = '+m*3],skill:'calc'});
   return tasks;
@@ -173,7 +173,7 @@ function gen_2_3(){
   const r=ri(2,4),s=ri(2,6),t=ri(2,5);
   const topR=(r*s+1)*t,gR=gcd(topR,s);
   const ansR=gR===s?String(topR/gR):`${topR/gR}/${s/gR}`;
-  tasks.push({text:`${r} celých ${1}/${s} × ${t} = ? (smíšené číslo: výsledek jako čitatel po zkrácení)`,ans:topR/gR,hints:['Přepočti smíšené na zlomek: '+r+'·'+s+'+1 = '+(r*s+1)+'/'+s,'('+topR+'/'+gR+')/'+s/gR],skill:'calc'});
+  tasks.push({text:`${r} celých ${1}/${s} × ${t} = ? (smíšené číslo: výsledek jako čitatel po zkrácení)`,ans:topR/gR,hints:['Smíšené číslo převeď na zlomek: celá část × jmenovatel + čitatel.','('+topR+'/'+gR+')/'+s/gR],skill:'calc'});
   return tasks;
 }
 
@@ -252,7 +252,7 @@ function gen_4_1(){
   tasks.push({text:`Rozděl ${sum} v poměru ${m} : ${n}. Kolik je první díl?`,ans:part,hints:['1 díl = celek / (m+n).','1 díl = '+sum+'/'+(m+n)+' = '+r2(sum/(m+n))+' → '+part],skill:'anal'});
   // poměr délek
   const x=ri(6,20),y=ri(3,x-2);const g=gcd(x,y);
-  tasks.push({text:`Úsečky mají délky ${x} cm a ${y} cm. Jaký je první člen jejich poměru v základním tvaru?`,ans:x/g,hints:['Vyděl oběma NSD('+x+','+y+') = '+g+'.',x+'/'+g+' : '+y+'/'+g+' → '+(x/g)+':'+(y/g)],skill:'anal'});
+  tasks.push({text:`Úsečky mají délky ${x} cm a ${y} cm. Jaký je první člen jejich poměru v základním tvaru?`,ans:x/g,hints:['Najdi NSD obou délek a vyděl jím oba členy.',x+'/'+g+' : '+y+'/'+g+' → '+(x/g)+':'+(y/g)],skill:'anal'});
   // poměr z dílů
   const c=ri(3,8),d=ri(3,8),total2=ri(20,60);
   const cpart=Math.round(total2*c/(c+d));

--- a/projects/rpg-tasks-8.js
+++ b/projects/rpg-tasks-8.js
@@ -223,7 +223,7 @@ window.RPG_TASK_EXTRA_8 = {
   (()=>{const r=ri(2,6);return{text:`Kružnice o poloměru ${r}.\nJaký je její průměr?`,ans:String(2*r),hints:[`d = 2r.`,``],skill:'geo'};})(),
   (()=>{return{text:`Osa úsečky AB prochází středem AB.\nPlatí to?\n(ANO/NE)`,ans:'ANO',hints:[`Osa úsečky prochází středem a je na ni kolmá.`,``],skill:'geo'};})(),
   (()=>{return{text:`Kružnice opisná trojúhelníku prochází\nvšemi vrcholy. Platí to?\n(ANO/NE)`,ans:'ANO',hints:[`Kružnice opisná = ta, která prochází všemi třemi vrcholy.`,``],skill:'geo'};})(),
-  (()=>{return{text:`Kolik bodů má osa úsečky AB společných\ns úsečkou AB?`,ans:'1',hints:[`Osa přechází středem úsečky — právě 1 bod.`,``],skill:'geo'};})(),
+  (()=>{return{text:`Kolik bodů má osa úsečky AB společných\ns úsečkou AB?`,ans:'1',hints:[`Rozmysli si, kudy přesně osa úsečky prochází.`,``],skill:'geo'};})(),
   (()=>{const r=ri(3,8);return{text:`Bod leží uvnitř kružnice o poloměru ${r},\nje jeho vzdálenost od středu větší než ${r}?\n(ANO/NE)`,ans:'NE',hints:[`Uvnitř = vzdálenost < poloměr.`,``],skill:'geo'};})()
  ],
  '6-2': () => [   // Thaletova kružnice

--- a/projects/rpg-tasks-9.js
+++ b/projects/rpg-tasks-9.js
@@ -43,7 +43,7 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const z=ri(2,8)*100,p=[10,25,50][ri(0,2)];const after=z*(1+p/100);return{text:`Po zdražení o ${p} % stojí zboží ${after} Kč.\nPůvodní cena? (Kč)`,ans:String(z),hints:[`${after} ÷ ${cz(1+p/100)}.`,``],skill:'anal'};})()
  ],
  '1-3': () => [
-  (()=>{const a=ri(5,20),b=ri(3,15);return{text:`Vypočítej:\n${a} + (-${b}) =`,ans:String(a-b),hints:[`Plus a minus dává minus.`,`${a} − ${b}`],skill:'calc'};})(),
+  (()=>{const a=ri(5,20),b=ri(3,15);return{text:`Vypočítej:\n${a} + (-${b}) =`,ans:String(a-b),hints:[`Přičíst záporné číslo znamená odečíst ho.`,`${a} − ${b}`],skill:'calc'};})(),
   (()=>{const a=ri(4,15),b=ri(4,15);return{text:`Vypočítej:\n(-${a}) − (-${b}) =`,ans:String(-a+b),hints:[`− (−${b}) = + ${b}.`,`−${a} + ${b}`],skill:'calc'};})(),
   (()=>{const a=ri(2,9),b=ri(2,9);return{text:`Vypočítej:\n(-${a}) × (-${b}) =`,ans:String(a*b),hints:[`− × − = +.`,``],skill:'calc'};})(),
   (()=>{const b=ri(2,6),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ (-${b}) =`,ans:String(q),hints:[`− ÷ − = +.`,``],skill:'calc'};})(),
@@ -76,7 +76,7 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const a=ri(2,4);return{text:`Vypočítej:\n(-${a})⁴ =`,ans:String(a**4),hints:[`Sudý exponent → výsledek kladný.`,``],skill:'anal'};})(),
   (()=>{const a=ri(2,4),b=ri(2,3);return{text:`Zapiš číslem:\n(${a} · ${b})² =`,ans:String((a*b)**2),hints:[`(${a*b})².`,``],skill:'anal'};})(),
   (()=>{const a=ri(2,4),m=ri(2,3),n=ri(2,3);return{text:`Zapiš číslem:\n(${a}^${m})^${n} =`,ans:String(a**(m*n)),hints:[`Exponenty se násobí: ${a}^${m*n}.`,``],skill:'anal'};})(),
-  (()=>{const a=ri(2,4),b=ri(2,4);return{text:`Zapiš číslem:\n${a}² · ${b}² =`,ans:String(a**2*b**2),hints:[`= (${a*b})² = ${(a*b)**2}.`,``],skill:'anal'};})(),
+  (()=>{const a=ri(2,4),b=ri(2,4);return{text:`Zapiš číslem:\n${a}² · ${b}² =`,ans:String(a**2*b**2),hints:[`a² · b² = (a·b)² — umocni součin ${a}·${b}.`,``],skill:'anal'};})(),
   (()=>{const a=ri(2,4);return{text:`Zapiš číslem:\n${a}^3 · ${a}^0 =`,ans:String(a**3),hints:[`${a}^0 = 1, takže ${a}^3.`,``],skill:'anal'};})(),
   (()=>{const a=ri(2,4),n=ri(2,3);return{text:`Zapiš číslem:\n(-${a})^${n*2} =`,ans:String(a**(n*2)),hints:[`Sudý exponent → kladné: ${a}^${n*2}.`,``],skill:'anal'};})()
  ],
@@ -114,7 +114,7 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const x=ri(2,6),a=ri(2,4),bb=ri(2,3),e=ri(1,5);return{text:`Vyřeš rovnici:\n${a}(${bb}x − ${e}) = ${a*(bb*x-e)}`,ans:String(x),hints:[`${a*bb}x − ${a*e}.`,``],skill:'anal'};})(),
   (()=>{const x=ri(3,9),a=ri(2,5);return{text:`Vyřeš rovnici:\n5x − ${a} = 3x + ${2*x-a}`,ans:String(x),hints:[`2x = ${2*x}.`,``],skill:'anal'};})(),
   (()=>{const a=ri(2,5),q=ri(3,8),x=a*q;return{text:`Vyřeš rovnici:\nx / ${a} = ${q}`,ans:String(x),hints:[`x = ${q} × ${a}.`,``],skill:'anal'};})(),
-  (()=>{const a=ri(2,5),q=ri(2,6),c=ri(1,4),x=a*q;return{text:`Vyřeš rovnici:\nx / ${a} + ${c} = ${q+c}`,ans:String(x),hints:[`x/${a} = ${q}, x = ${x}.`,``],skill:'anal'};})(),
+  (()=>{const a=ri(2,5),q=ri(2,6),c=ri(1,4),x=a*q;return{text:`Vyřeš rovnici:\nx / ${a} + ${c} = ${q+c}`,ans:String(x),hints:[`Nejdřív odečti ${c} z obou stran, pak vynásob ${a}.`,``],skill:'anal'};})(),
   (()=>{const x=ri(3,9),b=ri(2,4),a=b+ri(1,2);return{text:`Vyřeš rovnici:\n${a}x − ${b}x = ${(a-b)*x}`,ans:String(x),hints:[`${a-b}x = ${(a-b)*x}.`,``],skill:'anal'};})(),
   (()=>{const x=ri(2,7),a=ri(2,5),b=ri(1,4);return{text:`Vyřeš rovnici:\n2(x + ${a}) + ${b} = ${2*(x+a)+b}`,ans:String(x),hints:[`2x + ${2*a+b} = ${2*(x+a)+b}.`,``],skill:'anal'};})()
  ],
@@ -128,7 +128,7 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const x=ri(5,20),y=x+ri(2,8);return{text:`Dvě čísla, větší o ${y-x}. Součet ${x+y}.\nMenší číslo?`,ans:String(x),hints:[`x + (x + ${y-x}) = ${x+y}.`,``],skill:'anal'};})(),
   (()=>{const a=ri(2,6),b=ri(3,9);return{text:`Trojnásobek čísla zvýšený o ${b} je ${3*a+b}.\nJaké číslo?`,ans:String(a),hints:[`3x + ${b} = ${3*a+b}.`,``],skill:'anal'};})(),
   (()=>{const v=ri(50,120),t=ri(2,4);return{text:`Auto jede ${v} km/h.\nZa ${t} hodiny ujede kolik km?`,ans:String(v*t),hints:[`s = v · t = ${v} · ${t}.`,``],skill:'anal'};})(),
-  (()=>{const x=ri(5,15)*2;return{text:`Polovina čísla je ${x/2}.\nJaké číslo?`,ans:String(x),hints:[`x/2 = ${x/2}, x = ${x}.`,``],skill:'anal'};})()
+  (()=>{const x=ri(5,15)*2;return{text:`Polovina čísla je ${x/2}.\nJaké číslo?`,ans:String(x),hints:[`Polovina vznikla dělením dvěma — vrať to násobením dvěma.`,``],skill:'anal'};})()
  ],
 
  // ───────── OBLAST 4 — SEKTOR LOMENÉHO KÓDU ─────────
@@ -174,7 +174,7 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const x=ri(2,12),y=ri(2,12);return{text:`Vyřeš soustavu, urči x:\nx + y = ${x+y}\nx − y = ${x-y}`,ans:String(x),hints:[`Sečti rovnice: 2x = ${2*x}.`,``],skill:'anal'};})(),
   (()=>{const x=ri(2,12),y=ri(2,12);return{text:`Vyřeš soustavu, urči y:\nx + y = ${x+y}\nx − y = ${x-y}`,ans:String(y),hints:[`Odečti rovnice: 2y = ${2*y}.`,``],skill:'anal'};})(),
   (()=>{const x=ri(2,8),y=2*x;return{text:`Vyřeš soustavu, urči x:\ny = 2x\nx + y = ${3*x}`,ans:String(x),hints:[`3x = ${3*x}.`,``],skill:'anal'};})(),
-  (()=>{const x=ri(2,9),y=ri(2,9);return{text:`Vyřeš soustavu, urči x:\nx + y = ${x+y}\n2x + y = ${2*x+y}`,ans:String(x),hints:[`Odečti rovnice: x = ${x}.`,``],skill:'anal'};})(),
+  (()=>{const x=ri(2,9),y=ri(2,9);return{text:`Vyřeš soustavu, urči x:\nx + y = ${x+y}\n2x + y = ${2*x+y}`,ans:String(x),hints:[`Odečti první rovnici od druhé — y se vyruší.`,``],skill:'anal'};})(),
   (()=>{const a=ri(6,14),b=ri(2,a-2);return{text:`Součet dvou čísel je ${a+b}, rozdíl ${a-b}.\nVětší z čísel?`,ans:String(a),hints:[`(součet + rozdíl) / 2.`,``],skill:'anal'};})(),
   (()=>{const x=ri(3,9),y=ri(2,8);return{text:`Vyřeš soustavu, urči y:\nx = ${x}\n2x + 3y = ${2*x+3*y}`,ans:String(y),hints:[`3y = ${3*y}.`,``],skill:'anal'};})(),
   (()=>{const x=ri(2,8),y=ri(2,8),a=ri(2,4);return{text:`Vyřeš soustavu, urči y:\n${a}x + y = ${a*x+y}\nx = ${x}`,ans:String(y),hints:[`${a*x} + y = ${a*x+y}.`,``],skill:'anal'};})(),

--- a/tests/rpg-boss-lock.test.cjs
+++ b/tests/rpg-boss-lock.test.cjs
@@ -1,0 +1,127 @@
+/* ══════════════════════════════════════════════════════════════════
+   Regrese: (1) po porážce bosse je VŠECHEN vstup trvale zamčený
+   (útok, input, MC, ANO/NE, nápověda) a submitAnswer/submitMC nic
+   nedělají; (2) MC distraktory obsahují i opačné znaménko, když je
+   správná odpověď nenulová; (3) jediná nápověda — tlačítko se po
+   použití vypne a text neprozrazuje výsledek.
+   Spusť: node tests/rpg-boss-lock.test.cjs
+   ══════════════════════════════════════════════════════════════════ */
+const http = require('http'); const fs = require('fs'); const path = require('path');
+const { chromium } = require('playwright');
+const ROOT = path.join(__dirname, '..');
+const EXEC = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+const MIME = {'.html':'text/html','.js':'text/javascript','.css':'text/css'};
+let pass=0, fail=0; const ok=(c,m)=>{c?(pass++,console.log('  ✅ '+m)):(fail++,console.log('  ❌ '+m));};
+
+function serve(){return new Promise(res=>{const s=http.createServer((q,r)=>{let u=decodeURIComponent(q.url.split('?')[0]);if(u.endsWith('/'))u+='index.html';const f=path.normalize(path.join(ROOT,u));if(!f.startsWith(ROOT+path.sep)||!fs.existsSync(f)||fs.statSync(f).isDirectory()){r.writeHead(404);return r.end();}r.writeHead(200,{'Content-Type':MIME[path.extname(f)]||'application/octet-stream'});fs.createReadStream(f).pipe(r);});s.listen(0,()=>res(s));});}
+
+const SEED = {name:'TEST',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[]};
+
+async function answerCorrect(page){
+ await page.evaluate(()=>{
+  const t=BT.curTask, a=String(t.ans);
+  if(BT.mcMode){
+   const btns=[...document.querySelectorAll('#mc-grid .mc-btn')];
+   const target=btns.find(b=>b.textContent.replace(/^[A-D]/,'')===a);
+   if(target)target.click(); else submitMC(a,btns[0]);
+  }else if(/^(ANO|NE)$/i.test(a.trim())){
+   answerYN(a.toUpperCase());
+  }else{
+   document.getElementById('bt-ans').disabled=false;
+   document.getElementById('bt-ans').value=a; submitAnswer();
+  }
+ });
+}
+
+(async()=>{
+ const srv=await serve(); const base=`http://127.0.0.1:${srv.address().port}`;
+ const browser=await chromium.launch({executablePath:EXEC});
+
+ for(const g of [6,7,8,9]){
+  console.log(`\n── rpg-mat-${g} ──`);
+  const ctx=await browser.newContext({viewport:{width:480,height:900}});
+  const page=await ctx.newPage();
+  const errs=[]; page.on('pageerror',e=>errs.push(e.message));
+  await page.addInitScript((seed)=>{localStorage.setItem('RPG_MAT_'+document.title.match(/\d/),JSON.stringify(seed));},SEED);
+  await page.goto(`${base}/projects/rpg-mat-${g}.html`,{waitUntil:'load'});
+  await page.waitForFunction(()=>typeof AREAS!=='undefined'&&typeof launchBattle==='function',{timeout:8000});
+  await page.evaluate((seed)=>{localStorage.setItem(SAVE_KEY,JSON.stringify(seed));loadS&&typeof loadS==='function';},SEED).catch(()=>{});
+  await page.evaluate(()=>{S.done={};continueGame?continueGame():startGame&&startGame();}).catch(()=>{});
+  await page.evaluate(()=>{S.done={};S.xpClaimed=S.xpClaimed||{};});
+
+  // ── 1) nápověda: jediná, vypne tlačítko, neprozrazuje výsledek (ne-MC mise) ──
+  await page.evaluate(()=>{const ar=AREAS.find(a=>a.missions.some(m=>!m.mc));const m=ar.missions.find(m=>!m.mc);launchBattle(ar.id,m.id);});
+  await page.waitForFunction(()=>document.querySelector('#s-battle').classList.contains('active'),{timeout:5000});
+  await page.waitForTimeout(600);
+  {
+   const h=await page.evaluate(()=>{
+    showHint();
+    const txt=document.getElementById('hint-box').textContent;
+    const dis=document.getElementById('hint-btn').disabled;
+    showHint(); // druhé volání nesmí nic změnit
+    const txt2=document.getElementById('hint-box').textContent;
+    return {txt,dis,same:txt===txt2,leak:txt.includes('Výsledek: '+String(BT.curTask.ans)),hl:BT.hl};
+   });
+   ok(h.txt.trim().length>5,`g${g} nápověda má obsah`);
+   ok(h.dis,`g${g} tlačítko nápovědy se po použití vypne`);
+   ok(h.same,`g${g} druhé volání showHint nic nemění`);
+   ok(!h.leak,`g${g} nápověda neprozrazuje výsledek`);
+   ok(h.hl===1,`g${g} BT.hl=1 po nápovědě (XP penalizace platí)`);
+  }
+
+  // ── 2) porážka bosse → vstup trvale zamčený ──
+  {
+   const tot=await page.evaluate(()=>BT.tasks.length);
+   for(let i=0;i<tot;i++){
+    await answerCorrect(page); await page.waitForTimeout(350);
+    const more=await page.evaluate(()=>document.getElementById('next-btn').style.display!=='none'&&!BT.tasks.every((_,j)=>S.done[`${BT.mid}-${j}`]));
+    if(more){await page.evaluate(()=>nextTask());await page.waitForTimeout(300);}
+   }
+   const st=await page.evaluate(()=>({
+    defeated:BT.bossDefeated===true,
+    ansDis:document.getElementById('bt-ans').disabled,
+    hintDis:document.getElementById('hint-btn').disabled,
+    atkDis:(document.getElementById('attack-btn')||{disabled:true}).disabled,
+   }));
+   ok(st.defeated,`g${g} BT.bossDefeated po výhře`);
+   ok(st.ansDis&&st.hintDis&&st.atkDis,`g${g} input+nápověda+útok zamčené po výhře`);
+   // pokus o útok po smrti bosse nesmí nic udělat (žádné XP, žádná změna)
+   const xp0=await page.evaluate(()=>S.xp);
+   await page.evaluate(()=>{document.getElementById('bt-ans').disabled=false;document.getElementById('bt-ans').value=String(BT.curTask.ans);submitAnswer();});
+   await page.waitForTimeout(250);
+   const xp1=await page.evaluate(()=>S.xp);
+   ok(xp0===xp1,`g${g} submitAnswer po porážce bosse je no-op (XP ${xp0}→${xp1})`);
+   await page.evaluate(()=>{try{submitMC('1',document.createElement('button'));}catch(e){window.__mcErr=e.message;}});
+   const mcErr=await page.evaluate(()=>window.__mcErr||'');
+   ok(mcErr==='',`g${g} submitMC po porážce bosse je no-op (bez výjimky)`);
+  }
+
+  // ── 3) MC distraktory: záporná odpověď ⇒ aspoň jedna záporná volba; opačné znaménko v nabídce ──
+  {
+   const mc=await page.evaluate(()=>{
+    const res={negHasNeg:true,oppPresent:true,checked:0};
+    for(let it=0;it<60;it++){
+     const fake={ans:String((it%2?-1:1)*( (it%7)+2 )),hints:['x'],skill:'calc'};
+     renderMC(fake);
+     const opts=[...document.querySelectorAll('#mc-grid .mc-btn')].map(b=>b.textContent.replace(/^[A-D]/,''));
+     const cn=parseFloat(fake.ans);
+     res.checked++;
+     if(!opts.includes(String(-cn)))res.oppPresent=false;
+     if(cn<0&&!opts.some(o=>parseFloat(o)<0))res.negHasNeg=false;
+    }
+    return res;
+   });
+   ok(mc.oppPresent,`g${g} MC: opačné znaménko je vždy mezi volbami (${mc.checked}×)`);
+   ok(mc.negHasNeg,`g${g} MC: záporná odpověď ⇒ záporné volby existují`);
+  }
+
+  ok(errs.length===0,`g${g} žádné JS chyby (${errs.slice(0,2).join(' | ')})`);
+  await ctx.close();
+ }
+
+ await browser.close(); srv.close();
+ console.log(`\n══════════════════════════════════════════`);
+ console.log(`  VÝSLEDEK: ${pass} ✅ / ${fail} ❌`);
+ console.log('══════════════════════════════════════════');
+ process.exit(fail?1:0);
+})().catch(e=>{console.error(e);process.exit(1);});

--- a/tests/vstudents-deep.harness.cjs
+++ b/tests/vstudents-deep.harness.cjs
@@ -90,7 +90,8 @@ async function answerWrong(page){
           pool.forEach((t, i) => {
             if (!t || typeof t.text !== 'string' || !t.text.trim()) bad.push(`${m.id}[${i}]: chybí text`);
             if (t && (t.ans === undefined || t.ans === null || String(t.ans) === 'NaN' || String(t.ans) === 'undefined')) bad.push(`${m.id}[${i}]: vadná odpověď (${t && t.ans})`);
-            if (t && !m.mc && (!Array.isArray(t.hints) || t.hints.length < 1 || t.hints.some(h => !h || !String(h).trim()))) bad.push(`${m.id}[${i}]: chybí/prázdné hints`);
+            if (t && !m.mc && (!Array.isArray(t.hints) || !t.hints[0] || !String(t.hints[0]).trim())) bad.push(`${m.id}[${i}]: chybí/prázdný hints[0]`);
+            if (t && !m.mc && Array.isArray(t.hints) && /Výsledek:/.test(String(t.hints[0] || ''))) bad.push(`${m.id}[${i}]: hints[0] prozrazuje výsledek`);
           });
         }
         return bad.slice(0, 8);
@@ -128,14 +129,15 @@ async function answerWrong(page){
       const isMc = await page.evaluate(() => BT.mcMode);
       if (!isMc) {
         const h = await page.evaluate(async () => {
-          const out = [];
-          showHint(); out.push(document.getElementById('hint-box').textContent.trim());
-          const lbl1 = document.getElementById('hint-btn').textContent;
-          showHint(); out.push(document.getElementById('hint-box').textContent.trim());
-          return { out, lbl1 };
+          showHint();
+          const txt = document.getElementById('hint-box').textContent.trim();
+          const disabled = document.getElementById('hint-btn').disabled;
+          const ans = String(BT.curTask.ans);
+          return { txt, disabled, ans };
         });
-        ok(h.out[0].length > 0 && h.out[1].length > 0, `g${g} nápovědy 1+2 neprázdné`);
-        ok(/2\s*\/\s*2/.test(h.lbl1), `g${g} label nápovědy se mění (${h.lbl1})`);
+        ok(h.txt.length > 0, `g${g} nápověda neprázdná`);
+        ok(h.disabled, `g${g} po nápovědě je tlačítko vypnuté (jediná nápověda)`);
+        ok(!h.txt.includes('Výsledek: ' + h.ans), `g${g} nápověda neprozrazuje výsledek`);
       }
       const w0 = await page.evaluate(() => parseFloat(document.getElementById('bt-hpbar').style.width));
       const tot = await page.evaluate(() => BT.tasks.length);


### PR DESCRIPTION
Opravy 4 nahlášených chyb ve všech 4 hrách RPG Matematika:

## 1. Útok po smrti bosse
Nový flag `BT.bossDefeated` se nastaví v `checkMissionComplete()` při výhře a **trvale zamkne** input, tlačítko ÚTOK, MC tlačítka, ANO/NE i nápovědu. `submitAnswer()` a `submitMC()` mají guard na začátku (no-op po výhře) a `onTimeOut()` už po výhře input znovu neodemkne. Resetuje se v `launchBattle()`.

## 2. Chybná znaménková pravidla v nápovědách
- „Plus a minus dává minus" (rpg-tasks-9, `a + (−b)`) → „Přičíst záporné číslo znamená odečíst ho" — výsledek totiž může být i kladný.
- „Minus a minus dává plus" (rpg-mat-9, `a − (−b)`) → explicitně „Dvě mínusová znaménka HNED VEDLE SEBE se ruší… (platí jen vedle sebe nebo při násobení/dělení)".

## 3. Mocniny v MC: všechny volby kladné
`renderMC` / `trRenderMC` / `twRenderMC` teď **vždy přidají hodnotu s opačným znaménkem** mezi distraktory (pokud je odpověď nenulová). Žák u `(−3)³` musí rozlišit −27 vs. 27.

## 4. Jediná nápověda, jen postup, nikdy výsledek
- `showHint`/`trHint` zobrazí jen `hints[0]`, tlačítko „💡 NÁPOVĚDA" se po použití vypne. Žádné 2 úrovně, žádný fallback „Výsledek: …".
- Audit přes Playwright: žádná hra nemá prázdný `hints[0]` ani „Výsledek:" v první nápovědě.
- Opraveny nápovědy, které prozrazovaly odpověď (krychle stěny/hrany, osa úsečky, NSD, rozpočítané rovnice v tasks-7/8/9).
- XP penalizace za nápovědu zůstává (`BT.hl=1`).

## Testy
- **Nový** `tests/rpg-boss-lock.test.cjs` — 48 ✅ (zámek po výhře, no-op submit, jediná nápověda, MC opačné znaménko, vše × 4 hry)
- `tests/vstudents-deep.harness.cjs` aktualizován na jedinou nápovědu — 65 ✅
- `rpg-train(-6/7/8)` 4×12 ✅ · `rpg-tower-game` 27 ✅ · `rpg-battle-questions` 15 ✅ · audity bank 4× 0 problémů (2M generací)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_