### PR TITLE
fix: viewport-fit battle + teacher console tweaks + shop rebalance

### DIFF
--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -458,6 +458,16 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  .mc-btn{font-size:16px;padding:16px 8px}
  .attr-nm{min-width:140px;font-size:11px}
 }
+@media(max-height:750px){
+ .bt-top{min-height:140px;padding:8px 18px 30px}
+ .bt-monster{font-size:70px}
+ .player-hp{font-size:22px;margin-bottom:6px}
+ .items-bar{min-height:36px;margin-bottom:4px}
+ .bt-problem{padding:12px;margin-bottom:6px;font-size:20px}
+ .bt-row{margin-bottom:6px}
+ .bt-input{padding:8px;font-size:17px}
+ .topnav{margin-bottom:6px;padding-bottom:6px}
+}
 </style>
 </head>
 <body>

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -1280,12 +1280,12 @@ const SHOP_ITEMS=[
  {id:'victory-cyber',  cat:'victory',name:'Cyber výbuch',ic:'🔥',price:100, cssKey:'vc-cyber'},
  {id:'victory-neon',   cat:'victory',name:'Neon záření', ic:'💚',price:140, cssKey:'vc-neon'},
  // ── powerupy (gameplay, one-time) ──
- {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:350,minLevel:3,desc:'+1 prázdné srdce na start každého boje.'},
- {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:300,minLevel:3,desc:'+5 sekund na každý příklad.'},
- {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:450,minLevel:4,desc:'Zmrznutí trvá 30 s místo 15 s.'},
- {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:600,minLevel:5,desc:'+1 plné srdce na start každého boje.'},
- {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:450,minLevel:5,desc:'+1 XP navíc za každý kritický zásah.'},
- {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:700,minLevel:6,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
+ {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:550,minLevel:5,desc:'+1 prázdné srdce na start každého boje.'},
+ {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:500,minLevel:4,desc:'+5 sekund na každý příklad.'},
+ {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:700,minLevel:6,desc:'Zmrznutí trvá 30 s místo 15 s.'},
+ {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:1000,minLevel:8,desc:'+1 plné srdce na start každého boje.'},
+ {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:750,minLevel:7,desc:'+1 XP navíc za každý kritický zásah.'},
+ {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:1300,minLevel:10,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
 ];
 let _shopCat='border';
 function setShopCat(cat,btn){_shopCat=cat;document.querySelectorAll('.shop-tab').forEach(b=>b.classList.remove('on'));if(btn)btn.classList.add('on');renderShop();}

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -1292,12 +1292,12 @@ const SHOP_ITEMS=[
  {id:'victory-cyber',  cat:'victory',name:'Cyber výbuch',ic:'🔥',price:100, cssKey:'vc-cyber'},
  {id:'victory-neon',   cat:'victory',name:'Neon záření', ic:'💚',price:140, cssKey:'vc-neon'},
  // ── powerupy (gameplay, one-time) ──
- {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:350,minLevel:3,desc:'+1 prázdné srdce na start každého boje.'},
- {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:300,minLevel:3,desc:'+5 sekund na každý příklad.'},
- {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:450,minLevel:4,desc:'Zmrznutí trvá 30 s místo 15 s.'},
- {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:600,minLevel:5,desc:'+1 plné srdce na start každého boje.'},
- {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:450,minLevel:5,desc:'+1 XP navíc za každý kritický zásah.'},
- {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:700,minLevel:6,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
+ {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:550,minLevel:5,desc:'+1 prázdné srdce na start každého boje.'},
+ {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:500,minLevel:4,desc:'+5 sekund na každý příklad.'},
+ {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:700,minLevel:6,desc:'Zmrznutí trvá 30 s místo 15 s.'},
+ {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:1000,minLevel:8,desc:'+1 plné srdce na start každého boje.'},
+ {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:750,minLevel:7,desc:'+1 XP navíc za každý kritický zásah.'},
+ {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:1300,minLevel:10,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
 ];
 let _shopCat='border';
 function setShopCat(cat,btn){_shopCat=cat;document.querySelectorAll('.shop-tab').forEach(b=>b.classList.remove('on'));if(btn)btn.classList.add('on');renderShop();}

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -444,6 +444,16 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  .mc-btn{font-size:16px;padding:16px 8px}
  .attr-nm{min-width:140px;font-size:11px}
 }
+@media(max-height:750px){
+ .bt-top{min-height:140px;padding:8px 18px 30px}
+ .bt-monster{font-size:70px}
+ .player-hp{font-size:22px;margin-bottom:6px}
+ .items-bar{min-height:36px;margin-bottom:4px}
+ .bt-problem{padding:12px;margin-bottom:6px;font-size:20px}
+ .bt-row{margin-bottom:6px}
+ .bt-input{padding:8px;font-size:17px}
+ .topnav{margin-bottom:6px;padding-bottom:6px}
+}
 /* ── TEORIE (s-learn) ── */
 .learn-section{margin-bottom:18px}
 .learn-section h3{font-family:var(--px);font-weight:700;font-size:13px;color:var(--accent);letter-spacing:1px;text-transform:uppercase;margin-bottom:8px;border-bottom:1px solid var(--gold);padding-bottom:4px}

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -1508,12 +1508,12 @@ const SHOP_ITEMS=[
  {id:'victory-cyber',  cat:'victory',name:'Cyber výbuch',ic:'🔥',price:100, cssKey:'vc-cyber'},
  {id:'victory-neon',   cat:'victory',name:'Neon záření', ic:'💚',price:140, cssKey:'vc-neon'},
  // ── powerupy (gameplay, one-time) ──
- {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:350,minLevel:3,desc:'+1 prázdné srdce na start každého boje.'},
- {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:300,minLevel:3,desc:'+5 sekund na každý příklad.'},
- {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:450,minLevel:4,desc:'Zmrznutí trvá 30 s místo 15 s.'},
- {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:600,minLevel:5,desc:'+1 plné srdce na start každého boje.'},
- {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:450,minLevel:5,desc:'+1 XP navíc za každý kritický zásah.'},
- {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:700,minLevel:6,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
+ {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:550,minLevel:5,desc:'+1 prázdné srdce na start každého boje.'},
+ {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:500,minLevel:4,desc:'+5 sekund na každý příklad.'},
+ {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:700,minLevel:6,desc:'Zmrznutí trvá 30 s místo 15 s.'},
+ {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:1000,minLevel:8,desc:'+1 plné srdce na start každého boje.'},
+ {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:750,minLevel:7,desc:'+1 XP navíc za každý kritický zásah.'},
+ {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:1300,minLevel:10,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
 ];
 let _shopCat='border';
 function setShopCat(cat,btn){_shopCat=cat;document.querySelectorAll('.shop-tab').forEach(b=>b.classList.remove('on'));if(btn)btn.classList.add('on');renderShop();}

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -459,6 +459,16 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  .mc-btn{font-size:16px;padding:16px 8px}
  .attr-nm{min-width:140px;font-size:11px}
 }
+@media(max-height:750px){
+ .bt-top{min-height:140px;padding:8px 18px 30px}
+ .bt-monster{font-size:70px}
+ .player-hp{font-size:22px;margin-bottom:6px}
+ .items-bar{min-height:36px;margin-bottom:4px}
+ .bt-problem{padding:12px;margin-bottom:6px;font-size:20px}
+ .bt-row{margin-bottom:6px}
+ .bt-input{padding:8px;font-size:17px}
+ .topnav{margin-bottom:6px;padding-bottom:6px}
+}
 </style>
 </head>
 <body>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -439,6 +439,16 @@ body::before{
  .mc-btn{font-size:16px;padding:16px 8px}
  .attr-nm{min-width:140px;font-size:11px}
 }
+@media(max-height:750px){
+ .bt-top{min-height:140px;padding:8px 18px 30px}
+ .bt-monster{font-size:70px}
+ .player-hp{font-size:22px;margin-bottom:6px}
+ .items-bar{min-height:36px;margin-bottom:4px}
+ .bt-problem{padding:12px;margin-bottom:6px;font-size:20px}
+ .bt-row{margin-bottom:6px}
+ .bt-input{padding:8px;font-size:17px}
+ .topnav{margin-bottom:6px;padding-bottom:6px}
+}
 /* ── KREDITY ── */
 .credits-chip{display:inline-flex;align-items:center;gap:5px;font-family:var(--px);font-size:13px;color:#f4d03f;background:#1a1500;border:2px solid #7a5c00;padding:2px 9px;border-radius:2px}
 /* ── SHOP ── */

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -892,12 +892,12 @@ const SHOP_ITEMS=[
  {id:'victory-cyber',  cat:'victory',name:'Cyber výbuch',ic:'🔥',price:100, cssKey:'vc-cyber'},
  {id:'victory-neon',   cat:'victory',name:'Neon záření', ic:'💚',price:140, cssKey:'vc-neon'},
  // ── powerupy (gameplay, one-time) ──
- {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:350,minLevel:3,desc:'+1 prázdné srdce na start každého boje.'},
- {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:300,minLevel:3,desc:'+5 sekund na každý příklad.'},
- {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:450,minLevel:4,desc:'Zmrznutí trvá 30 s místo 15 s.'},
- {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:600,minLevel:5,desc:'+1 plné srdce na start každého boje.'},
- {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:450,minLevel:5,desc:'+1 XP navíc za každý kritický zásah.'},
- {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:700,minLevel:6,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
+ {id:'pu-ghost-heart',  cat:'powerup',name:'Železná vůle',    ic:'🫀',price:550,minLevel:5,desc:'+1 prázdné srdce na start každého boje.'},
+ {id:'pu-time-bonus',   cat:'powerup',name:'Přesýpací hodiny',ic:'⏳',price:500,minLevel:4,desc:'+5 sekund na každý příklad.'},
+ {id:'pu-freeze-dbl',   cat:'powerup',name:'Permafrost',      ic:'🧊',price:700,minLevel:6,desc:'Zmrznutí trvá 30 s místo 15 s.'},
+ {id:'pu-full-heart',   cat:'powerup',name:'Druhá krev',      ic:'💗',price:1000,minLevel:8,desc:'+1 plné srdce na start každého boje.'},
+ {id:'pu-xp-crit',      cat:'powerup',name:'Adrenalin',       ic:'⚡',price:750,minLevel:7,desc:'+1 XP navíc za každý kritický zásah.'},
+ {id:'pu-second-chance',cat:'powerup',name:'Druhá šance',     ic:'🛡️',price:1300,minLevel:10,desc:'1× za boj: místo porážky přežiješ s 1 ❤️.'},
 ];
 
 function _walletBal(){return(typeof RPGWallet!=='undefined')?RPGWallet.getCredits():(S.credits||0);}

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -613,7 +613,9 @@ function renderTable(){
   const totalMast=(u.rows.reduce((s,x)=>s+masteryCount(x.r.data||{}),0))|0;
   const maxLv=(u.rows.reduce((m,x)=>Math.max(m,(x.r.data||{}).level||1),1))|0;
   const avgPct=(Math.round(u.rows.reduce((s,x)=>s+pct(x.r.data||{}),0)/u.rows.length))|0;
-  const chips=u.rows.map(x=>{const g=gMeta(x.r.game),d=x.r.data||{};const lv=((d.level||1)|0);return '<span class="tag" style="background:'+esc(g.accent||'#888')+';font-size:11px">'+g.emoji+' '+g.gr+' LV'+lv+'</span>';}).join(' ');
+  // souhrn místo všech ročníkových chipů: emoji her + počet (detail je po rozbalení)
+  const gameEmojis=u.rows.map(x=>gMeta(x.r.game).emoji).join('');
+  const chips='<span class="tag" style="background:var(--panel2);font-size:11px;white-space:nowrap" title="'+esc(u.rows.map(x=>gMeta(x.r.game).gr).join(', '))+'">'+gameEmojis+' · '+u.rows.length+' '+(u.rows.length===1?'hra':'hry')+'</span>';
   const allSel=u.rows.every(x=>SEL.has(selKey(x.r)));
   const someSel=!allSel&&u.rows.some(x=>SEL.has(selKey(x.r)));
   const selAttr=allSel?' checked':someSel?' data-indeterminate="1"':'';
@@ -630,26 +632,30 @@ function renderTable(){
    '<td style="font-size:12px;color:var(--muted)">'+onlineDot(lastAt)+esc(fmtDate(lastAt))+'</td>'+
    '<td><span style="font-size:12px;color:var(--muted)">'+(expanded?'▲ sbalit':'▶ '+u.rows.length+' '+(u.rows.length===1?'hra':'hry'))+'</span></td></tr>';
   if(expanded){
+   // jeden kompaktní blok místo plných tabulkových řádků (řešení vysokých řádků)
+   const colspan=admin?9:8;
+   let lines='';
    u.rows.forEach(({r,i})=>{
     const g=gMeta(r.game),d=r.data||{},p=pct(d);
     const mc=(masteryCount(d))|0,totalM=(missionsFor(r.game).length||21)|0;
-    const mastCell=mc>0?'<span style="color:var(--gold);font-weight:700">'+mc+'</span><span style="color:var(--muted)">/'+totalM+' 🏅</span>':'<span style="color:var(--muted)">0/'+totalM+'</span>';
+    const mast=mc>0?'<span style="color:var(--gold);font-weight:700">'+mc+'</span><span style="color:var(--muted)">/'+totalM+'🏅</span>':'<span style="color:var(--muted)">0/'+totalM+'🏅</span>';
     const checked=SEL.has(selKey(r))?' checked':'';
-    html+='<tr style="background:rgba(0,0,0,0.15)">'+
-     (admin?'<td><input type="checkbox" class="sel-row" data-i="'+i+'" onclick="event.stopPropagation();toggleSel('+i+',this.checked)"'+checked+'></td>':'')+
-     '<td style="padding-left:28px"><div class="em" style="font-size:11px">'+esc(d.name||'—')+'</div></td>'+
-     '<td><span class="tag" style="background:'+esc(g.accent||'#888')+'">'+g.emoji+' '+g.gr+'</span></td>'+
-     '<td>'+((d.level||1)|0)+'</td>'+
-     '<td>'+((d.xp||0)|0)+'</td>'+
-     '<td><div style="display:flex;align-items:center;gap:8px"><div class="bar" style="flex:1"><i style="width:'+(p|0)+'%;background:'+esc(g.accent||'#888')+'"></i></div><span style="font-size:11px;color:var(--muted)">'+(p|0)+'%</span></div></td>'+
-     '<td style="font-size:13px">'+mastCell+'</td>'+
-     '<td style="font-size:12px;color:var(--muted)">'+onlineDot(r.updated_at)+esc(fmtDate(r.updated_at))+'</td>'+
-     '<td><div class="rowbtns">'+
+    lines+='<div style="display:flex;align-items:center;gap:10px;padding:5px 2px;border-top:1px solid rgba(255,255,255,.06);font-size:12px;flex-wrap:wrap">'+
+     (admin?'<input type="checkbox" class="sel-row" data-i="'+i+'" onclick="event.stopPropagation();toggleSel('+i+',this.checked)"'+checked+'>':'')+
+     '<span class="tag" style="background:'+esc(g.accent||'#888')+';white-space:nowrap">'+g.emoji+' '+g.gr+'</span>'+
+     '<span style="color:var(--muted)">LV <b style="color:var(--text)">'+((d.level||1)|0)+'</b></span>'+
+     '<span style="color:var(--muted)">'+((d.xp||0)|0)+' XP</span>'+
+     '<div class="bar" style="width:80px"><i style="width:'+(p|0)+'%;background:'+esc(g.accent||'#888')+'"></i></div>'+
+     '<span style="color:var(--muted)">'+(p|0)+'%</span>'+
+     '<span>'+mast+'</span>'+
+     '<span style="color:var(--muted)">'+onlineDot(r.updated_at)+esc(fmtDate(r.updated_at))+'</span>'+
+     '<span style="margin-left:auto;display:flex;gap:5px">'+
        '<button class="mini" onclick="openDetail('+i+')">Detail</button>'+
-       '<a class="mini" style="text-decoration:none" target="_blank" href="'+g.file+'?su='+encodeURIComponent(r.user_id)+'">👁 Náhled</a>'+
-       (admin?'<button class="mini red" onclick="delChar('+i+')">🗑</button>':'')+
-     '</div></td></tr>';
+       '<a class="mini" style="text-decoration:none" target="_blank" href="'+g.file+'?su='+encodeURIComponent(r.user_id)+'" title="Náhled">👁</a>'+
+       (admin?'<button class="mini red" onclick="delChar('+i+')" title="Smazat">🗑</button>':'')+
+     '</span></div>';
    });
+   html+='<tr class="exp-detail"><td colspan="'+colspan+'" style="background:rgba(0,0,0,0.15);padding:4px 14px 8px">'+lines+'</td></tr>';
   }
  });
  html+='</tbody></table>';

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -265,11 +265,11 @@ body{background:var(--bg);color:var(--text);font-family:var(--px);min-height:100
     Žáci mohou po správné odpovědi v boji napsat <b style="color:var(--gold)">jednou větou jak na to přišli</b>. Zde vidíš jejich vzkazy ze všech ročníků. Slouží jako formativní zpětná vazba: kde žáci přemýšlejí správně a kde jen tipují.</p>
    <div class="controls">
     <select id="expl-game" aria-label="Vysvětlení: filtr podle ročníku" onchange="onExplGameChange()">
-     <option value="">— Všechny ročníky —</option>
+     <option value="" selected>— Všechny ročníky —</option>
      <option value="RPG_MAT_6">🚀 Vesmírná expedice (6. ročník)</option>
      <option value="RPG_MAT_7">⛏️ Ztracený chrám (7. ročník)</option>
      <option value="RPG_MAT_8">🎓 Matematická akademie (8. ročník)</option>
-     <option value="RPG_MAT_9" selected>💻 NULL_BYTE (9. ročník)</option>
+     <option value="RPG_MAT_9">💻 NULL_BYTE (9. ročník)</option>
     </select>
     <select id="expl-class" aria-label="Vysvětlení: filtr podle třídy" onchange="renderExplain()">
      <option value="">Všechny třídy</option>
@@ -354,15 +354,10 @@ const MISSIONS_9=[
 ];
 const MISSIONS_BY_GAME={RPG_MAT_6:MISSIONS_6,RPG_MAT_7:MISSIONS_7,RPG_MAT_8:MISSIONS_8,RPG_MAT_9:MISSIONS_9};
 function missionsFor(gameKey){return MISSIONS_BY_GAME[gameKey]||[];}
-const ARTIFACTS_BY_GAME={
- RPG_MAT_6:[{id:'starmap',nm:'Hvězdná mapa 🗺️'},{id:'crystal',nm:'Desetinný krystal 💎'},{id:'core',nm:'Jádro asteroidu ⚙️'},{id:'protractor',nm:'Hvězdný úhloměr 📐'},{id:'mirror',nm:'Zrcadlový úlomek 🪞'},{id:'cube',nm:'Energetická kostka 🧊'},{id:'medal',nm:'Galaktický odznak 🏅'}],
- RPG_MAT_7:[{id:'mapscrap',nm:'Útržek staré mapy 🗺️'},{id:'papyrus',nm:'Papyrový svitek 📜'},{id:'lapis',nm:'Lazuritový amulet 🔷'},{id:'weight',nm:'Zlaté závaží ⚖️'},{id:'ring',nm:'Faraonův prsten 💍'},{id:'mirror',nm:'Zrcadlo bohyně 🪞'},{id:'crown',nm:'Faraonova koruna 👑'}],
- RPG_MAT_8:[{id:'map',nm:'Mapa sedmi krajin 🗺️'},{id:'sword',nm:'Pythagorův meč ⚔️'},{id:'wand',nm:'Algebraická hůl 🪄'},{id:'shield',nm:'Výrazový štít 🛡️'},{id:'ring',nm:'Kruhový prsten 💍'},{id:'compass',nm:'Rýsovací kompas 🧭'},{id:'crown',nm:'Diplom arcimága 👑'}],
- RPG_MAT_9:[{id:'acckey',nm:'Přístupový klíč 🔑'},{id:'core',nm:'Energetické jádro 🔋'},{id:'decmod',nm:'Dešifrovací modul 💾'},{id:'frag',nm:'Fragment kódu 🧩'},{id:'netkey',nm:'Síťový klíč 🛰️'},{id:'vizchip',nm:'Vizualizační čip 📊'},{id:'root',nm:'Root přístup 👁️'}]
-};
 const ATTR=[['calc','🔢 Výpočty'],['geo','📐 Geometrie'],['anal','🧠 Analýza'],['craft','⚡ Instinkt']];
 const gMeta=k=>GAMES.find(g=>g.key===k)||{emoji:'❓',nm:k,gr:'',accent:'#888'};
 let ROWS=[];   // všechny postavy
+let STAFF_EMAILS=new Set(); // e-maily učitelů/superadminů (lowercase) — nepatří mezi žáky
 let SNAP_DATA={}; // game → [{user_id,snapped_at,errs}]
 let CLASSES=[];       // [{id,name,…}]
 let MEMBERSHIPS=[];   // [{class_id,user_id}]
@@ -374,6 +369,7 @@ function membersOfClass(cid){const s=new Set();MEMBERSHIPS.forEach(m=>{if(m.clas
 function studentsDistinct(){
  const map=new Map();
  ROWS.forEach(r=>{
+  if(r.email&&STAFF_EMAILS.has(r.email.toLowerCase()))return; // učitelé/superadmini nejsou žáci
   const cur=map.get(r.user_id)||{user_id:r.user_id,name:'',email:r.email||'',games:[]};
   if(r.full_name&&!cur.name)cur.name=r.full_name;
   if((r.data&&r.data.name)&&!cur.name)cur.name=r.data.name;
@@ -510,6 +506,9 @@ function openGodMode(file,sid){
 async function loadData(){
  document.getElementById('tbl-wrap').innerHTML='<div class="empty">Načítám data…</div>';
  ROWS=(await RPGCloud.listAllSaves()).filter(r=>r.game!=='_wallet'); // peněženka není postava
+ // Načti role, ať z přehledu/tříd vyřadíme učitelské účty (testovací postavy učitelů)
+ try{const roles=await RPGCloud.listRoles();STAFF_EMAILS=new Set((roles||[]).map(t=>(t.email||'').toLowerCase()));}
+ catch(e){STAFF_EMAILS=new Set();}
  await loadClasses();
  // Načti snímky chybovosti ze snap_events (fáze 6b)
  if(RPGCloud.getErrsSnaps){
@@ -833,7 +832,6 @@ function openDetail(i){
    '<h4>Odměny a úpravy (superadmin)</h4>'+
    '<div class="actrow"><input type="number" id="adj-xp" placeholder="±XP" value="100"><button class="mini gold" onclick="giveXP('+i+')">Přidat XP</button>'+
      '<span style="font-size:11px;color:var(--muted)">level se dopočítá z XP</span></div>'+
-   (()=>{const arts=ARTIFACTS_BY_GAME[r.game]||[];const opts='<option value="">— vybrat artefakt —</option>'+arts.map(a=>'<option value="'+esc(a.id)+'"'+(inv.includes(a.id)?' disabled':'')+'>'+esc(a.id)+' – '+esc(a.nm)+'</option>').join('');return '<div class="actrow"><select id="adj-item" style="font-family:inherit;font-size:13px;padding:7px 9px;border-radius:5px;border:1px solid var(--line);background:var(--panel2);color:var(--text);flex:1">'+opts+'</select><button class="mini gold" onclick="giveItem('+i+')">+ Artefakt</button></div>';})()+
    '<div class="actrow"><button class="mini red" onclick="delChar('+i+')">🗑 Smazat celou postavu</button></div>';
  }
  document.getElementById('modal').innerHTML=
@@ -902,19 +900,6 @@ async function giveXP(i){
  d.level=Math.floor(d.xp/100)+1;
  const res=await RPGCloud.updateSaveFor(r.user_id,r.game,d);
  if(res.ok){r.data=d;toast((delta>=0?'+':'')+delta+' XP přidáno');renderStats();renderTable();openDetail(i);}
- else toast('Chyba: '+res.error,1);
-}
-async function giveItem(i){
- const r=window.__filtered[i];if(!r)return;
- const sel=document.getElementById('adj-item');
- const artId=sel&&sel.value;
- if(!artId){toast('Vyber artefakt.',1);return;}
- const d=Object.assign({},r.data||{});
- d.inv=Array.isArray(d.inv)?d.inv.slice():[];
- if(d.inv.includes(artId)){toast('Žák tento artefakt už má.',1);return;}
- d.inv.push(artId);
- const res=await RPGCloud.updateSaveFor(r.user_id,r.game,d);
- if(res.ok){r.data=d;toast('Artefakt přidán');openDetail(i);}
  else toast('Chyba: '+res.error,1);
 }
 async function delChar(i){
@@ -1366,17 +1351,18 @@ function renderLeaderboardTab(){
  const cid=document.getElementById('lb-class').value||'';
  const mem=cid?membersOfClass(cid):null;
  let rows=(ROWS||[]).filter(r=>r.game===game&&(!mem||mem.has(r.user_id)))
-  .map(r=>{const d=r.data||{};return {name:r.name||r.full_name||'Hráč',xp:(d.xp||0)|0,lvl:(d.level||1)|0,at:r.updated_at};})
+  .map(r=>{const d=r.data||{};return {name:(r.name||d.name||r.full_name||'Hráč'),real:r.full_name||'',xp:(d.xp||0)|0,lvl:(d.level||1)|0,at:r.updated_at};})
   .sort((a,b)=>b.xp-a.xp||a.name.localeCompare(b.name,'cs'));
  if(!rows.length){wrap.innerHTML='<div class="empty">V tomto ročníku zatím nikdo nehrál'+(cid?' (v této třídě)':'')+'.</div>';return;}
  const medal=i=>i===0?'🥇':i===1?'🥈':i===2?'🥉':(i+1)+'.';
  wrap.innerHTML=rows.map((r,i)=>
   '<div style="display:flex;align-items:center;gap:10px;background:var(--panel2);border:1px solid var(--line);border-radius:8px;padding:8px 12px;margin-bottom:6px'+(i<3?';border-color:var(--gold)':'')+'">'+
   '<span style="min-width:30px;text-align:center">'+medal(i)+'</span>'+
-  '<span style="flex:1;font-weight:600">'+onlineDot(r.at)+esc(r.name)+'</span>'+
+  '<span style="flex:1;min-width:0"><span style="font-weight:600">'+onlineDot(r.at)+esc(r.name)+'</span>'+
+  (r.real&&r.real!==r.name?'<span style="color:var(--muted);font-size:11px;margin-left:6px">('+esc(r.real)+')</span>':'')+'</span>'+
   '<span style="color:var(--muted);font-size:12px;min-width:54px;text-align:right">Lvl '+r.lvl+'</span>'+
   '<span style="color:var(--gold);min-width:80px;text-align:right">'+r.xp+' XP</span></div>').join('')+
-  '<p style="color:var(--muted);font-size:12px;margin-top:8px">Celkem '+rows.length+' žáků. 🟢/🟡 = nedávno online.</p>';
+  '<p style="color:var(--muted);font-size:12px;margin-top:8px">Celkem '+rows.length+' žáků. 🟢/🟡 = nedávno online. Skutečné jméno (v závorce) vidíš jen ty — žáci ve hře jen herní přezdívky.</p>';
 }
 
 /* ── VĚŽ LEGEND (Fáze 11) ── */

--- a/projects/rpg-wallet.js
+++ b/projects/rpg-wallet.js
@@ -41,12 +41,12 @@ window.RPGWallet = (function () {
     { id: 'victory-cyber',   cat: 'victory', name: 'Cyber výbuch', ic: '🔥', price: 100, cssKey: 'vc-cyber' },
     { id: 'victory-neon',    cat: 'victory', name: 'Neon záření',  ic: '💚', price: 140, cssKey: 'vc-neon' },
     // ── powerupy (gameplay, one-time purchase) ──
-    { id: 'pu-ghost-heart',   cat: 'powerup', name: 'Železná vůle',    ic: '🫀', price: 350, minLevel: 3, desc: '+1 prázdné srdce na start každého boje.' },
-    { id: 'pu-time-bonus',    cat: 'powerup', name: 'Přesýpací hodiny',ic: '⏳', price: 300, minLevel: 3, desc: '+5 sekund na každý příklad.' },
-    { id: 'pu-freeze-dbl',    cat: 'powerup', name: 'Permafrost',      ic: '🧊', price: 450, minLevel: 4, desc: 'Zmrznutí trvá 30 s místo 15 s.' },
-    { id: 'pu-full-heart',    cat: 'powerup', name: 'Druhá krev',      ic: '💗', price: 600, minLevel: 5, desc: '+1 plné srdce na start každého boje.' },
-    { id: 'pu-xp-crit',       cat: 'powerup', name: 'Adrenalin',       ic: '⚡', price: 450, minLevel: 5, desc: '+1 XP navíc za každý kritický zásah.' },
-    { id: 'pu-second-chance',  cat: 'powerup', name: 'Druhá šance',    ic: '🛡️', price: 700, minLevel: 6, desc: '1× za boj: místo porážky přežiješ s 1 ❤️.' },
+    { id: 'pu-ghost-heart',   cat: 'powerup', name: 'Železná vůle',    ic: '🫀', price: 550, minLevel: 5, desc: '+1 prázdné srdce na start každého boje.' },
+    { id: 'pu-time-bonus',    cat: 'powerup', name: 'Přesýpací hodiny',ic: '⏳', price: 500, minLevel: 4, desc: '+5 sekund na každý příklad.' },
+    { id: 'pu-freeze-dbl',    cat: 'powerup', name: 'Permafrost',      ic: '🧊', price: 700, minLevel: 6, desc: 'Zmrznutí trvá 30 s místo 15 s.' },
+    { id: 'pu-full-heart',    cat: 'powerup', name: 'Druhá krev',      ic: '💗', price: 1000, minLevel: 8, desc: '+1 plné srdce na start každého boje.' },
+    { id: 'pu-xp-crit',       cat: 'powerup', name: 'Adrenalin',       ic: '⚡', price: 750, minLevel: 7, desc: '+1 XP navíc za každý kritický zásah.' },
+    { id: 'pu-second-chance',  cat: 'powerup', name: 'Druhá šance',    ic: '🛡️', price: 1300, minLevel: 10, desc: '1× za boj: místo porážky přežiješ s 1 ❤️.' },
   ];
 
   const VALID = new Set(SHOP_ITEMS.map(i => i.id));


### PR DESCRIPTION
## Summary

Several smaller improvements bundled into one PR.

### 1. Battle controls fit without scrolling (phone/tablet)
- `@media(max-height:750px)` in all 4 RPG games shrinks `.bt-top` 240→140px and `.bt-monster` 110→70px, trims padding on problem/input/rows/topnav
- All battle controls (problem, input, ÚTOK/ANO/NE, hint, DÁLE) visible without scrolling on 360×740 phone portrait and tablet landscape

### 2. Teacher console tweaks (`rpg-ucitel.html`)
- **Explanations** tab defaults to *all grades* instead of grade 9
- **XP leaderboard** shows the student's real first+last name (`full_name`) next to the in-game nickname — teacher-only; students still see only nicknames in-game
- **Classes** section no longer lists teachers/superadmins (by role email) as assignable students
- Removed the teacher **"give artifact"** control (+ dead `giveItem`/`ARTIFACTS_BY_GAME`)
- **Overview** redesign (your chosen direction): collapsed row shows one summary chip (game emojis + count) instead of a chip per grade; expanded detail is a single compact block of one-line entries per game instead of full-height table rows — fixes the very tall expanded rows and cramped actions

### 3. Shop powerup rebalance (all 4 games + `rpg-wallet.js`)
- Strong one-time gameplay powerups got higher prices and level gates so they're a late-game goal, not an early buy:

| Powerup | Před | Po |
|---|---|---|
| Přesýpací hodiny | 300 / LV3 | 500 / LV4 |
| Železná vůle | 350 / LV3 | 550 / LV5 |
| Permafrost | 450 / LV4 | 700 / LV6 |
| Adrenalin | 450 / LV5 | 750 / LV7 |
| Druhá krev | 600 / LV5 | 1000 / LV8 |
| Druhá šance | 700 / LV6 | 1300 / LV10 |

## Tests
- teacher 50/50 ✅ · issue103 28/28 ✅ · classes-console 11/11 ✅ · wallet 35/35 ✅ · hack 71/71 ✅ · perf 20/20 ✅ · vstudents-deep 65/65 ✅

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st