### PR TITLE
fix: attack-btn locked after correct answer, YN buttons reset, explain delete

### DIFF
--- a/projects/rpg-cloud-setup-phase6.sql
+++ b/projects/rpg-cloud-setup-phase6.sql
@@ -38,3 +38,9 @@ create policy "expl_read_staff" on explanations
   for select using (
     (select my_role()) in ('teacher', 'superadmin')
   );
+
+-- učitel/superadmin může mazat záznamy
+create policy "expl_delete_staff" on explanations
+  for delete using (
+    (select my_role()) in ('teacher', 'superadmin')
+  );

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -723,7 +723,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div class="bt-problem" id="bt-prob">...</div>
  <div class="bt-row" id="bt-input-row">
  <input id="bt-ans" aria-label="Odpověď" class="bt-input" type="text" placeholder="?" autocomplete="off">
- <button class="btn" onclick="submitAnswer()" style="white-space:nowrap">ÚTOK ⚔</button>
+ <button id="attack-btn" class="btn" onclick="submitAnswer()" style="white-space:nowrap">ÚTOK ⚔</button>
  </div>
  <div class="bt-row" id="yn-row" style="display:none">
  <button class="btn g" style="flex:1" onclick="answerYN('ANO')">✓ ANO</button>
@@ -1944,6 +1944,7 @@ function renderTask(){
  const yn=isYN(t);
  document.getElementById('bt-input-row').style.display=yn?'none':'flex';
  document.getElementById('yn-row').style.display=yn?'flex':'none';
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=false);
  document.getElementById('hint-btn').style.display='inline-block';
  document.getElementById('mc-grid').style.display='none';
  document.getElementById('bt-ans').value='';
@@ -2346,6 +2347,7 @@ function submitAnswer(){
  saveS();
  document.getElementById('bt-ans').disabled=true;
  document.getElementById('hint-btn').disabled=true;
+ document.getElementById('attack-btn').disabled=true;
  document.getElementById('next-btn').style.display='inline-block';
  if(!BT.mcMode)document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -723,7 +723,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div class="bt-problem" id="bt-prob">...</div>
  <div class="bt-row" id="bt-input-row">
  <input id="bt-ans" aria-label="Odpověď" class="bt-input" type="text" placeholder="?" autocomplete="off">
- <button class="btn" onclick="submitAnswer()" style="white-space:nowrap">ÚTOK ⚔</button>
+ <button id="attack-btn" class="btn" onclick="submitAnswer()" style="white-space:nowrap">ÚTOK ⚔</button>
  </div>
  <div class="bt-row" id="yn-row" style="display:none">
  <button class="btn g" style="flex:1" onclick="answerYN('ANO')">✓ ANO</button>
@@ -1956,6 +1956,7 @@ function renderTask(){
  const yn=isYN(t);
  document.getElementById('bt-input-row').style.display=yn?'none':'flex';
  document.getElementById('yn-row').style.display=yn?'flex':'none';
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=false);
  document.getElementById('hint-btn').style.display='inline-block';
  document.getElementById('mc-grid').style.display='none';
  document.getElementById('bt-ans').value='';
@@ -2358,6 +2359,7 @@ function submitAnswer(){
  saveS();
  document.getElementById('bt-ans').disabled=true;
  document.getElementById('hint-btn').disabled=true;
+ document.getElementById('attack-btn').disabled=true;
  document.getElementById('next-btn').style.display='inline-block';
  if(!BT.mcMode)document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -723,7 +723,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div class="bt-problem" id="bt-prob">...</div>
  <div class="bt-row" id="bt-input-row">
  <input id="bt-ans" aria-label="Odpověď" class="bt-input" type="text" placeholder="?" autocomplete="off">
- <button class="btn" onclick="submitAnswer()" style="white-space:nowrap">ÚTOK ⚔</button>
+ <button id="attack-btn" class="btn" onclick="submitAnswer()" style="white-space:nowrap">ÚTOK ⚔</button>
  </div>
  <div class="bt-row" id="yn-row" style="display:none">
  <button class="btn g" style="flex:1" onclick="answerYN('ANO')">✓ ANO</button>
@@ -2166,6 +2166,7 @@ function renderTask(){
  const yn=isYN(t);
  document.getElementById('bt-input-row').style.display=yn?'none':'flex';
  document.getElementById('yn-row').style.display=yn?'flex':'none';
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=false);
  document.getElementById('hint-btn').style.display='inline-block';
  document.getElementById('mc-grid').style.display='none';
  document.getElementById('bt-ans').value='';
@@ -2568,6 +2569,7 @@ function submitAnswer(){
  saveS();
  document.getElementById('bt-ans').disabled=true;
  document.getElementById('hint-btn').disabled=true;
+ document.getElementById('attack-btn').disabled=true;
  document.getElementById('next-btn').style.display='inline-block';
  if(!BT.mcMode)document.getElementById('bt-explain').style.display='block';
  damageMonster(xpGain,isCrit);

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -2109,6 +2109,7 @@ function renderTask(){
  const yn=isYN(t);
  document.getElementById('bt-input-row').style.display=yn?'none':'flex';
  document.getElementById('yn-row').style.display=yn?'flex':'none';
+ document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=false);
  document.getElementById('hint-btn').style.display='inline-block';
  document.getElementById('mc-grid').style.display='none';
  document.getElementById('bt-ans').value='';


### PR DESCRIPTION
## Fixes

### Bug: clicking attack after correct answer (issue reported by student)
- Games 6/7/8 were missing `id="attack-btn"` on the attack button, so `document.getElementById('attack-btn').disabled=true` was silently a no-op
- Added `id="attack-btn"` to all 3 games, and added the `attack-btn.disabled=true` line in the correct-answer branch of `submitAnswer()`
- Game 9 already had this correct

### Issue #104: ANO/NE first task in 8th grade can't be clicked
- `checkMissionComplete()` disables `#yn-row button` when a mission is won
- `renderTask()` was not re-enabling those buttons when showing the next task
- Added `document.querySelectorAll('#yn-row button').forEach(b=>b.disabled=false)` in `renderTask()` for all 4 games

### Issue #102: explanation delete doesn't work in teacher console
- `explanations` table RLS had INSERT + SELECT policies but **no DELETE policy**
- Supabase silently deleted 0 rows without an error, so `res.ok` was true but nothing was deleted
- Added `expl_delete_staff` DELETE policy to `rpg-cloud-setup-phase6.sql`
- **Action needed: run the new policy SQL on Supabase** (see last block in rpg-cloud-setup-phase6.sql)

## Test plan
- [x] `node tests/rpg-boss-lock.test.cjs` — 48/48
- [x] `node tests/rpg-attack-initial.test.cjs` — 60/60
- [ ] After merging, run in Supabase SQL editor: `create policy "expl_delete_staff" on explanations for delete using ((select my_role()) in ('teacher', 'superadmin'));`

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_