### PR TITLE
Mobile/responsive audit: enlarge small tap targets + 360px regression test

### DIFF
--- a/projects/cesta_penez.html
+++ b/projects/cesta_penez.html
@@ -63,7 +63,7 @@ a:focus-visible { outline: 2px solid var(--blue); outline-offset: 3px; border-ra
   padding-bottom: 10px;
   align-items: center;
 }
-.top-bar a { color: var(--muted); }
+.top-bar a { color: var(--muted); display: inline-block; padding: 6px 0; }
 .top-bar a:hover { color: var(--blue); }
 .top-bar .mid { display:flex; align-items:center; gap:10px; }
 .coins {

--- a/projects/index.html
+++ b/projects/index.html
@@ -201,7 +201,7 @@
     .filter-bar { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin: 6px 0 10px; }
     .filter-tag {
       background: none; border: 1px dashed var(--fg-dim); color: var(--fg-dim);
-      border-radius: 3px; padding: 1px 8px; font-family: var(--mono); font-size: 11px;
+      border-radius: 3px; padding: 5px 9px; font-family: var(--mono); font-size: 11px;
       cursor: pointer; transition: all 0.15s; line-height: 1.6;
     }
     .filter-tag:hover { border-color: var(--accent); color: var(--accent); border-style: solid; }

--- a/projects/prijimacky-matematika/index.html
+++ b/projects/prijimacky-matematika/index.html
@@ -72,7 +72,7 @@
       display: flex; justify-content: space-between; gap: 18px;
       font-size: .82rem; color: var(--muted);
     }
-    .top-bar a { color: var(--muted); }
+    .top-bar a { color: var(--muted); display: inline-block; padding: 6px 0; }
     .top-bar a:hover { color: var(--blue); }
     .top-bar .crumb { color: var(--text); font-weight: 500; }
 
@@ -238,7 +238,7 @@
       color: var(--muted);
       font-size: .82rem;
     }
-    footer a { color: var(--muted); }
+    footer a { color: var(--muted); display: inline-block; padding: 4px 0; }
     footer a:hover { color: var(--blue); }
 
     /* CERMAT COUNTDOWN CHIP */

--- a/projects/procenta_priklady.html
+++ b/projects/procenta_priklady.html
@@ -60,7 +60,7 @@ a:focus-visible { outline: 2px solid var(--blue); outline-offset: 3px; border-ra
   display: flex; justify-content: space-between; gap: 18px;
   padding-bottom: 10px;
 }
-.top-bar a { color: var(--muted); }
+.top-bar a { color: var(--muted); display: inline-block; padding: 6px 0; }
 .top-bar a:hover { color: var(--blue); }
 
 /* INTRO */

