### PR TITLE
perf: defer all external scripts in RPG games (0 render-blocking)

### DIFF
--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -3079,16 +3079,16 @@ window.addEventListener('load',()=>{
  }
 });
 </script>
-<script src="./rpg-sprites-6.js"></script>
-<script src="./rpg-tasks-6.js"></script>
-<script src="./rpg-learn-6.js"></script>
-<script src="./rpg-wallet.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="./rpg-cloud.js"></script>
-<script src="./rpg-battle-6.js"></script>
-<script src="./rpg-shared.js"></script>
-<script src="./rpg-tasktypes.js"></script>
-<script src="./rpg-battle-ui.js"></script>
-<script>RPGCloud.attachGame(SAVE_KEY);</script>
+<script defer src="./rpg-sprites-6.js"></script>
+<script defer src="./rpg-tasks-6.js"></script>
+<script defer src="./rpg-learn-6.js"></script>
+<script defer src="./rpg-wallet.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script defer src="./rpg-cloud.js"></script>
+<script defer src="./rpg-battle-6.js"></script>
+<script defer src="./rpg-shared.js"></script>
+<script defer src="./rpg-tasktypes.js"></script>
+<script defer src="./rpg-battle-ui.js"></script>
+<script>window.addEventListener('load',function(){if(window.RPGCloud&&RPGCloud.attachGame)RPGCloud.attachGame(SAVE_KEY);});</script>
 </body>
 </html>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -3088,16 +3088,16 @@ window.addEventListener('load',()=>{
  }
 });
 </script>
-<script src="./rpg-sprites-7.js"></script>
-<script src="./rpg-tasks-7.js"></script>
-<script src="./rpg-learn-7.js"></script>
-<script src="./rpg-wallet.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="./rpg-cloud.js"></script>
-<script src="./rpg-battle-7.js"></script>
-<script src="./rpg-shared.js"></script>
-<script src="./rpg-tasktypes.js"></script>
-<script src="./rpg-battle-ui.js"></script>
-<script>RPGCloud.attachGame(SAVE_KEY);</script>
+<script defer src="./rpg-sprites-7.js"></script>
+<script defer src="./rpg-tasks-7.js"></script>
+<script defer src="./rpg-learn-7.js"></script>
+<script defer src="./rpg-wallet.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script defer src="./rpg-cloud.js"></script>
+<script defer src="./rpg-battle-7.js"></script>
+<script defer src="./rpg-shared.js"></script>
+<script defer src="./rpg-tasktypes.js"></script>
+<script defer src="./rpg-battle-ui.js"></script>
+<script>window.addEventListener('load',function(){if(window.RPGCloud&&RPGCloud.attachGame)RPGCloud.attachGame(SAVE_KEY);});</script>
 </body>
 </html>

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -3300,16 +3300,16 @@ window.addEventListener('load',()=>{
  }
 });
 </script>
-<script src="./rpg-sprites-8.js"></script>
-<script src="./rpg-tasks-8.js"></script>
-<script src="./rpg-learn-8.js"></script>
-<script src="./rpg-wallet.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="./rpg-cloud.js"></script>
-<script src="./rpg-battle-8.js"></script>
-<script src="./rpg-shared.js"></script>
-<script src="./rpg-tasktypes.js"></script>
-<script src="./rpg-battle-ui.js"></script>
-<script>RPGCloud.attachGame(SAVE_KEY);</script>
+<script defer src="./rpg-sprites-8.js"></script>
+<script defer src="./rpg-tasks-8.js"></script>
+<script defer src="./rpg-learn-8.js"></script>
+<script defer src="./rpg-wallet.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script defer src="./rpg-cloud.js"></script>
+<script defer src="./rpg-battle-8.js"></script>
+<script defer src="./rpg-shared.js"></script>
+<script defer src="./rpg-tasktypes.js"></script>
+<script defer src="./rpg-battle-ui.js"></script>
+<script>window.addEventListener('load',function(){if(window.RPGCloud&&RPGCloud.attachGame)RPGCloud.attachGame(SAVE_KEY);});</script>
 </body>
 </html>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -842,9 +842,9 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 </div>
 
 <!-- rozšiřující banka úloh (nepovinná; bez ní hra běží na základním poolu) -->
-<script src="./rpg-tasks-9.js"></script>
-<script src="./rpg-sprites-9.js"></script>
-<script src="./rpg-learn-9.js"></script>
+<script defer src="./rpg-tasks-9.js"></script>
+<script defer src="./rpg-sprites-9.js"></script>
+<script defer src="./rpg-learn-9.js"></script>
 <script>
 // ══════════════════════════════════════════
 // HELPERS
@@ -3244,13 +3244,13 @@ window.addEventListener('load',()=>{
  }
 });
 </script>
-<script src="./rpg-wallet.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-<script src="./rpg-cloud.js"></script>
-<script src="./rpg-battle-9.js"></script>
-<script src="./rpg-shared.js"></script>
-<script src="./rpg-tasktypes.js"></script>
-<script src="./rpg-battle-ui.js"></script>
-<script>RPGCloud.attachGame(SAVE_KEY);</script>
+<script defer src="./rpg-wallet.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+<script defer src="./rpg-cloud.js"></script>
+<script defer src="./rpg-battle-9.js"></script>
+<script defer src="./rpg-shared.js"></script>
+<script defer src="./rpg-tasktypes.js"></script>
+<script defer src="./rpg-battle-ui.js"></script>
+<script>window.addEventListener('load',function(){if(window.RPGCloud&&RPGCloud.attachGame)RPGCloud.attachGame(SAVE_KEY);});</script>
 </body>
 </html>

