### PR TITLE
feat: tower & leaderboards for teachers (#103) + fix ?su/preview regression

### DIFF
--- a/projects/rpg-cloud-setup-phase12.sql
+++ b/projects/rpg-cloud-setup-phase12.sql
@@ -1,0 +1,74 @@
+-- ════════════════════════════════════════════════════════════════════
+--  RPG Matematika — FÁZE 12: Věž legend — nástroje pro učitele
+--  ────────────────────────────────────────────────────────────────────
+--  Issue #103:
+--   • Učitel chce vidět žebříček věže i bez vlastní třídy → tower_board
+--     to už umí (není omezený na třídu), ale neumí vrátit user_id pro
+--     správu. Přidáváme tower_board_admin (jen STAFF), který vrací i
+--     user_id + runs, aby šlo žáka z žebříčku smazat.
+--   • Smazání žáka z žebříčku věže → tower_delete_run (jen STAFF).
+--
+--  Model jako fáze 11: žádný přímý přístup k tabulkám, vše přes
+--  SECURITY DEFINER RPC. Spustit PO fázi 11 (a po fázi 2 kvůli my_role()).
+-- ════════════════════════════════════════════════════════════════════
+
+-- ── 1) Žebříček sezóny pro učitele (vč. user_id a počtu pokusů) ───────
+-- Stejná data jako tower_board, ale jen pro učitele/superadmina a navíc
+-- s user_id (pro mazání) a runs (statistika). Není omezeno na třídu —
+-- učitel vidí všechny, kdo v dané sezóně lezli, i bez vlastní třídy.
+create or replace function public.tower_board_admin(p_game text)
+returns table (user_id uuid, display_name text, best_floor int, runs int, updated_at timestamptz)
+language sql stable security definer set search_path = public as $$
+  select
+    t.user_id,
+    coalesce(nullif(s.name, ''), nullif(s.full_name, ''), 'Hráč') as display_name,
+    t.best_floor,
+    t.runs,
+    t.updated_at
+  from public.tower_runs t
+  left join public.saves s on s.user_id = t.user_id and s.game = t.game
+  where t.game = p_game
+    and t.season = _season_label()
+    and (select my_role()) in ('teacher', 'superadmin')
+  order by t.best_floor desc, t.updated_at asc
+  limit 100;
+$$;
+
+-- ── 2) Smazání žáka z žebříčku věže (aktuální sezóna) ────────────────
+-- Učitel/superadmin smaže pokus žáka v AKTUÁLNÍ sezóně dané hry. Síň
+-- slávy (tower_hall) zůstává nedotčená — to je trvalý historický zápis.
+-- Vrací počet smazaných řádků (0 = nic k smazání).
+create or replace function public.tower_delete_run(p_user_id uuid, p_game text)
+returns int
+language plpgsql security definer set search_path = public as $$
+declare v_n int;
+begin
+  if (select my_role()) not in ('teacher', 'superadmin') then
+    raise exception 'forbidden';
+  end if;
+  if p_user_id is null then raise exception 'missing user'; end if;
+  delete from public.tower_runs
+   where user_id = p_user_id and game = p_game and season = _season_label();
+  get diagnostics v_n = row_count;
+  return v_n;
+end $$;
+
+-- ── 3) Práva (vzor fáze 9/11: anon nikam, jen authenticated) ─────────
+do $$
+declare f text;
+begin
+  foreach f in array array[
+    'public.tower_board_admin(text)',
+    'public.tower_delete_run(uuid,text)'
+  ]
+  loop
+    execute format('revoke execute on function %s from public, anon;', f);
+    execute format('grant  execute on function %s to authenticated;',  f);
+  end loop;
+end $$;
+
+-- ════════════════════════════════════════════════════════════════════
+--  Hotovo. Konzole (záložka VĚŽ LEGEND) teď u žebříčku sezóny ukáže
+--  tlačítko 🗑 pro smazání žáka. Vstup učitele do věže (náhled) je čistě
+--  klientský — server žádný zápis nepřijme (tower_submit hlídá ročník).
+-- ════════════════════════════════════════════════════════════════════

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -662,6 +662,24 @@ window.RPGCloud = (function () {
       return { ok: true, count: data };
     } catch (e) { return { ok: false, error: String(e) }; }
   }