--- a/tests/mobile-audit.cjs
+++ b/tests/mobile-audit.cjs
@@ -1,0 +1,102 @@
+/* Mobilní/responzivní audit — načte každou stránku na 360px šířce a hlásí:
+   - horizontální přetečení (scrollWidth > clientWidth)
+   - prvky vyčuhující za pravý okraj viewportu
+   - malé klikací plochy (<40px) u tlačítek/odkazů
+   Spusť: node tests/mobile-audit.cjs
+*/
+const http = require('http'); const fs = require('fs'); const path = require('path');
+const { chromium } = require('playwright');
+const ROOT = path.join(__dirname, '..');
+const EXEC = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+const MIME = {'.html':'text/html','.js':'text/javascript','.css':'text/css','.png':'image/png','.jpg':'image/jpeg','.svg':'image/svg+xml'};
+
+function serve(){return new Promise(res=>{const s=http.createServer((q,r)=>{let u=decodeURIComponent(q.url.split('?')[0]);if(u.endsWith('/'))u+='index.html';const f=path.normalize(path.join(ROOT,u));if(!f.startsWith(ROOT+path.sep)||!fs.existsSync(f)||fs.statSync(f).isDirectory()){r.writeHead(404);return r.end();}r.writeHead(200,{'Content-Type':MIME[path.extname(f)]||'application/octet-stream'});fs.createReadStream(f).pipe(r);});s.listen(0,()=>res(s));});}
+
+const PAGES = [
+ ['Home (terminal)','/index.html'],
+ ['404','/404.html'],
+ ['Projects index','/projects/index.html'],
+ ['Přijímačky archiv','/projects/prijimacky-matematika/index.html'],
+ ['Únikovka procenta','/projects/unikovka_procenta.html'],
+ ['Únikovka tělesa','/projects/unikovka_telesa.html'],
+ ['Procenta příklady','/projects/procenta_priklady.html'],
+ ['Cesta peněz','/projects/cesta_penez.html'],
+ ['RPG hub','/projects/rpg-matematika.html'],
+ ['RPG mat 6','/projects/rpg-mat-6.html'],
+ ['RPG mat 7','/projects/rpg-mat-7.html'],
+ ['RPG mat 8','/projects/rpg-mat-8.html'],
+ ['RPG mat 9','/projects/rpg-mat-9.html'],
+ ['Travels index','/travels/index.html'],
+];
+
+const VW = 360, VH = 740;
+
+(async()=>{
+ const srv=await serve(); const base='http://127.0.0.1:'+srv.address().port;
+ const browser=await chromium.launch({executablePath:EXEC});
+ let totalIssues=0;
+ for(const [name,url] of PAGES){
+  const ctx=await browser.newContext({viewport:{width:VW,height:VH},deviceScaleFactor:2,isMobile:true,hasTouch:true});
+  const page=await ctx.newPage();
+  const errs=[]; page.on('pageerror',e=>errs.push(e.message));
+  try{
+   await page.goto(base+url,{waitUntil:'load',timeout:15000});
+   await page.waitForTimeout(600);
+  }catch(e){console.log('\n### '+name+'  ('+url+')\n  ⚠️ NELZE NAČÍST: '+e.message);await ctx.close();continue;}
+
+  const report=await page.evaluate((VW)=>{
+   const out={overflowDoc:false,docW:0,offRight:[],smallTaps:[],tinyFont:[]};
+   const de=document.documentElement;
+   out.docW=Math.max(de.scrollWidth,document.body?document.body.scrollWidth:0);
+   out.overflowDoc=out.docW>VW+1;
+   // prvky vyčuhující výrazně za pravý okraj (>4px), jen viditelné
+   const all=[...document.querySelectorAll('body *')];
+   const seen=new Set();
+   for(const el of all){
+    const cs=getComputedStyle(el);
+    if(cs.display==='none'||cs.visibility==='hidden'||parseFloat(cs.opacity)===0)continue;
+    const r=el.getBoundingClientRect();
+    if(r.width===0||r.height===0)continue;
+    if(r.right>VW+4&&r.width<=VW+40){ // ignoruj plnošířkové wrappery, hlas konkrétní vyčuhující prvky
+     const sel=el.tagName.toLowerCase()+(el.id?'#'+el.id:'')+(el.className&&typeof el.className==='string'?'.'+el.className.trim().split(/\s+/).slice(0,2).join('.'):'');
+     if(!seen.has(sel)){seen.add(sel);out.offRight.push({sel,right:Math.round(r.right),w:Math.round(r.width)});}
+    }
+   }
+   // malé klikací plochy: viditelná tlačítka/odkazy s rozměrem <40px (a obsahem)
+   const taps=[...document.querySelectorAll('button,a,[role=button],input[type=button],input[type=submit],.btn')];
+   const tapSeen=new Set();
+   for(const el of taps){
+    const cs=getComputedStyle(el);
+    if(cs.display==='none'||cs.visibility==='hidden'||parseFloat(cs.opacity)===0)continue;
+    const r=el.getBoundingClientRect();
+    if(r.width===0||r.height===0)continue;
+    const txt=(el.textContent||el.value||'').trim().slice(0,24);
+    if(!txt&&!el.querySelector('img,svg'))continue;
+    if(r.height<40||r.width<32){
+     const key=el.tagName+'|'+txt+'|'+Math.round(r.height);
+     if(!tapSeen.has(key)){tapSeen.add(key);out.smallTaps.push({txt:txt||'(ikona)',h:Math.round(r.height),w:Math.round(r.width)});}
+    }
+   }
+   return out;
+  },VW);
+
+  const issues=[];
+  if(report.overflowDoc)issues.push('📏 horizontální přetečení dokumentu: scrollWidth='+report.docW+'px (>'+VW+')');
+  if(report.offRight.length)issues.push('➡️  '+report.offRight.length+' prvků vyčuhuje vpravo: '+report.offRight.slice(0,6).map(o=>o.sel+' (right='+o.right+',w='+o.w+')').join('  |  '));
+  if(report.smallTaps.length)issues.push('👆 '+report.smallTaps.length+' malých klik. ploch (<40px): '+report.smallTaps.slice(0,10).map(t=>'"'+t.txt+'" '+t.w+'×'+t.h).join(', '));
+  if(errs.length)issues.push('🐞 JS chyby: '+errs.slice(0,2).join(' | '));
+
+  if(issues.length){
+   console.log('\n### '+name+'  ('+url+')');
+   issues.forEach(i=>console.log('  '+i));
+   totalIssues+=issues.length;
+  }else{
+   console.log('\n### '+name+'  ('+url+')\n  ✅ OK (docW='+report.docW+')');
+  }
+  await ctx.close();
+ }
+ await browser.close(); srv.close();
+ console.log('\n==========================================');
+ console.log('  CELKEM nálezů: '+totalIssues);
+ console.log('==========================================');
+})().catch(e=>{console.error(e);process.exit(1);});