--- a/tests/perf.test.cjs
+++ b/tests/perf.test.cjs
@@ -1,0 +1,48 @@
+/* Výkonová regrese — hlídá, že se externí skripty u her nenačítají render-blocking.
+   Po optimalizaci mají všechny 4 RPG hry 0 blokujících externích skriptů (vše defer),
+   takže Supabase CDN ani banky úloh neblokují parsování. Test taky ověří, že se
+   stránky načtou bez JS chyb a že počet requestů nepřekročí rozpočet.
+   Spusť: node tests/perf.test.cjs
+*/
+const http = require('http'); const fs = require('fs'); const path = require('path');
+const { chromium } = require('playwright');
+const ROOT = path.join(__dirname, '..');
+const EXEC = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+const MIME = {'.html':'text/html','.js':'text/javascript','.css':'text/css','.png':'image/png','.jpg':'image/jpeg','.svg':'image/svg+xml','.json':'application/json'};
+let pass=0, fail=0; const ok=(c,m)=>{c?(pass++,console.log('  ✅ '+m)):(fail++,console.log('  ❌ '+m));};
+
+function serve(){return new Promise(res=>{const s=http.createServer((q,r)=>{let u=decodeURIComponent(q.url.split('?')[0]);if(u.endsWith('/'))u+='index.html';const f=path.normalize(path.join(ROOT,u));if(!f.startsWith(ROOT+path.sep)||!fs.existsSync(f)||fs.statSync(f).isDirectory()){r.writeHead(404);return r.end();}r.writeHead(200,{'Content-Type':MIME[path.extname(f)]||'application/octet-stream'});fs.createReadStream(f).pipe(r);});s.listen(0,()=>res(s));});}
+
+// hry musí mít 0 render-blocking externích skriptů (vše defer)
+const GAMES = ['/projects/rpg-mat-6.html','/projects/rpg-mat-7.html','/projects/rpg-mat-8.html','/projects/rpg-mat-9.html'];
+
+(async()=>{
+ const srv=await serve(); const base='http://127.0.0.1:'+srv.address().port;
+ const browser=await chromium.launch({executablePath:EXEC});
+ for(const u of GAMES){
+  const ctx=await browser.newContext(); const p=await ctx.newPage(); const errs=[]; p.on('pageerror',e=>errs.push(e.message));
+  await p.goto(base+u,{waitUntil:'load',timeout:20000});
+  const m=await p.evaluate(()=>{
+   const ext=[...document.querySelectorAll('script[src]')];
+   return {
+    ext:ext.length,
+    blocking:ext.filter(s=>!s.defer&&!s.async).length,
+    blockingSrc:ext.filter(s=>!s.defer&&!s.async).map(s=>s.getAttribute('src')),
+    // klíčové globály z odložených skriptů musí být po 'load' k dispozici
+    sprites:typeof window.RPGSprites6!=='undefined'||typeof window.RPGSprites7!=='undefined'||typeof window.RPGSprites8!=='undefined'||typeof window.RPGSprites9!=='undefined',
+    launch:typeof launchBattle==='function',
+   };
+  });
+  ok(m.blocking===0, u+' nemá render-blocking externí skripty (našel '+m.blocking+(m.blocking?': '+m.blockingSrc.join(','):'')+')');
+  ok(m.ext>=8, u+' má externí skripty s defer ('+m.ext+')');
+  ok(m.sprites, u+' sprite modul k dispozici po load (defer dojel)');
+  ok(m.launch, u+' launchBattle definován');
+  ok(errs.length===0, u+' bez JS chyb'+(errs.length?(' ['+errs[0]+']'):''));
+  await ctx.close();
+ }
+ await browser.close(); srv.close();
+ console.log('\n==========================================');
+ console.log('  VÝSLEDEK: '+pass+' ✅ / '+fail+' ❌');
+ console.log('==========================================');
+ process.exit(fail?1:0);
+})().catch(e=>{console.error(e);process.exit(1);});


### PR DESCRIPTION
## Summary
- All `<script src>` tags in rpg-mat-6/7/8/9.html now carry `defer` — Supabase CDN + all module JS (tasks/sprites/learn/wallet/cloud/battle/shared/tasktypes/battle-ui) download in parallel without blocking HTML parsing
- `attachGame(SAVE_KEY)` call converted to `window.addEventListener('load', ...)` guard
- New regression test `tests/perf.test.cjs` (Playwright) checks all 4 games: 0 blocking external scripts, ≥8 deferred externals, sprite globals present after load, launchBattle defined, no JS errors

## Test plan
- [x] `node tests/perf.test.cjs` — 20/20
- [x] `node tests/rpg-boss-lock.test.cjs` — 48/48
- [x] `node tests/rpg-train.test.cjs` — 12/12

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_