### PR TITLE
feat: enlarge mobile tap targets on student-facing tools (≥44px)

### DIFF
--- a/projects/cesta_penez.html
+++ b/projects/cesta_penez.html
@@ -567,6 +567,8 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
   transition:border-color .15s,box-shadow .15s}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
+/* mobil: dotykové plochy nav/jazyk na ≥44px */
+@media(pointer:coarse){.lang-btn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center}.tp-back,.tp-home{display:inline-flex;align-items:center;min-height:44px}}
 </style>
 </head>
 <body>

--- a/projects/index.html
+++ b/projects/index.html
@@ -218,6 +218,8 @@
     .filter-tag:hover { border-color: var(--accent); color: var(--accent); border-style: solid; }
     .filter-tag.active { background: var(--accent); border-color: var(--accent); color: var(--bg); border-style: solid; }
     .project.hidden { display: none; }
+    /* mobil: větší dotykové plochy filtrů a odkazů (zachová terminálový vzhled) */
+    @media(pointer:coarse){.filter-tag{min-height:40px;padding:9px 13px;display:inline-flex;align-items:center}.project .filename{display:inline-flex;align-items:center;min-height:40px}}
   </style>
 </head>
 <body>

--- a/projects/prijimacky-matematika/index.html
+++ b/projects/prijimacky-matematika/index.html
@@ -279,6 +279,8 @@
       .files a { padding: 7px 12px; font-size: .82rem; }
       .cermat-banner { padding: 0 16px; }
     }
+    /* mobil: větší dotykové plochy PDF tlačítek a navigace */
+    @media(pointer:coarse){.files a{min-height:44px;padding:10px 14px}.top-bar a{min-height:44px;display:inline-flex;align-items:center}footer a{display:inline-flex;align-items:center;min-height:40px}}
   </style>
 </head>
 <body>

--- a/projects/procenta_priklady.html
+++ b/projects/procenta_priklady.html
@@ -584,6 +584,8 @@ input.answer.wrong { border-color: var(--red); background: var(--red-light); ani
 .lang-btn:hover{border-color:var(--blue);box-shadow:0 2px 8px rgba(26,115,200,.2)}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
+/* mobil: dotykové plochy nav/jazyk na ≥44px */
+@media(pointer:coarse){.lang-btn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center}.tp-back,.tp-home{display:inline-flex;align-items:center;min-height:44px}}
 </style>
 </head>
 <body>

--- a/projects/rpg-matematika.html
+++ b/projects/rpg-matematika.html
@@ -139,6 +139,8 @@ body::before{
 .sc .act{font-size:11px;color:#f4d03f;font-weight:700;letter-spacing:1px;padding:7px 0}
 /* přístupnost: vypnout veškerý pohyb */
 .reduced-motion *,.reduced-motion *::before,.reduced-motion *::after{animation:none!important;transition:none!important;scroll-behavior:auto!important}
+/* mobil: dotykové plochy tlačítek na ≥44px */
+@media(pointer:coarse){.btn,.gp-btn,.fb-send{display:inline-flex;align-items:center;justify-content:center;min-height:44px}}
 </style>
 </head>
 <body>
@@ -234,7 +236,7 @@ body::before{
            font-family:inherit;font-size:14px;resize:vertical;box-sizing:border-box"></textarea>
    <div style="display:flex;justify-content:space-between;align-items:center;margin-top:10px;flex-wrap:wrap;gap:8px">
     <span id="fb-status" style="font-size:12px;color:var(--muted)"></span>
-    <button onclick="submitFeedback()"
+    <button onclick="submitFeedback()" class="fb-send"
      style="font-family:inherit;font-weight:700;font-size:13px;padding:9px 18px;border-radius:6px;cursor:pointer;
             border:2px solid #19e6e6;background:#19e6e6;color:#06101e">Odeslat</button>
    </div>

--- a/projects/unikovka_mocniny.html
+++ b/projects/unikovka_mocniny.html
@@ -117,6 +117,8 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 #lang-bar{position:fixed;bottom:16px;right:16px;z-index:200;display:flex;gap:6px;background:rgba(255,255,255,.92);border-radius:50px;padding:5px 8px;box-shadow:0 2px 12px rgba(0,0,0,.12);backdrop-filter:blur(6px)}
 .lang-btn{background:none;border:2px solid transparent;border-radius:50px;font-size:1.35rem;cursor:pointer;padding:3px 7px;line-height:1;transition:border-color .15s,box-shadow .15s}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
+/* mobil: dotykové plochy nav/jazyk na ≥44px */
+@media(pointer:coarse){.lang-btn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center}.tp-back,.tp-home{display:inline-flex;align-items:center;min-height:44px}}
 </style>
 </head>
 <body>

--- a/projects/unikovka_procenta.html
+++ b/projects/unikovka_procenta.html
@@ -216,6 +216,8 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
 .lang-btn:hover{border-color:var(--blue);box-shadow:0 2px 8px rgba(26,115,200,.2)}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}.chest{animation:none!important}.confetti-piece{display:none!important}}
+/* mobil: dotykové plochy nav/jazyk na ≥44px */
+@media(pointer:coarse){.lang-btn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center}.tp-back,.tp-home{display:inline-flex;align-items:center;min-height:44px}}
 </style>
 </head>
 <body>

--- a/projects/unikovka_telesa.html
+++ b/projects/unikovka_telesa.html
@@ -221,6 +221,8 @@ table.tt tr:nth-child(even) td{background:#fafaf5}
   transition:border-color .15s,box-shadow .15s}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}.chest{animation:none!important}.confetti-piece{display:none!important}}
+/* mobil: dotykové plochy nav/jazyk na ≥44px */
+@media(pointer:coarse){.lang-btn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center}.tp-back,.tp-home{display:inline-flex;align-items:center;min-height:44px}}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Problem
The mobile audit (`tests/mobile-audit.cjs`) found nav/lang/button tap targets under 40px tall on student-facing tools. Students (8.–9. grade) often play on phones, so sub-40px targets are a real usability issue.

## Fix
Added `@media(pointer:coarse)` blocks — these only apply on **touch devices**, so the desktop look is completely unchanged.

| Page | Change |
|------|--------|
| 5 educational tools (únikovky procenta/tělesa/mocniny, procenta_priklady, cesta_penez) | `.lang-btn` → 44×44, `.tp-back`/`.tp-home` → 44px tall |
| projects index | filter tags + project links → 40px (keeps dense terminal look) |
| přijímačky archiv | PDF download buttons → 44px, nav → 44px |
| RPG hub | `.btn`/`.gp-btn`/`.fb-send` → 44px |

## Result
- Mobile audit: **9 findings → 3** — all four core educational tools, projects index main nav, přijímačky and RPG hub now ✅ OK
- The 3 remaining are personal/footer-legal pages (home terminal page, projects footer privacy/terms link, travels) — left intentionally per the retro aesthetic decision
- a11y audit still 100% clean
- `unikovka_procenta.html` diff verified clean (no CRLF churn)

CSS-only, no logic changes. All pages render fine (verified by the audit harness loading each in a real browser).

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_