--- a/travels/index.html
+++ b/travels/index.html
@@ -225,7 +225,7 @@
       text-transform: uppercase;
       color: var(--fg-dim);
     }
-    footer a { color: var(--fg-dim); border-bottom: 1px solid transparent; }
+    footer a { color: var(--fg-dim); border-bottom: 1px solid transparent; display: inline-block; padding: 5px 0; }
     footer a:hover { color: var(--accent); border-bottom-color: var(--accent); }
 
     /* ───────────── RESPONSIVE ───────────── */


### PR DESCRIPTION
## Summary
Second of the four improvement areas. Ran a full responsive audit of every page at **360px** (the small-phone width students use) and fixed the findings.

### Audit result (good news first)
- ✅ **No horizontal overflow** on any page (home, 404, projects, přijímačky, all 4 RPG games, RPG hub, both únikovky, procenta, cesta peněz, travels)
- ✅ **No off-screen / overflowing elements**
- ✅ **No JS errors** at mobile viewport
- The only finding category was **tap-target size** on a few secondary nav / filter links below the WCAG-AA 24px minimum.

### Fixes (text & font unchanged — only larger click area)
| Element | Before | After |
|---|---|---|
| `projects/` filter chips | 22px | **30px** |
| Přijímačky `domů`/`projekty` links | 15px | **29px** |
| Procenta/Cesta `← zpět` / `domů` | 21px | **33px** |
| Travels `HOME ↗` footer link | 18px | **28px** |

Left intentionally: the **terminal home page** inline links (17px) — adding padding would break its monospace line grid, which is core to that page's aesthetic. Flag toggles (28–32px), únikovka nav (30px) and RPG-hub buttons (34–37px) all already clear the 24px AA bar.

### New regression tool
`tests/mobile-audit.cjs` — serves the repo and loads each page at 360px in Playwright, reporting horizontal overflow, off-right elements and sub-40px tap targets. No test previously checked small viewports. Run: `node tests/mobile-audit.cjs`.

## Test plan
- [ ] `node tests/mobile-audit.cjs` → only remaining sub-24px item is the intentional terminal home links
- [ ] Open `/projects/` on a phone — filter chips easier to tap, terminal look unchanged
- [ ] Open a tool page (procenta/cesta) — `zpět`/`domů` links bigger, top-bar not misaligned

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_