### PR TITLE
fix: gap between intro panels in all escape rooms

### DIFF
--- a/projects/unikovka_mocniny.html
+++ b/projects/unikovka_mocniny.html
@@ -24,6 +24,7 @@ body{font-family:'Lexend',sans-serif;background:var(--bg);background-image:radia
 .screen{display:none;min-height:100vh;padding:24px 16px 48px;max-width:680px;margin:0 auto}
 .screen.active{display:flex;flex-direction:column;align-items:center}
 #intro{justify-content:center;text-align:center;gap:18px}
+#intro-content{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}
 .title-main{font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:800}

--- a/projects/unikovka_procenta.html
+++ b/projects/unikovka_procenta.html
@@ -43,6 +43,7 @@ body{
 
 /* INTRO */
 #intro{justify-content:center;text-align:center;gap:18px}
+#intro-content{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;
   filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}

--- a/projects/unikovka_rovnice.html
+++ b/projects/unikovka_rovnice.html
@@ -24,6 +24,7 @@ body{font-family:'Lexend',sans-serif;background:var(--bg);background-image:radia
 .screen{display:none;min-height:100vh;padding:24px 16px 48px;max-width:680px;margin:0 auto}
 .screen.active{display:flex;flex-direction:column;align-items:center}
 #intro{justify-content:center;text-align:center;gap:18px}
+#intro-content{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}
 .title-main{font-size:2.5rem;color:var(--blue);line-height:1.1;font-weight:800}

--- a/projects/unikovka_telesa.html
+++ b/projects/unikovka_telesa.html
@@ -44,6 +44,7 @@ body{
 
 /* INTRO */
 #intro{justify-content:center;text-align:center;gap:18px}
+#intro-content{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;
   filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}

--- a/projects/unikovka_trojuhelniky.html
+++ b/projects/unikovka_trojuhelniky.html
@@ -24,6 +24,7 @@ body{font-family:'Lexend',sans-serif;background:var(--bg);background-image:radia
 .screen{display:none;min-height:100vh;padding:24px 16px 48px;max-width:680px;margin:0 auto}
 .screen.active{display:flex;flex-direction:column;align-items:center}
 #intro{justify-content:center;text-align:center;gap:18px}
+#intro-content{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
 .chest{font-size:88px;animation:float 3s ease-in-out infinite;display:inline-block;filter:drop-shadow(0 8px 16px rgba(0,0,0,.15))}
 @keyframes float{0%,100%{transform:translateY(0)}50%{transform:translateY(-9px)}}
 .title-main{font-size:2.5rem;color:var(--green);line-height:1.1;font-weight:800}


### PR DESCRIPTION
## Problem

The intro screen of every escape room showed the description panel and the rules panel touching each other without any gap. `#intro` had `gap:18px` set, but `#intro-content` is a single block-level child of `#intro`, so the flex gap had nothing to act on — all cards inside it were just stacking as normal block elements.

## Fix

One-liner CSS rule added to each file:

```css
#intro-content{display:flex;flex-direction:column;align-items:center;gap:18px;width:100%}
```

Now the chest icon, title, description card, rules card and start button all have 18 px breathing room between them — matching the visual style of cesta_penez.

## Files changed

`unikovka_procenta`, `unikovka_telesa`, `unikovka_mocniny`, `unikovka_rovnice`, `unikovka_trojuhelniky` — 1 line added per file, CSS only.

## Test plan

- [ ] Open each escape room intro — panels should have visible gap between them
- [ ] Click Start — game still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_