### PR TITLE
Add @media (prefers-reduced-motion) to all games and tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 travels/images/ua_2017/originals/
 travels/images/cr_bh_2018/originals/
 .claude/
+tests/diag-*.cjs

--- a/projects/cesta_penez.html
+++ b/projects/cesta_penez.html
@@ -555,6 +555,7 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
   font-size:1.35rem;cursor:pointer;padding:3px 7px;line-height:1;
   transition:border-color .15s,box-shadow .15s}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
 </style>
 </head>
 <body>

--- a/projects/procenta_priklady.html
+++ b/projects/procenta_priklady.html
@@ -572,6 +572,7 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
   line-height:1;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 .lang-btn:hover{border-color:var(--blue);box-shadow:0 2px 8px rgba(26,115,200,.2)}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
 </style>
 </head>
 <body>

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -421,6 +421,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 .reduced-motion .victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}
 .reduced-motion .gold-drop.go,.reduced-motion .particle.go{display:none!important}
 .reduced-motion .hit-flash.go,.reduced-motion .bt-input.player-hit,.reduced-motion .bt-monster.charge{animation:none!important}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}.float-txt{display:none!important}#hit-vignette{display:none!important}#levelup.show .lvl-bg,#levelup.show .lvl-ring,#levelup.show .lvl-txt,#levelup.show .lvl-sub{animation:none!important;opacity:1!important;transform:none!important}.victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}.gold-drop.go,.particle.go{display:none!important}.hit-flash.go,.bt-input.player-hit,.bt-monster.charge{animation:none!important}}
 /* ── INTRO ── */
 .blink{animation:blink 1s steps(1) infinite}
 @keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -407,6 +407,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 .reduced-motion .victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}
 .reduced-motion .gold-drop.go,.reduced-motion .particle.go{display:none!important}
 .reduced-motion .hit-flash.go,.reduced-motion .bt-input.player-hit,.reduced-motion .bt-monster.charge{animation:none!important}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}.float-txt{display:none!important}#hit-vignette{display:none!important}#levelup.show .lvl-bg,#levelup.show .lvl-ring,#levelup.show .lvl-txt,#levelup.show .lvl-sub{animation:none!important;opacity:1!important;transform:none!important}.victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}.gold-drop.go,.particle.go{display:none!important}.hit-flash.go,.bt-input.player-hit,.bt-monster.charge{animation:none!important}}
 /* ── INTRO ── */
 .blink{animation:blink 1s steps(1) infinite}
 @keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -422,6 +422,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 .reduced-motion .victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}
 .reduced-motion .gold-drop.go,.reduced-motion .particle.go{display:none!important}
 .reduced-motion .hit-flash.go,.reduced-motion .bt-input.player-hit,.reduced-motion .bt-monster.charge{animation:none!important}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}.float-txt{display:none!important}#hit-vignette{display:none!important}#levelup.show .lvl-bg,#levelup.show .lvl-ring,#levelup.show .lvl-txt,#levelup.show .lvl-sub{animation:none!important;opacity:1!important;transform:none!important}.victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}.gold-drop.go,.particle.go{display:none!important}.hit-flash.go,.bt-input.player-hit,.bt-monster.charge{animation:none!important}}
 /* ── INTRO ── */
 .blink{animation:blink 1s steps(1) infinite}
 @keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -396,6 +396,7 @@ body::before{
 .reduced-motion .victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}
 .reduced-motion .gold-drop.go,.reduced-motion .particle.go{display:none!important}
 .reduced-motion .hit-flash.go,.reduced-motion .bt-input.player-hit,.reduced-motion .bt-monster.charge{animation:none!important}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}.float-txt{display:none!important}#hit-vignette{display:none!important}#levelup.show .lvl-bg,#levelup.show .lvl-ring,#levelup.show .lvl-txt,#levelup.show .lvl-sub{animation:none!important;opacity:1!important;transform:none!important}.victory-banner.go{animation:none!important;opacity:1!important;transform:translate(-50%,-50%)!important}.gold-drop.go,.particle.go{display:none!important}.hit-flash.go,.bt-input.player-hit,.bt-monster.charge{animation:none!important}}
 /* ── CERMAT CHIP ── */
 .cermat-chip{display:inline-flex;align-items:center;gap:5px;font-family:var(--px);font-weight:700;font-size:12px;padding:3px 9px;border:2px solid;letter-spacing:.5px}
 .cermat-chip.cc-far{color:#6dd0e8;background:#040d12;border-color:#3a8a9e}

--- a/projects/unikovka_procenta.html
+++ b/projects/unikovka_procenta.html
@@ -204,6 +204,7 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
   line-height:1;box-shadow:0 1px 4px rgba(0,0,0,.08)}
 .lang-btn:hover{border-color:var(--blue);box-shadow:0 2px 8px rgba(26,115,200,.2)}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}.chest{animation:none!important}.confetti-piece{display:none!important}}
 </style>
 </head>
 <body>

--- a/projects/unikovka_telesa.html
+++ b/projects/unikovka_telesa.html
@@ -209,6 +209,7 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
   font-size:1.35rem;cursor:pointer;padding:3px 7px;line-height:1;
   transition:border-color .15s,box-shadow .15s}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
+@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}.chest{animation:none!important}.confetti-piece{display:none!important}}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Added `@media(prefers-reduced-motion:reduce)` block to all 4 RPG games (rpg-mat-6/7/8/9) — suppresses float-txt, hit-vignette, levelup, victory-banner, particles, hit-flash, player-hit, charge animations automatically when the OS preference is set
- Added same `*{animation:none;transition:none}` block to cesta_penez, procenta_priklady, unikovka_procenta, unikovka_telesa — covers shake, popIn, float, bounce, confetti-fall
- For unikovky also hides `.confetti-piece` (display:none) since confetti JS dynamically creates elements mid-animation
- Added `tests/diag-*.cjs` to .gitignore to prevent stray diagnostic scripts from showing as untracked

The existing `.reduced-motion` JS-toggled class is preserved — the new `@media` block makes it work automatically without any JS needed.

## Test plan
- [ ] Set OS reduced motion preference (Windows: Settings → Accessibility → Visual effects → Animation effects off)
- [ ] Open any RPG game — no animations should play (boss sprite, VFX, particles, hit-flash all static)
- [ ] Open unikovka_procenta — chest emoji should not float, confetti should not appear on completion
- [ ] Normal users (no OS preference set) should see no change

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_