### PR TITLE
fix: mobile tap targets for unikovka_rovnice

### DIFF
--- a/projects/unikovka_rovnice.html
+++ b/projects/unikovka_rovnice.html
@@ -112,6 +112,7 @@ body{font-family:'Lexend',sans-serif;background:var(--bg);background-image:radia
 #lang-bar{position:fixed;bottom:16px;right:16px;z-index:200;display:flex;gap:6px;background:rgba(255,255,255,.92);border-radius:50px;padding:5px 8px;box-shadow:0 2px 12px rgba(0,0,0,.12);backdrop-filter:blur(6px)}
 .lang-btn{background:none;border:2px solid transparent;border-radius:50px;font-size:1.35rem;cursor:pointer;padding:3px 7px;line-height:1;transition:border-color .15s,box-shadow .15s}
 .lang-btn.active{border-color:var(--blue);box-shadow:0 0 0 2px rgba(26,115,200,.25)}
+@media(pointer:coarse){.lang-btn{min-width:44px;min-height:44px;display:inline-flex;align-items:center;justify-content:center}.tp-back,.tp-home{display:inline-flex;align-items:center;min-height:44px}}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- `unikovka_rovnice.html` already existed on main (10-lock linear equations escape room, 7th–9th grade)
- This PR adds the missing `@media(pointer:coarse)` block for mobile touch targets (≥44px), consistent with the same fix applied to all other únikovky in PR #114

## Test plan
- [ ] Open on mobile/touch device — lang buttons and back/home links should be comfortably tappable
- [ ] Desktop appearance unchanged

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_