+  // Fáze 12 — žebříček sezóny pro učitele (vč. user_id pro mazání). Jen STAFF.
+  async function towerBoardAdmin(game) {
+    if (!client || !isStaff()) return [];
+    try {
+      const { data, error } = await client.rpc('tower_board_admin', { p_game: game });
+      if (error) throw error;
+      return data || [];
+    } catch (e) { console.warn('[RPGCloud] towerBoardAdmin:', e); return []; }
+  }
+  // Fáze 12 — smazání žáka z žebříčku věže (aktuální sezóna). Jen STAFF.
+  async function towerDeleteRun(userId, game) {
+    if (!client || !isStaff()) return { ok: false, error: 'Nemáš oprávnění.' };
+    try {
+      const { data, error } = await client.rpc('tower_delete_run', { p_user_id: userId, p_game: game });
+      if (error) return { ok: false, error: error.message };
+      return { ok: true, count: data };
+    } catch (e) { return { ok: false, error: String(e) }; }
+  }
 
   // centrální vykreslení žebříčku do prvku v mapě (žádné per-game edity).
   // Bez cloudu/preview → skryje. Bez přihlášení → teaser. Přihlášen → reálná data.
@@ -836,6 +854,14 @@ window.RPGCloud = (function () {
   /* napojení pro jednotlivou hru: lišta + stažení postavy po přihlášení.
      Učitelský náhled přes URL: ?preview=1 (hraní nanečisto) nebo
      ?su=<user_id>&game=<KEY> (read-only pohled na postavu žáka). */
+  // Spustí callback hned, když už DOM proběhl, jinak počká na DOMContentLoaded.
+  // Nutné, protože hry teď volají attachGame z 'load' listeneru (defer) =>
+  // DOMContentLoaded už mezitím proběhl a klasický listener by se nespustil.
+  function onDomReady(cb) {
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', cb);
+    else cb();
+  }
+
   function attachGame(saveKey, onLoaded) {
     const params  = new URLSearchParams(location.search);
     const preview = params.get('preview') === '1';
@@ -843,7 +869,7 @@ window.RPGCloud = (function () {
 
     if (preview || suId) { previewActive = true; sandboxStorage(saveKey); }
 
-    document.addEventListener('DOMContentLoaded', async () => {
+    onDomReady(async () => {
       // ── Učitelský pohled na postavu žáka (read-only) ──
       if (suId) {
         const okStaff = await requireStaff();
@@ -985,7 +1011,7 @@ window.RPGCloud = (function () {
 
   /* napojení pro hub: lišta + stažení všech postav a překreslení */
   function attachHub(games, rerender, mountSel) {
-    document.addEventListener('DOMContentLoaded', () => {
+    onDomReady(() => {
       const host = (mountSel && document.querySelector(mountSel)) || document.body;
       const after = document.getElementById('cloud-mount');
       const bar = makeBar('max-width:100%');
@@ -1028,5 +1054,7 @@ window.RPGCloud = (function () {
            advanceBattle, setBattleStatus, listActiveBattles,
            inviteBattleEmail, myBattleInvites, pollBattle,
            // Fáze 11 — věž legend
-           towerEligible, towerSubmit, towerBoard, towerHall, towerCloseSeason };
+           towerEligible, towerSubmit, towerBoard, towerHall, towerCloseSeason,
+           // Fáze 12 — věž legend: nástroje pro učitele
+           towerBoardAdmin, towerDeleteRun };
 })();

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -2462,6 +2462,15 @@ async function renderTowerGate(){
   act.innerHTML='<button class="btn b" onclick="var b=document.getElementById(\'cloud-btn\');if(b)b.click();">🔑 PŘIHLÁSIT SE</button>';
   return;
  }
+ // Učitel/superadmin smí vstoupit do KAŽDÉ věže jako náhled — postup se
+ // NEzapočítává (TW.practice ⇒ žádný zápis; server tower_submit ho stejně odmítne).
+ if(RPGCloud.isStaff&&RPGCloud.isStaff()){
+  TW.practice=true;
+  st.innerHTML='👁 <b>Učitelský náhled</b> — věž si můžeš vyzkoušet, ale postup se NEzapočítává do žebříčku ani síně slávy.';
+  act.innerHTML='<button class="btn b" onclick="twStart()">▶ VSTOUPIT (náhled)</button>';
+  twRenderBoard();twRenderHall();
+  return;
+ }
  st.textContent='Ověřuji vstup do věže…';act.innerHTML='';
  const ok=await RPGCloud.towerEligible(SAVE_KEY);
  if(!document.getElementById('s-tower').classList.contains('active'))return;

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -2474,6 +2474,15 @@ async function renderTowerGate(){
   act.innerHTML='<button class="btn b" onclick="var b=document.getElementById(\'cloud-btn\');if(b)b.click();">🔑 PŘIHLÁSIT SE</button>';
   return;
  }
+ // Učitel/superadmin smí vstoupit do KAŽDÉ věže jako náhled — postup se
+ // NEzapočítává (TW.practice ⇒ žádný zápis; server tower_submit ho stejně odmítne).
+ if(RPGCloud.isStaff&&RPGCloud.isStaff()){
+  TW.practice=true;
+  st.innerHTML='👁 <b>Učitelský náhled</b> — věž si můžeš vyzkoušet, ale postup se NEzapočítává do žebříčku ani síně slávy.';
+  act.innerHTML='<button class="btn b" onclick="twStart()">▶ VSTOUPIT (náhled)</button>';
+  twRenderBoard();twRenderHall();
+  return;
+ }
  st.textContent='Ověřuji vstup do věže…';act.innerHTML='';
  const ok=await RPGCloud.towerEligible(SAVE_KEY);
  if(!document.getElementById('s-tower').classList.contains('active'))return;

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -2684,6 +2684,15 @@ async function renderTowerGate(){
   act.innerHTML='<button class="btn b" onclick="var b=document.getElementById(\'cloud-btn\');if(b)b.click();">🔑 PŘIHLÁSIT SE</button>';
   return;
  }
+ // Učitel/superadmin smí vstoupit do KAŽDÉ věže jako náhled — postup se
+ // NEzapočítává (TW.practice ⇒ žádný zápis; server tower_submit ho stejně odmítne).
+ if(RPGCloud.isStaff&&RPGCloud.isStaff()){
+  TW.practice=true;
+  st.innerHTML='👁 <b>Učitelský náhled</b> — věž si můžeš vyzkoušet, ale postup se NEzapočítává do žebříčku ani síně slávy.';
+  act.innerHTML='<button class="btn b" onclick="twStart()">▶ VSTOUPIT (náhled)</button>';
+  twRenderBoard();twRenderHall();
+  return;
+ }
  st.textContent='Ověřuji vstup do věže…';act.innerHTML='';
  const ok=await RPGCloud.towerEligible(SAVE_KEY);
  if(!document.getElementById('s-tower').classList.contains('active'))return;

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -2843,6 +2843,15 @@ async function renderTowerGate(){
   act.innerHTML='<button class="btn b" onclick="var b=document.getElementById(\'cloud-btn\');if(b)b.click();">🔑 PŘIHLÁSIT SE</button>';
   return;
  }
+ // Učitel/superadmin smí vstoupit do KAŽDÉ věže jako náhled — postup se
+ // NEzapočítává (TW.practice ⇒ žádný zápis; server tower_submit ho stejně odmítne).
+ if(RPGCloud.isStaff&&RPGCloud.isStaff()){
+  TW.practice=true;
+  st.innerHTML='👁 <b>Učitelský náhled</b> — věž si můžeš vyzkoušet, ale postup se NEzapočítává do žebříčku ani síně slávy.';
+  act.innerHTML='<button class="btn b" onclick="twStart()">▶ VSTOUPIT (náhled)</button>';
+  twRenderBoard();twRenderHall();
+  return;
+ }
  st.textContent='Ověřuji vstup do věže…';act.innerHTML='';
  const ok=await RPGCloud.towerEligible(SAVE_KEY);
  if(!document.getElementById('s-tower').classList.contains('active'))return;

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -118,6 +118,7 @@ body{background:var(--bg);color:var(--text);font-family:var(--px);min-height:100
    <button class="tab on" data-tab="overview">PŘEHLED ŽÁKŮ</button>
    <button class="tab" data-tab="classes">TŘÍDY</button>
    <button class="tab" data-tab="diag">DIAGNOSTIKA</button>
+   <button class="tab" data-tab="leaderboard">🏆 ŽEBŘÍČKY</button>
    <button class="tab" data-tab="tower">VĚŽ LEGEND</button>
    <button class="tab" data-tab="explain">VYSVĚTLENÍ</button>
    <button class="tab" data-tab="feedback">ZPĚTNÁ VAZBA</button>
@@ -217,6 +218,22 @@ body{background:var(--bg);color:var(--text);font-family:var(--px);min-height:100
     <button class="mini" onclick="loadData().then(renderDiag)">↻ Obnovit</button>
    </div>
    <div id="diag-wrap"><div class="empty">Načítám…</div></div>
+  </div>
+
+  <!-- ŽEBŘÍČKY (XP) — viditelné pro učitele i bez vlastní třídy (#103) -->
+  <div id="t-leaderboard" class="hidden">
+   <p style="color:var(--muted);margin-bottom:14px;line-height:1.6">
+    <b style="color:var(--gold)">🏆 Žebříček XP</b> — pořadí žáků podle zkušeností v daném ročníku.
+    Žáci ve hře vidí jen spolužáky ze své třídy; tady jako učitel vidíš celý ročník
+    i bez vlastní třídy. Volitelně filtruj na konkrétní třídu.</p>
+   <div class="controls">
+    <select id="lb-game" aria-label="Žebříček: filtr podle ročníku" onchange="renderLeaderboardTab()"></select>
+    <select id="lb-class" aria-label="Žebříček: filtr podle třídy" onchange="renderLeaderboardTab()">
+     <option value="">Celý ročník</option>
+    </select>
+    <button class="mini" onclick="renderLeaderboardTab()">↻ Obnovit</button>
+   </div>
+   <div id="lb-wrap"><div class="empty">Načítám…</div></div>
   </div>
 
   <!-- VĚŽ LEGEND -->
@@ -1330,6 +1347,38 @@ async function deleteFeedbackUI(i){
 }
 
 /* ── taby ── */
+/* ── ŽEBŘÍČKY (XP) — #103: učitel vidí pořadí žáků i bez vlastní třídy ── */
+let lbInited=false;
+function initLeaderboardTab(){
+ if(!lbInited){
+  const gs=document.getElementById('lb-game');gs.innerHTML='';
+  GAMES.forEach(g=>{const o=document.createElement('option');o.value=g.key;o.textContent=g.emoji+' '+g.nm+' ('+g.gr+')';gs.appendChild(o);});
+  gs.value='RPG_MAT_9';
+  const cs=document.getElementById('lb-class');cs.innerHTML='<option value="">Celý ročník</option>';
+  (CLASSES||[]).forEach(c=>{const o=document.createElement('option');o.value=c.id;o.textContent=classLabel(c);cs.appendChild(o);});
+  lbInited=true;
+ }
+ renderLeaderboardTab();
+}
+function renderLeaderboardTab(){
+ const wrap=document.getElementById('lb-wrap');
+ const game=document.getElementById('lb-game').value||'RPG_MAT_9';
+ const cid=document.getElementById('lb-class').value||'';
+ const mem=cid?membersOfClass(cid):null;
+ let rows=(ROWS||[]).filter(r=>r.game===game&&(!mem||mem.has(r.user_id)))
+  .map(r=>{const d=r.data||{};return {name:r.name||r.full_name||'Hráč',xp:(d.xp||0)|0,lvl:(d.level||1)|0,at:r.updated_at};})
+  .sort((a,b)=>b.xp-a.xp||a.name.localeCompare(b.name,'cs'));
+ if(!rows.length){wrap.innerHTML='<div class="empty">V tomto ročníku zatím nikdo nehrál'+(cid?' (v této třídě)':'')+'.</div>';return;}
+ const medal=i=>i===0?'🥇':i===1?'🥈':i===2?'🥉':(i+1)+'.';
+ wrap.innerHTML=rows.map((r,i)=>
+  '<div style="display:flex;align-items:center;gap:10px;background:var(--panel2);border:1px solid var(--line);border-radius:8px;padding:8px 12px;margin-bottom:6px'+(i<3?';border-color:var(--gold)':'')+'">'+
+  '<span style="min-width:30px;text-align:center">'+medal(i)+'</span>'+
+  '<span style="flex:1;font-weight:600">'+onlineDot(r.at)+esc(r.name)+'</span>'+
+  '<span style="color:var(--muted);font-size:12px;min-width:54px;text-align:right">Lvl '+r.lvl+'</span>'+
+  '<span style="color:var(--gold);min-width:80px;text-align:right">'+r.xp+' XP</span></div>').join('')+
+  '<p style="color:var(--muted);font-size:12px;margin-top:8px">Celkem '+rows.length+' žáků. 🟢/🟡 = nedávno online.</p>';
+}
+
 /* ── VĚŽ LEGEND (Fáze 11) ── */
 function towerGameSel(){
  const sel=document.getElementById('tower-game');
@@ -1343,17 +1392,26 @@ async function renderTower(){
  const game=towerGameSel();
  const bw=document.getElementById('tower-board-wrap'),hw=document.getElementById('tower-hall-wrap');
  bw.innerHTML='<div class="empty">Načítám…</div>';hw.innerHTML='<div class="empty">Načítám…</div>';
- let board=[],hall=[];
- try{[board,hall]=await Promise.all([RPGCloud.towerBoard(game),RPGCloud.towerHall(game)]);}
+ let board=[],hall=[],canDelete=false;
+ try{
+  // Fáze 12: admin žebříček vrací i user_id (pro mazání). Pokud RPC ještě
+  // není nasazené (vrátí []), spadneme zpět na read-only veřejný žebříček.
+  [board,hall]=await Promise.all([RPGCloud.towerBoardAdmin(game),RPGCloud.towerHall(game)]);
+  if(board.length){canDelete=true;}
+  else{board=await RPGCloud.towerBoard(game);}
+ }
  catch(e){bw.innerHTML='<div class="empty">Chyba při načítání.</div>';hw.innerHTML='';return;}
+ window.__towerBoard=board;
  const medal=i=>i===0?'🥇':i===1?'🥈':i===2?'🥉':(i+1)+'.';
  if(!board.length)bw.innerHTML='<div class="empty">V této sezóně zatím nikdo nelezl.</div>';
  else bw.innerHTML=board.map((r,i)=>
   '<div style="display:flex;align-items:center;gap:10px;background:var(--panel2);border:1px solid var(--line);border-radius:8px;padding:8px 12px;margin-bottom:6px'+(i<10?';border-color:var(--gold)':'')+'">'+
   '<span style="min-width:30px;text-align:center">'+medal(i)+'</span>'+
-  '<span style="flex:1;font-weight:600">'+esc(r.display_name)+'</span>'+
-  '<span style="color:var(--gold)">'+(r.best_floor|0)+'. patro</span></div>').join('')+
-  '<p style="color:var(--muted);font-size:12px;margin-top:6px">Zlatý rámeček = aktuální top 10 (zapíše se při uzavření sezóny).</p>';
+  '<span style="flex:1;font-weight:600">'+esc(r.display_name)+(r.runs?'<span style="color:var(--muted);font-weight:400;font-size:12px"> · '+(r.runs|0)+'× pokus</span>':'')+'</span>'+
+  '<span style="color:var(--gold)">'+(r.best_floor|0)+'. patro</span>'+
+  (canDelete&&r.user_id?'<button class="mini red" title="Smazat žáka z žebříčku věže" onclick="deleteTowerRunUI('+i+')">🗑</button>':'')+
+  '</div>').join('')+
+  '<p style="color:var(--muted);font-size:12px;margin-top:6px">Zlatý rámeček = aktuální top 10 (zapíše se při uzavření sezóny).'+(canDelete?' 🗑 odebere žáka z žebříčku aktuální sezóny (síň slávy zůstává).':'')+'</p>';
  if(!hall.length)hw.innerHTML='<div class="empty">Síň slávy je zatím prázdná — naplní se uzavřením první sezóny.</div>';
  else{
   let html='',season=null;
@@ -1375,6 +1433,14 @@ async function closeSeasonUI(){
  if(r.ok){toast('Sezóna uzavřena — do síně slávy zapsáno '+r.count+' jmen');renderTower();}
  else toast('Chyba: '+r.error,1);
 }
+async function deleteTowerRunUI(i){
+ const board=window.__towerBoard||[];const row=board[i];if(!row||!row.user_id)return;
+ const game=towerGameSel();
+ if(!confirm('Smazat „'+(row.display_name||'žák')+'" ('+(row.best_floor|0)+'. patro) z žebříčku věže aktuální sezóny?\n\nSíň slávy zůstane nedotčená. Žák může věž zkusit znovu.'))return;
+ const r=await RPGCloud.towerDeleteRun(row.user_id,game);
+ if(r.ok){toast(r.count>0?'Žák smazán z žebříčku věže.':'Žák v žebříčku nebyl (možná už smazán).');renderTower();}
+ else toast('Chyba: '+r.error,1);
+}
 
 document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
  document.querySelectorAll('.tab').forEach(x=>x.classList.remove('on'));
@@ -1384,6 +1450,7 @@ document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
  document.getElementById('t-classes').classList.toggle('hidden',tab!=='classes');
  document.getElementById('t-preview').classList.toggle('hidden',tab!=='preview');
  document.getElementById('t-diag').classList.toggle('hidden',tab!=='diag');
+ document.getElementById('t-leaderboard').classList.toggle('hidden',tab!=='leaderboard');
  document.getElementById('t-tower').classList.toggle('hidden',tab!=='tower');
  document.getElementById('t-explain').classList.toggle('hidden',tab!=='explain');
  document.getElementById('t-feedback').classList.toggle('hidden',tab!=='feedback');
@@ -1391,6 +1458,7 @@ document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
  if(tab==='classes'){renderClasses();renderBroadcasts();}
  if(tab==='teachers')loadTeachers();
  if(tab==='diag')renderDiag();
+ if(tab==='leaderboard')initLeaderboardTab();
  if(tab==='tower')renderTower();
  if(tab==='explain')initExplainTab();
  if(tab==='feedback')loadFeedback();

--- a/tests/rpg-issue103.test.cjs
+++ b/tests/rpg-issue103.test.cjs
@@ -1,0 +1,164 @@
+/* ══════════════════════════════════════════════════════════════════
+   Test Issue #103 — Věž legend a žebříčky pro učitele.
+   (1) HRA: učitel (isStaff) smí vstoupit do KAŽDÉ věže jako náhled —
+       gate hlásí „Učitelský náhled" a konec běhu NEvolá towerSubmit
+       (postup se nezapočítává). Napříč všemi 4 ročníky.
+   (2) KONZOLE: záložka 🏆 ŽEBŘÍČKY řadí žáky podle XP z uložených postav
+       (učitel vidí celý ročník i bez vlastní třídy).
+   (3) KONZOLE: žebříček věže má 🗑 a maže přes tower_delete_run(user_id).
+   Spusť: node tests/rpg-issue103.test.cjs
+   ══════════════════════════════════════════════════════════════════ */
+const http = require('http'); const fs = require('fs'); const path = require('path');
+const { chromium } = require('playwright');
+const ROOT = path.join(__dirname, '..');
+const EXEC = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+const MIME = {'.html':'text/html','.js':'text/javascript','.css':'text/css'};
+let pass=0, fail=0; const ok=(c,m)=>{c?(pass++,console.log('  ✅ '+m)):(fail++,console.log('  ❌ '+m));};
+
+function serve(){return new Promise(res=>{const s=http.createServer((q,r)=>{let u=decodeURIComponent(q.url.split('?')[0]);if(u.endsWith('/'))u+='index.html';const f=path.normalize(path.join(ROOT,u));if(!f.startsWith(ROOT+path.sep)||!fs.existsSync(f)||fs.statSync(f).isDirectory()){r.writeHead(404);return r.end();}r.writeHead(200,{'Content-Type':MIME[path.extname(f)]||'application/octet-stream'});fs.createReadStream(f).pipe(r);});s.listen(0,()=>res(s));});}
+
+const SEED = {name:'TEST',xp:0,level:1,attrs:{calc:0,geo:0,anal:0,craft:0},done:{},inv:[]};
+
+async function answerCurrent(page, correct){
+  await page.evaluate((correct)=>{
+    const t=TW.task;const v=correct?String(t.ans):'×××';
+    if(TW.m.mc){const btns=[...document.querySelectorAll('#tw-mc .mc-btn')];const target=btns.find(b=>correct===(b.textContent.replace(/^[A-D]/,'')===String(t.ans)));(target||btns[0]).click();}
+    else if(/^(ANO|NE)$/i.test(String(t.ans).trim())){twAnswerYN(correct?String(t.ans).toUpperCase():(String(t.ans).toUpperCase()==='ANO'?'NE':'ANO'));}
+    else{document.getElementById('tw-ans').value=v;twSubmit();}
+  },correct);
+}
+
+// ── (1) HRA: učitelský náhled věže (4 ročníky) ──────────────────────
+async function gameStaffPreview(browser, base, N){
+  const KEY='RPG_MAT_'+N;
+  const ctx=await browser.newContext({viewport:{width:480,height:900}});
+  const page=await ctx.newPage();
+  page.on('pageerror',e=>{fail++;console.log('  ❌ JS chyba g'+N+': '+e.message);});
+  await page.addInitScript(({key,seed})=>{localStorage.setItem(key,JSON.stringify(seed));},{key:KEY,seed:SEED});
+  await page.goto(`${base}/projects/rpg-mat-${N}.html`,{waitUntil:'load'});
+  await page.evaluate(()=>continueGame());
+  await page.evaluate(()=>{
+    window.__rpc={submits:[]};
+    window.RPGCloud=Object.assign({},window.RPGCloud,{
+      configured:()=>true, currentUser:()=>({id:'teacher-1'}), isStaff:()=>true,
+      towerEligible:async()=>{throw new Error('eligible se nemá volat pro staff');},
+      towerSubmit:async(g,f)=>{window.__rpc.submits.push({g,f});return{ok:true,best:f};},
+      towerBoard:async()=>[{display_name:'Žák A',best_floor:5,is_me:false}],
+      towerHall:async()=>[],
+    });
+    go('map');go('tower');
+  });
+  await page.waitForTimeout(300);
+  const gate=await page.evaluate(()=>({st:document.getElementById('tw-gate-status').textContent,btn:document.getElementById('tw-gate-actions').textContent}));
+  ok(/náhled/i.test(gate.st),`g${N} brána hlásí „Učitelský náhled"`);
+  ok(/VSTOUPIT/.test(gate.btn),`g${N} učitel má tlačítko vstupu (náhled)`);
+  // výstup 2 patra → konec → NESMÍ volat towerSubmit
+  await page.evaluate(()=>twStart());
+  await page.waitForTimeout(120);
+  ok(await page.evaluate(()=>TW.practice===true),`g${N} běh je v practice režimu (TW.practice)`);
+  for(let i=0;i<2;i++){await answerCurrent(page,true);await page.waitForTimeout(1100);}
+  await page.evaluate(()=>twGiveUp());
+  await page.waitForTimeout(300);
+  const res=await page.evaluate(()=>({subs:window.__rpc.submits.length,cloud:document.getElementById('tw-end-cloud').textContent}));
+  ok(res.subs===0,`g${N} konec náhledu NEvolá towerSubmit (nezapočítává se)`);
+  ok(/nanečisto/i.test(res.cloud),`g${N} hlášení: lezeš nanečisto`);
+  await ctx.close();
+}
+
+// ── (2)+(3) KONZOLE ─────────────────────────────────────────────────
+function consoleMock(scenario){
+  return `(function(){
+    const S=${JSON.stringify(scenario)};
+    const db={roles:S.roles||[],saves:S.saves||[],classes:[],class_members:[],notes:[]};
+    window.__rpcCalls=[];
+    function mkClient(){
+      function q(table){let single=false,filters=[];
+        function rows(){let r=(db[table]||[]).slice();filters.forEach(([c,v])=>{r=r.filter(x=>String(x[c])===String(v));});return r;}
+        function resolve(){const r=rows();return Promise.resolve({data:single?(r[0]||null):r,error:null});}
+        const b={select(){return b;},insert(){return b;},upsert(){return b;},update(){return b;},delete(){return b;},
+          eq(c,v){filters.push([c,v]);return b;},order(){return b;},limit(){return b;},range(){return b;},is(){return b;},in(){return b;},
+          maybeSingle(){single=true;return resolve();},single(){single=true;return resolve();},then(res,rej){return resolve().then(res,rej);}};
+        return b;}
+      return {auth:{getSession:async()=>({data:{session:S.session||null}}),onAuthStateChange:()=>({data:{subscription:{unsubscribe(){}}}}),signInWithOAuth:async()=>{},signOut:async()=>{}},
+        from:q,
+        rpc:async(fn,args)=>{window.__rpcCalls.push({fn,args});
+          if(fn==='tower_board_admin')return{data:S.boardAdmin||[],error:null};
+          if(fn==='tower_hall_of_fame')return{data:S.hall||[],error:null};
+          if(fn==='tower_delete_run')return{data:1,error:null};
+          if(fn==='tower_board')return{data:S.board||[],error:null};
+          return{data:[],error:null};}};
+    }
+    window.supabase={createClient:()=>mkClient()};
+  })();`;
+}
+
+async function runConsole(browser, base){
+  const admin='vojtech.konopa@husovaliberec.cz';
+  const scenario={
+    roles:[{email:admin,role:'superadmin'}],
+    session:{user:{id:'u-admin',email:admin,user_metadata:{full_name:'Vojta'}}},
+    saves:[
+      {user_id:'s1',game:'RPG_MAT_9',name:'Neo',full_name:'N',email:'n@x',updated_at:new Date().toISOString(),data:{xp:340,level:4}},
+      {user_id:'s2',game:'RPG_MAT_9',name:'Trinity',full_name:'T',email:'t@x',updated_at:new Date().toISOString(),data:{xp:120,level:2}},
+      {user_id:'s3',game:'RPG_MAT_9',name:'Morpheus',full_name:'M',email:'m@x',updated_at:new Date().toISOString(),data:{xp:560,level:6}},
+      {user_id:'s4',game:'RPG_MAT_6',name:'Šesták',full_name:'S',email:'s@x',updated_at:new Date().toISOString(),data:{xp:99,level:1}},
+    ],
+    boardAdmin:[
+      {user_id:'s3',display_name:'Morpheus',best_floor:23,runs:4,updated_at:new Date().toISOString()},
+      {user_id:'s1',display_name:'Neo',best_floor:11,runs:2,updated_at:new Date().toISOString()},
+    ],
+    hall:[],
+  };
+  const ctx=await browser.newContext();
+  const page=await ctx.newPage();
+  const errs=[];page.on('pageerror',e=>errs.push(e.message));
+  await page.addInitScript(consoleMock(scenario));
+  await page.goto(`${base}/projects/rpg-ucitel.html`,{waitUntil:'load'});
+  await page.waitForFunction(()=>!document.getElementById('console').classList.contains('hidden'),{timeout:8000});
+  await page.waitForFunction(()=>Array.isArray(window.ROWS)&&window.ROWS.length>0,{timeout:6000}).catch(()=>{});
+
+  // (2) ŽEBŘÍČKY tab
+  await page.click('.tab[data-tab="leaderboard"]');
+  await page.waitForFunction(()=>!document.getElementById('t-leaderboard').classList.contains('hidden'),{timeout:4000});
+  await page.waitForFunction(()=>/XP/.test(document.getElementById('lb-wrap').textContent),{timeout:4000}).catch(()=>{});
+  const lb=await page.evaluate(()=>document.getElementById('lb-wrap').textContent);
+  ok(/🥇/.test(lb)&&/Morpheus/.test(lb)&&/560 XP/.test(lb),'žebříček: 1. Morpheus 560 XP (řazeno dle XP)');
+  // pořadí: Morpheus(560) > Neo(340) > Trinity(120)
+  const order=await page.evaluate(()=>{const t=document.getElementById('lb-wrap').textContent;return [t.indexOf('Morpheus'),t.indexOf('Neo'),t.indexOf('Trinity')];});
+  ok(order[0]<order[1]&&order[1]<order[2],'žebříček: správné pořadí Morpheus→Neo→Trinity');
+  ok(!/Šesták/.test(lb),'žebříček 9. ročníku neukazuje žáka 6. ročníku');
+  // přepnutí na 6. ročník
+  await page.selectOption('#lb-game','RPG_MAT_6');
+  await page.waitForTimeout(150);
+  ok(/Šesták/.test(await page.evaluate(()=>document.getElementById('lb-wrap').textContent)),'přepnutí ročníku: 6. ročník ukáže Šestáka');
+
+  // (3) VĚŽ LEGEND — mazání žáka z žebříčku
+  await page.click('.tab[data-tab="tower"]');
+  await page.waitForFunction(()=>!document.getElementById('t-tower').classList.contains('hidden'),{timeout:4000});
+  await page.waitForFunction(()=>/patro/.test(document.getElementById('tower-board-wrap').textContent),{timeout:4000});
+  const hasDel=await page.evaluate(()=>document.querySelectorAll('#tower-board-wrap button').length);
+  ok(hasDel>=2,'žebříček věže (admin): u každého řádku je 🗑 tlačítko ('+hasDel+')');
+  ok(/4× pokus/.test(await page.evaluate(()=>document.getElementById('tower-board-wrap').textContent)),'žebříček věže ukazuje počet pokusů');
+  // klik na první 🗑 → confirm → tower_delete_run(s3)
+  page.once('dialog',d=>d.accept());
+  await page.evaluate(()=>document.querySelector('#tower-board-wrap button').click());
+  await page.waitForFunction(()=>window.__rpcCalls.some(c=>c.fn==='tower_delete_run'),{timeout:4000});
+  const del=await page.evaluate(()=>window.__rpcCalls.find(c=>c.fn==='tower_delete_run'));
+  ok(del&&del.args.p_user_id==='s3'&&del.args.p_game==='RPG_MAT_9','🗑 volá tower_delete_run(user_id=s3, RPG_MAT_9)');
+  ok(errs.length===0,'konzole bez JS chyb'+(errs.length?(' ['+errs[0]+']'):''));
+  await ctx.close();
+}
+
+(async()=>{
+  const srv=await serve(); const base='http://127.0.0.1:'+srv.address().port;
+  const browser=await chromium.launch({executablePath:EXEC});
+  console.log('\n── (1) HRA: učitelský náhled věže (4 ročníky) ──');
+  for(const N of [6,7,8,9]) await gameStaffPreview(browser,base,N);
+  console.log('\n── (2)+(3) KONZOLE: žebříčky + mazání z věže ──');
+  await runConsole(browser,base);
+  await browser.close(); srv.close();
+  console.log('\n══════════════════════════════════════════');
+  console.log('  VÝSLEDEK: '+pass+' ✅ / '+fail+' ❌');
+  console.log('══════════════════════════════════════════');
+  process.exit(fail?1:0);
+})().catch(e=>{console.error(e);process.exit(1);});


### PR DESCRIPTION
Closes #103.

## #103 — three parts

**1. Teacher sees leaderboards even without a class** — new **🏆 ŽEBŘÍČKY** tab in the console. Ranks students by XP per grade, optional class filter. Built from `listAllSaves()` (staff already has it) — **no SQL, not class-gated**. (The tower season board was already visible to teachers; this adds the XP ranking students see in-game.)

**2. Teacher can enter ANY tower as a preview** — staff branch in `renderTowerGate()` in all 4 games: `TW.practice=true`, banner *"👁 Učitelský náhled — nezapočítává se"*, and `twEndRun` never calls `towerSubmit`. Server-side `tower_submit` already rejects non-eligible users, so it's safe even if bypassed.

**3. Delete a student from the tower board** — the public `tower_board` doesn't return `user_id`, so part 3 needs new RPCs:
- `tower_board_admin(p_game)` — staff-only, returns `user_id` + `runs`
- `tower_delete_run(p_user_id, p_game)` — staff-only, removes the student's current-season run (síň slávy untouched)

Console VĚŽ LEGEND tab now shows 🗑 per row. **Graceful**: if phase 12 isn't deployed yet, the board falls back to the read-only public `tower_board`.

## Bonus: fixes a regression from the defer PR (#105)
`attachGame()` registered its `?su=` / `?preview=1` handlers via `DOMContentLoaded`, but #105 moved the `attachGame()` call into the `load` event (after `DOMContentLoaded` fires), so the teacher's **"view student character"** and **"game preview"** silently broke. New `onDomReady()` helper runs the callback immediately when the DOM is already parsed. This restored `rpg-teacher.test.cjs` from 46/50 → **50/50**.

## ⚠️ Deploy step
Run `projects/rpg-cloud-setup-phase12.sql` in Supabase (after phase 11). Until then, part 3's delete buttons won't appear (board stays read-only) — parts 1 & 2 work without it.

## Tests
- `tests/rpg-issue103.test.cjs` — **28/28** (staff tower preview ×4 grades, XP leaderboard ranking, tower delete)
- Regression: teacher **50/50**, perf **20/20**, tower-game **108/108**, tower-console **12/12**, vstudents-deep **65/65**

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_