### PR TITLE
feat: živý souboj — trvalé statistiky pro učitele + vylepšené UI

### DIFF
--- a/projects/rpg-battle-ui.js
+++ b/projects/rpg-battle-ui.js
@@ -333,6 +333,12 @@
   // ════════════ VÝSLEDKY ════════════
   function renderResults(st) {
     stopPoll();
+    // Trvalá historie (Fáze 13): každý hráč zapíše vlastní výsledek (jednou).
+    var c0 = cloud();
+    if (c0 && c0.recordBattleResult && B && B.id && !B.recorded) {
+      B.recorded = true;
+      try { c0.recordBattleResult(B.id); } catch (e) {}
+    }
     var players = (st.players || []).slice().sort(function (a, b) { return b.score - a.score; });
     var medal = function (i) { return i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : (i + 1) + '.'; };
     var inner = '<div class="rpgb-h">🏁 Konec souboje</div>' +

--- a/projects/rpg-battle-ui.js
+++ b/projects/rpg-battle-ui.js
@@ -27,6 +27,39 @@
   function cloud() { return (typeof RPGCloud !== 'undefined') ? RPGCloud : null; }
   function esc(s) { return String(s == null ? '' : s).replace(/[&<>"]/g, function (c) {
     return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]; }); }
+  function reducedMotion() {
+    try { if (typeof RPGWallet !== 'undefined' && RPGWallet.getReducedMotion) return !!RPGWallet.getReducedMotion(); } catch (e) {}
+    try { return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches; } catch (e) { return false; }
+  }
+  var SHAPES = ['▲', '◆', '●', '■'];
+
+  // 3-2-1 odpočet před první otázkou (přeskočí se při reduced-motion)
+  function countdown(done) {
+    if (reducedMotion()) { done(); return; }
+    var ov = document.createElement('div'); ov.id = 'rpgb-cd';
+    document.body.appendChild(ov); var n = 3;
+    function step() {
+      ov.innerHTML = '<b>' + n + '</b>';
+      if (n-- <= 1) { setTimeout(function () { ov.remove(); done(); }, 850); }
+      else setTimeout(step, 850);
+    }
+    step();
+  }
+
+  // konfety pro výsledkovou obrazovku
+  function confetti() {
+    if (reducedMotion()) return;
+    var old = document.getElementById('rpgb-conf'); if (old) old.remove();
+    var box = document.createElement('div'); box.id = 'rpgb-conf';
+    var cols = ['#e8475f', '#3b82f6', '#eab308', '#22c55e', '#19e6e6'];
+    var html = '';
+    for (var i = 0; i < 70; i++) {
+      html += '<i style="left:' + (Math.random() * 100).toFixed(1) + '%;background:' + cols[i % cols.length] +
+        ';animation-duration:' + (2 + Math.random() * 1.8).toFixed(2) + 's;animation-delay:' + (Math.random() * 0.6).toFixed(2) + 's"></i>';
+    }
+    box.innerHTML = html; document.body.appendChild(box);
+    setTimeout(function () { box.remove(); }, 4200);
+  }
 
   // ── jednorázové vložení stylů ──
   function injectCss() {
@@ -72,7 +105,37 @@
       'transform-origin:left center;transform:scaleX(1);transition:transform .25s linear}' +
       '.rpgb-row{display:flex;justify-content:space-between;align-items:center;font-size:13px;color:var(--muted,#8895b5);margin-bottom:8px}' +
       '.rpgb-hdr{display:flex;justify-content:flex-end;margin:0 -4px 4px}' +
-      '.rpgb-x{font-size:22px;color:var(--muted,#8895b5);cursor:pointer;background:none;border:none;padding:2px 6px;line-height:1}';
+      '.rpgb-x{font-size:22px;color:var(--muted,#8895b5);cursor:pointer;background:none;border:none;padding:2px 6px;line-height:1}' +
+      // ── Kahoot dlaždice: 4 barvy + tvary ──
+      '.rpgb-ch{display:flex;align-items:center;gap:10px}' +
+      '.rpgb-sh{font-size:18px;line-height:1;flex:0 0 auto;opacity:.9}' +
+      '.rpgb-ch.k0{border-color:#e8475f;background:rgba(232,71,95,.14)}.rpgb-ch.k0:hover:not(:disabled){border-color:#ff6b81;background:rgba(232,71,95,.24)}' +
+      '.rpgb-ch.k1{border-color:#3b82f6;background:rgba(59,130,246,.14)}.rpgb-ch.k1:hover:not(:disabled){border-color:#60a5fa;background:rgba(59,130,246,.24)}' +
+      '.rpgb-ch.k2{border-color:#eab308;background:rgba(234,179,8,.14)}.rpgb-ch.k2:hover:not(:disabled){border-color:#facc15;background:rgba(234,179,8,.24)}' +
+      '.rpgb-ch.k3{border-color:#22c55e;background:rgba(34,197,94,.14)}.rpgb-ch.k3:hover:not(:disabled){border-color:#4ade80;background:rgba(34,197,94,.24)}' +
+      // ok/bad přebijí barvu dlaždice
+      '.rpgb-ch.ok{border-color:#4ade80!important;background:rgba(74,222,128,.22)!important;color:#4ade80}' +
+      '.rpgb-ch.bad{border-color:#ff6b6b!important;background:rgba(255,107,107,.22)!important;color:#ff6b6b}' +
+      // ── mezikolo: žebříček ──
+      '.rpgb-stand{margin:10px 0 4px}' +
+      '.rpgb-st{display:flex;align-items:center;gap:9px;padding:7px 11px;border-radius:8px;background:rgba(255,255,255,.04);' +
+      'margin:5px 0;font-size:14px;transition:transform .35s ease,background .25s;border:1px solid transparent}' +
+      '.rpgb-st.me{border-color:var(--gold,#19e6e6);background:rgba(25,230,230,.12)}' +
+      '.rpgb-st .rk{min-width:26px;text-align:center;font-weight:700}' +
+      '.rpgb-st .nm{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}' +
+      '.rpgb-st .sc{color:var(--gold,#19e6e6);min-width:62px;text-align:right;font-weight:700}' +
+      '.rpgb-st .dl{font-size:12px;min-width:34px;text-align:right}' +
+      // ── odpočet 3-2-1 ──
+      '#rpgb-cd{position:fixed;inset:0;z-index:10000;display:flex;align-items:center;justify-content:center;background:rgba(5,8,16,.92)}' +
+      '#rpgb-cd b{font-family:var(--px,"Roboto Mono",monospace);font-size:120px;font-weight:700;color:var(--gold,#19e6e6);' +
+      'text-shadow:0 0 30px rgba(25,230,230,.6);animation:rpgb-pop .9s ease}' +
+      '@keyframes rpgb-pop{0%{transform:scale(.3);opacity:0}40%{transform:scale(1.1);opacity:1}100%{transform:scale(1);opacity:.85}}' +
+      // ── konfety ──
+      '#rpgb-conf{position:fixed;inset:0;z-index:10001;pointer-events:none;overflow:hidden}' +
+      '#rpgb-conf i{position:absolute;top:-12px;width:9px;height:14px;border-radius:2px;animation:rpgb-fall linear forwards}' +
+      '@keyframes rpgb-fall{to{transform:translateY(105vh) rotate(720deg);opacity:.4}}' +
+      // ── lobby hráč: jemný nástup ──
+      '.rpgb-ply{animation:rpgb-in .25s ease}@keyframes rpgb-in{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:none}}';
     document.head.appendChild(css);
   }
 
@@ -213,7 +276,22 @@
     if (!B.questions && bt.q_seed != null) B.questions = BANK.build(Number(bt.q_seed), bt.q_count);
     if (bt.status === 'lobby') renderLobby(st);
     else if (bt.status === 'finished') renderResults(st);
-    else renderQuestion(st);   // active / paused
+    else {
+      // start souboje: 3-2-1 odpočet jednou před první otázkou
+      if (bt.q_index === 0 && !B.didCountdown) {
+        B.didCountdown = true;
+        snapCorrect(st);                       // výchozí snímek pro přehled odpovědí
+        countdown(function () { if (B && B.state) renderQuestion(B.state); });
+        return;
+      }
+      renderQuestion(st);   // active / paused
+    }
+  }
+
+  // snímek dosažených správných odpovědí na začátku otázky (host přehled)
+  function snapCorrect(st) {
+    B.snap = {};
+    (st.players || []).forEach(function (p) { B.snap[p.user_id] = p.correct_count || 0; });
   }
 
   // ════════════ LOBBY ════════════
@@ -259,6 +337,7 @@
     }
     // plný re-render jen při změně otázky (jinak by se ztratil výběr)
     if (qi !== B.lastQi) {
+      if (qi !== 0) snapCorrect(st);    // nová otázka → nový snímek pro přehled (q0 už máme z odpočtu)
       B.lastQi = qi; B.picked = -1; B.locked = (bt.status === 'paused');
       var q = B.questions[qi];
       var inner = '<div class="rpgb-row"><span>OTÁZKA ' + (qi + 1) + ' / ' + bt.q_count + '</span>' +
@@ -267,9 +346,11 @@
         '<div class="rpgb-q">' + esc(q.text) + '</div>' +
         '<div id="rpgb-choices">' +
         q.choices.map(function (ch, i) {
-          return '<button class="rpgb-ch" id="rpgb-c' + i + '" onclick="RPGBattle._pick(' + i + ')">' + esc(ch) + '</button>';
+          return '<button class="rpgb-ch k' + (i % 4) + '" id="rpgb-c' + i + '" onclick="RPGBattle._pick(' + i + ')">' +
+            '<span class="rpgb-sh">' + SHAPES[i % 4] + '</span><span>' + esc(ch) + '</span></button>';
         }).join('') + '</div>' +
-        '<div id="rpgb-fb" style="text-align:center;font-weight:700;min-height:22px;margin-top:6px"></div>';
+        '<div id="rpgb-fb" style="text-align:center;font-weight:700;min-height:22px;margin-top:6px"></div>' +
+        '<div id="rpgb-stand" class="rpgb-stand"></div>';
       if (B.role === 'host') {
         inner += '<div style="display:flex;gap:8px;margin-top:12px">' +
           '<button class="rpgb-btn go sm" style="flex:1" onclick="RPGBattle._next()">' +
@@ -280,10 +361,44 @@
       B.deadline = (bt.q_started_at ? new Date(bt.q_started_at).getTime() : Date.now()) + QSEC * 1000;
       tickStart();
     }
-    // lehká aktualizace: kolik odpovědělo
-    var answered = (st.players || []).filter(function (p) { return p.last_qi >= qi; }).length;
+    // lehká aktualizace přehledu odpovědí (host vidí správně/špatně živě)
+    var pls = st.players || [];
+    var answered = pls.filter(function (p) { return p.last_qi >= qi; });
     var ansEl = document.getElementById('rpgb-ans');
-    if (ansEl) ansEl.textContent = '✓ ' + answered + '/' + (st.players || []).length;
+    if (ansEl) {
+      if (B.role === 'host' && B.snap) {
+        var corr = answered.filter(function (p) { return (p.correct_count || 0) > (B.snap[p.user_id] || 0); }).length;
+        ansEl.innerHTML = '<span style="color:#4ade80">✓' + corr + '</span> ' +
+          '<span style="color:#ff6b6b">✗' + (answered.length - corr) + '</span> · ' + answered.length + '/' + pls.length;
+      } else {
+        ansEl.textContent = '✓ ' + answered.length + '/' + pls.length;
+      }
+    }
+    // mezikolo: jakmile jsem odpověděl/vypršel čas, ukaž živý žebříček
+    if (B.locked) renderStandings(st);
+  }
+
+  // průběžný žebříček (top 5 + já), animovaný posun pořadí přes CSS transition
+  function renderStandings(st) {
+    var el = document.getElementById('rpgb-stand'); if (!el) return;
+    var ranked = (st.players || []).slice().sort(function (a, b) { return (b.score || 0) - (a.score || 0); });
+    var meIdx = ranked.findIndex(function (p) { return p.user_id === st.me; });
+    var show = ranked.slice(0, 5);
+    if (meIdx >= 5) show.push(ranked[meIdx]);   // přilep „mě", když jsem mimo top 5
+    var medal = function (i) { return i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : (i + 1) + '.'; };
+    el.innerHTML = '<div class="rpgb-row" style="margin-bottom:2px"><span>PRŮBĚŽNÉ POŘADÍ</span><span></span></div>' +
+      show.map(function (p) {
+        var i = ranked.indexOf(p);
+        var up = B.rankPrev && B.rankPrev[p.user_id] != null && B.rankPrev[p.user_id] > i;
+        var dn = B.rankPrev && B.rankPrev[p.user_id] != null && B.rankPrev[p.user_id] < i;
+        return '<div class="rpgb-st' + (p.user_id === st.me ? ' me' : '') + '">' +
+          '<span class="rk">' + medal(i) + '</span>' +
+          '<span class="nm">' + esc(p.display_name) + (p.user_id === st.me ? ' (ty)' : '') + '</span>' +
+          '<span class="dl">' + (up ? '<span style="color:#4ade80">▲</span>' : dn ? '<span style="color:#ff6b6b">▼</span>' : '') + '</span>' +
+          '<span class="sc">' + (p.score || 0) + '</span></div>';
+      }).join('');
+    // zapamatuj pořadí pro příští šipky
+    B.rankPrev = {}; ranked.forEach(function (p, i) { B.rankPrev[p.user_id] = i; });
   }
 
   function tickStart() {
@@ -311,6 +426,7 @@
     lockChoices(true);
     var fb = document.getElementById('rpgb-fb');
     if (fb) { fb.textContent = correct ? '✓ Správně! +' + pts : '✗ Špatně'; fb.style.color = correct ? '#4ade80' : '#ff6b6b'; }
+    if (B.state) renderStandings(B.state);
   }
 
   // odhalí správnou (zeleně) a případně chybný výběr (červeně)
@@ -353,6 +469,9 @@
       '<button class="rpgb-btn go" style="margin-top:16px" onclick="RPGBattle._menu()">⚔️ Nový souboj</button>' +
       '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle.close()">Zavřít</button>';
     shell(inner);
+    // konfety, když jsem skončil na bedně (1.–3.)
+    var myRank = players.findIndex(function (p) { return p.user_id === st.me; });
+    if (myRank >= 0 && myRank < 3) confetti();
     // Odměny: zavolej hru zpět s výsledky (XP/kredity/odznaky řeší hra, ne UI)
     if (B && typeof onResult === 'function') {
       var me = st.me;

--- a/projects/rpg-cloud-setup-phase13.sql
+++ b/projects/rpg-cloud-setup-phase13.sql
@@ -1,0 +1,112 @@
+-- ═══════════════════════════════════════════════════════════════════
+-- RPG Matematika — Fáze 13: TRVALÁ HISTORIE ŽIVÝCH SOUBOJŮ
+-- Spustit po fázi 7 (živý souboj) a fázi 2 (my_role).
+--
+-- Proč: `battle_players` se maže s místností (cleanup_battles po 12 h,
+-- cascade). Učitel tak nevidí, kolik soubojů žák odehrál ani jeho
+-- úspěšnost. Tato fáze přidává TRVALÝ záznam výsledku per žák/souboj,
+-- který přežije úklid místností (bez FK na battles → cascade ho nesmaže).
+--
+-- Bezpečnost (vzor Fáze 7/9): RLS deny-all, vše přes SECURITY DEFINER.
+-- Žák si výsledek NEHLÁSÍ čísly (spoof) — funkce si correct/score/rank
+-- DOPOČÍTÁ sama z battle_players na serveru. Zápis je idempotentní
+-- (unique battle_id+user_id), takže opakované volání nepřičítá dvakrát.
+-- ═══════════════════════════════════════════════════════════════════
+
+-- ── Tabulka: jeden řádek = výsledek jednoho žáka v jednom souboji ────
+create table if not exists battle_results (
+  battle_id   uuid not null,                 -- bez FK → přežije cleanup battles
+  user_id     uuid references auth.users not null,
+  game        text not null default 'RPG_MAT_9',
+  correct     int  not null default 0,
+  wrong       int  not null default 0,       -- q_count - correct (timeout = chyba)
+  score       int  not null default 0,
+  rank        int  not null default 1,        -- 1 = vítěz
+  total       int  not null default 1,        -- počet hráčů v souboji
+  finished_at timestamptz default now(),
+  primary key (battle_id, user_id)
+);
+
+create index if not exists bresults_user on battle_results(user_id);
+create index if not exists bresults_game on battle_results(game);
+
+alter table battle_results enable row level security;
+-- (úmyslně bez permisivních politik → vše přes funkce níže)
+
+-- ── Zápis vlastního výsledku (volá ho hráč na výsledkové obrazovce) ──
+--    Server si correct/wrong/score/rank/total dopočítá z battle_players,
+--    takže žák nemůže čísla podvrhnout. Idempotentní přes ON CONFLICT.
+create or replace function public.record_battle_result(p_battle uuid)
+returns void language plpgsql security definer set search_path = public as $$
+declare
+  b battles;
+  me_score int; me_correct int; me_qcount int;
+  me_rank int; me_total int;
+begin
+  if auth.uid() is null then raise exception 'not authenticated'; end if;
+  select * into b from battles where id = p_battle;
+  if b.id is null then return; end if;                 -- místnost už uklizená
+  -- musím být účastník
+  select score, correct_count into me_score, me_correct
+    from battle_players where battle_id = p_battle and user_id = auth.uid();
+  if me_score is null then return; end if;             -- nebyl jsem hráč
+  me_qcount := greatest(b.q_count, me_correct);        -- pojistka
+  select count(*)::int into me_total
+    from battle_players where battle_id = p_battle;
+  select 1 + count(*)::int into me_rank
+    from battle_players
+   where battle_id = p_battle and score > me_score;
+  insert into battle_results (battle_id, user_id, game, correct, wrong, score, rank, total)
+  values (p_battle, auth.uid(), b.game, me_correct,
+          greatest(0, me_qcount - me_correct), me_score, me_rank, me_total)
+  on conflict (battle_id, user_id) do nothing;          -- ať se nepřičítá dvakrát
+end; $$;
+
+-- ── Učitelský přehled: agregace per žák (volitelně 1 ročník) ─────────
+--    Vrací jen user_id + souhrnné metriky (žádné e-maily / per-otázku).
+create or replace function public.battle_stats_all(p_game text default null)
+returns table (user_id uuid, played int, correct int, wrong int,
+               wins int, score int, avg_rank numeric)
+language sql security definer set search_path = public stable as $$
+  select r.user_id,
+         count(*)::int                              as played,
+         coalesce(sum(r.correct), 0)::int           as correct,
+         coalesce(sum(r.wrong), 0)::int             as wrong,
+         count(*) filter (where r.rank = 1)::int    as wins,
+         coalesce(sum(r.score), 0)::int             as score,
+         round(avg(r.rank), 1)                      as avg_rank
+  from battle_results r
+  where (select my_role()) in ('teacher', 'superadmin')
+    and (p_game is null or r.game = p_game)
+  group by r.user_id;
+$$;
+
+-- ── Můj vlastní souhrn (žák si smí přečíst jen svoje) ────────────────
+create or replace function public.battle_stats_me(p_game text default null)
+returns table (played int, correct int, wrong int, wins int,
+               score int, avg_rank numeric)
+language sql security definer set search_path = public stable as $$
+  select count(*)::int,
+         coalesce(sum(correct), 0)::int,
+         coalesce(sum(wrong), 0)::int,
+         count(*) filter (where rank = 1)::int,
+         coalesce(sum(score), 0)::int,
+         round(avg(rank), 1)
+  from battle_results
+  where user_id = auth.uid()
+    and (p_game is null or game = p_game);
+$$;
+
+-- ── Práva (vzor Fáze 9: anon nikam) ─────────────────────────────────
+revoke execute on function public.record_battle_result(uuid) from public, anon;
+revoke execute on function public.battle_stats_all(text)     from public, anon;
+revoke execute on function public.battle_stats_me(text)      from public, anon;
+grant   execute on function public.record_battle_result(uuid) to authenticated;
+grant   execute on function public.battle_stats_all(text)     to authenticated;
+grant   execute on function public.battle_stats_me(text)      to authenticated;
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Hotovo. Klient (rpg-battle-ui.js) volá record_battle_result() na konci
+-- souboje; učitelská konzole čte battle_stats_all() v záložce SOUBOJE.
+-- Bez přihlášení/cloudu se nic neděje (graceful).
+-- ═══════════════════════════════════════════════════════════════════

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -602,6 +602,31 @@ window.RPGCloud = (function () {
       if (error) throw error; return data || [];
     } catch (e) { return []; }
   }
+  /* Fáze 13: trvalá historie soubojů. Hráč po skončení zapíše svůj výsledek
+     (server si čísla dopočítá z battle_players → nelze podvrhnout). */
+  async function recordBattleResult(battleId) {
+    if (!client || !user) return false;
+    try {
+      const { error } = await client.rpc('record_battle_result', { p_battle: battleId });
+      return !error;
+    } catch (e) { return false; }
+  }
+  /* Učitel: agregace soubojových statistik per žák (volitelně 1 ročník). */
+  async function battleStatsAll(game) {
+    if (!client || !user) return [];
+    try {
+      const { data, error } = await client.rpc('battle_stats_all', { p_game: game || null });
+      if (error) throw error; return data || [];
+    } catch (e) { return []; }
+  }
+  /* Žák: vlastní soubojový souhrn. */
+  async function battleStatsMe(game) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('battle_stats_me', { p_game: game || null });
+      if (error) throw error; return (data && data[0]) || null;
+    } catch (e) { return null; }
+  }
   /* Polling: zavolá cb(state) hned a pak každých intervalMs (default 1200).
      Vrací stop() funkci. Klient tím drží živý stav bez websocketů. */
   function pollBattle(battleId, cb, intervalMs) {
@@ -1053,6 +1078,8 @@ window.RPGCloud = (function () {
            createBattle, joinBattle, battleState, submitBattleAnswer,
            advanceBattle, setBattleStatus, listActiveBattles,
            inviteBattleEmail, myBattleInvites, pollBattle,
+           // Fáze 13 — trvalá historie soubojů
+           recordBattleResult, battleStatsAll, battleStatsMe,
            // Fáze 11 — věž legend
            towerEligible, towerSubmit, towerBoard, towerHall, towerCloseSeason,
            // Fáze 12 — věž legend: nástroje pro učitele

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -126,6 +126,7 @@ h4{font-family:var(--px);font-size:12px;font-weight:700;color:var(--accent);lett
    <button class="tab" data-tab="diag">DIAGNOSTIKA</button>
    <button class="tab" data-tab="leaderboard">🏆 ŽEBŘÍČKY</button>
    <button class="tab" data-tab="tower">VĚŽ LEGEND</button>
+   <button class="tab" data-tab="battles">⚔️ SOUBOJE</button>
    <button class="tab" data-tab="explain">VYSVĚTLENÍ</button>
    <button class="tab" data-tab="feedback">ZPĚTNÁ VAZBA</button>
    <button class="tab" data-tab="preview">NÁHLED HER</button>
@@ -251,6 +252,17 @@ h4{font-family:var(--px);font-size:12px;font-weight:700;color:var(--accent);lett
      <div id="tower-hall-wrap"><div class="empty">Načítám…</div></div>
     </div>
    </div>
+  </div>
+
+  <!-- ŽIVÉ SOUBOJE -->
+  <div id="t-battles" class="hidden">
+   <div class="info-box"><b>⚔️ Živé souboje</b> — trvalý souhrn napříč všemi odehranými místnostmi (přežije úklid).
+    Kolik soubojů žák dohrál, kolik měl správně/špatně, kolikrát vyhrál a průměrné umístění.</div>
+   <div class="controls">
+    <select id="bt-game" aria-label="Souboje: filtr podle ročníku" onchange="renderBattles()"></select>
+    <button class="mini" onclick="renderBattles()">↻ Obnovit</button>
+   </div>
+   <div id="bt-wrap"><div class="empty">Načítám…</div></div>
   </div>
 
   <!-- VYSVĚTLENÍ POSTUPU -->
@@ -1462,6 +1474,62 @@ async function deleteTowerRunUI(i){
  else toast('Chyba: '+r.error,1);
 }
 
+/* ── ŽIVÉ SOUBOJE: trvalé statistiky (Fáze 13) ── */
+let BT_SORT={col:'played',dir:1};
+function initBattlesTab(){
+ const sel=document.getElementById('bt-game');
+ if(!sel.options.length){
+  const all=document.createElement('option');all.value='';all.textContent='— Všechny ročníky —';sel.appendChild(all);
+  GAMES.forEach(g=>{const o=document.createElement('option');o.value=g.key;o.textContent=g.emoji+' '+g.nm+' ('+g.gr+')';sel.appendChild(o);});
+ }
+ renderBattles();
+}
+function btSort(col){if(BT_SORT.col===col)BT_SORT.dir*=-1;else{BT_SORT.col=col;BT_SORT.dir=1;}renderBattles();}
+async function renderBattles(){
+ const game=document.getElementById('bt-game').value||'';
+ const wrap=document.getElementById('bt-wrap');
+ wrap.innerHTML='<div class="empty">Načítám…</div>';
+ let stats=[];
+ try{stats=await RPGCloud.battleStatsAll(game||null);}
+ catch(e){wrap.innerHTML='<div class="empty">Chyba při načítání. Nasazené SQL fáze 13?</div>';return;}
+ if(!stats||!stats.length){wrap.innerHTML='<div class="empty">Zatím žádné dohrané souboje'+(game?' v tomto ročníku':'')+'.</div>';return;}
+ // user_id → skutečné jméno/e-mail z načtených save (ROWS)
+ const info=new Map();
+ ROWS.forEach(r=>{if(!info.has(r.user_id))info.set(r.user_id,{name:r.full_name||'',email:r.email||''});});
+ const rows=stats.map(s=>{
+  const i=info.get(s.user_id)||{};
+  const tot=(s.correct|0)+(s.wrong|0);
+  return {name:i.name||'—',email:i.email||'',played:s.played|0,correct:s.correct|0,
+   wrong:s.wrong|0,wins:s.wins|0,acc:tot?Math.round(100*s.correct/tot):0,
+   avg:s.avg_rank!=null?Number(s.avg_rank):null};
+ });
+ rows.sort((a,b)=>{const c=BT_SORT.col;let va=a[c],vb=b[c];
+  if(c==='name'){return BT_SORT.dir*String(va).localeCompare(String(vb),'cs');}
+  if(va==null)va=999;if(vb==null)vb=999;return BT_SORT.dir*(vb-va);});
+ const ico=c=>BT_SORT.col===c?(BT_SORT.dir===1?' ▼':' ▲'):'';
+ const th=(c,lbl,al)=>'<th style="cursor:pointer;user-select:none;text-align:'+(al||'right')+'" onclick="btSort(\''+c+'\')">'+lbl+ico(c)+'</th>';
+ // barva úspěšnosti: zeleně→červeně
+ const accCol=p=>'hsl('+Math.round(p*1.2)+',60%,55%)';
+ let html='<table class="tbl"><thead><tr>'+
+  th('name','Žák','left')+th('played','Odehráno')+th('correct','Správně')+
+  th('wrong','Špatně')+th('acc','Úspěšnost')+th('wins','Výhry')+th('avg','⌀ umístění')+
+  '</tr></thead><tbody>';
+ rows.forEach(r=>{
+  html+='<tr>'+
+   '<td><div class="nm" style="font-weight:700">'+esc(r.name)+'</div>'+(r.email?'<div class="em">'+esc(r.email)+'</div>':'')+'</td>'+
+   '<td style="text-align:right;font-weight:700">'+r.played+'</td>'+
+   '<td style="text-align:right;color:#4ade80">'+r.correct+'</td>'+
+   '<td style="text-align:right;color:var(--red,#ff6b6b)">'+r.wrong+'</td>'+
+   '<td style="text-align:right;font-weight:700;color:'+accCol(r.acc)+'">'+r.acc+'%</td>'+
+   '<td style="text-align:right">'+(r.wins?'🥇 '+r.wins:'<span style="color:var(--muted)">0</span>')+'</td>'+
+   '<td style="text-align:right;color:var(--muted)">'+(r.avg!=null?r.avg.toFixed(1)+'.':'—')+'</td>'+
+   '</tr>';
+ });
+ html+='</tbody></table><p style="color:var(--muted);font-size:12px;margin-top:8px">'+
+  rows.length+' žáků · trvalá historie napříč všemi místnostmi. „Špatně" = otázky bez správné odpovědi (vč. nestihnutých). ⌀ umístění: nižší = lepší (1. = vítěz).</p>';
+ wrap.innerHTML=html;
+}
+
 document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
  document.querySelectorAll('.tab').forEach(x=>x.classList.remove('on'));
  t.classList.add('on');
@@ -1472,6 +1540,7 @@ document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
  document.getElementById('t-diag').classList.toggle('hidden',tab!=='diag');
  document.getElementById('t-leaderboard').classList.toggle('hidden',tab!=='leaderboard');
  document.getElementById('t-tower').classList.toggle('hidden',tab!=='tower');
+ document.getElementById('t-battles').classList.toggle('hidden',tab!=='battles');
  document.getElementById('t-explain').classList.toggle('hidden',tab!=='explain');
  document.getElementById('t-feedback').classList.toggle('hidden',tab!=='feedback');
  document.getElementById('t-teachers').classList.toggle('hidden',tab!=='teachers');
@@ -1480,6 +1549,7 @@ document.querySelectorAll('.tab').forEach(t=>t.onclick=()=>{
  if(tab==='diag')renderDiag();
  if(tab==='leaderboard')initLeaderboardTab();
  if(tab==='tower')renderTower();
+ if(tab==='battles')initBattlesTab();
  if(tab==='explain')initExplainTab();
  if(tab==='feedback')loadFeedback();
 });

--- a/tests/rpg-battle-stats-console.test.cjs
+++ b/tests/rpg-battle-stats-console.test.cjs
@@ -1,0 +1,132 @@
+/* ══════════════════════════════════════════════════════════════════
+   Test FÁZE 13 (konzole): záložka ⚔️ SOUBOJE v rpg-ucitel.html.
+   Mock RPC battle_stats_all → ověří render tabulky (odehráno/správně/
+   špatně/úspěšnost/výhry/⌀umístění), join na jméno žáka z save, XSS,
+   řazení a přepnutí ročníku.
+   Spusť: node tests/rpg-battle-stats-console.test.cjs
+   ══════════════════════════════════════════════════════════════════ */
+const { chromium } = require('playwright');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const PORT = 18491;
+const BASE = `http://localhost:${PORT}`;
+const CHROMIUM = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+
+let pass = 0, fail = 0;
+function ok(name, cond, d='') { if (cond){console.log('  ✅ '+name);pass++;} else {console.log('  ❌ '+name+(d?' — '+d:''));fail++;} }
+
+function mockScript(scenario) {
+  return `(function(){
+    const S = ${JSON.stringify(scenario)};
+    const db = { roles:S.roles||[], saves:S.saves||[], classes:[], class_members:[], notes:[] };
+    window.__rpcCalls = [];
+    function mkClient(){
+      function q(table){
+        let single=false, filters=[];
+        function rows(){ let r=(db[table]||[]).slice(); filters.forEach(([c,v])=>{r=r.filter(x=>String(x[c])===String(v));}); return r; }
+        function resolve(){ const r=rows(); return Promise.resolve({data: single?(r[0]||null):r, error:null}); }
+        const b={ select(){return b;}, insert(){return b;}, upsert(){return b;}, update(){return b;}, delete(){return b;},
+          eq(c,v){filters.push([c,v]);return b;}, order(){return b;}, limit(){return b;}, range(){return b;}, is(){return b;}, in(){return b;},
+          maybeSingle(){single=true;return resolve();}, single(){single=true;return resolve();},
+          then(res,rej){return resolve().then(res,rej);} };
+        return b;
+      }
+      return {
+        auth:{ getSession:async()=>({data:{session:S.session||null}}), onAuthStateChange:()=>({data:{subscription:{unsubscribe(){}}}}), signInWithOAuth:async()=>{}, signOut:async()=>{} },
+        from:q,
+        rpc:async(fn,args)=>{
+          window.__rpcCalls.push({fn,args});
+          if(fn==='battle_stats_all'){
+            let r=S.stats||[];
+            if(args&&args.p_game) r=r.filter(x=>x.game===args.p_game);
+            return {data:r,error:null};
+          }
+          return {data:[],error:null};
+        }
+      };
+    }
+    window.supabase = { createClient:()=>mkClient() };
+  })();`;
+}
+
+function startServer() {
+  const mime={html:'text/html',js:'application/javascript',css:'text/css'};
+  const srv=http.createServer((req,res)=>{ let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
+    const fp=path.normalize(path.join(ROOT,p));
+    if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}
+    try{const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    catch{res.writeHead(404);res.end('nf');} });
+  return new Promise(r=>srv.listen(PORT,()=>r(srv)));
+}
+
+async function run() {
+  console.log('\n── Konzole: záložka ⚔️ SOUBOJE ──\n');
+  const srv = await startServer();
+  const browser = await chromium.launch({ headless:true, executablePath:CHROMIUM });
+  const errors = [];
+  try {
+    const admin='vojtech.konopa@husovaliberec.cz';
+    const scenario = {
+      roles: [{ email: admin, role:'superadmin' }],
+      session: { user:{ id:'u-admin', email:admin, user_metadata:{full_name:'Vojta'} } },
+      saves: [
+        { user_id:'u-neo',  game:'RPG_MAT_9', data:{}, name:'NeoHrdina', email:'neo@husovaliberec.cz',  full_name:'Tomáš Anderson', updated_at:'2026-06-20T10:00:00Z' },
+        { user_id:'u-trin', game:'RPG_MAT_9', data:{}, name:'Trin',      email:'trin@husovaliberec.cz', full_name:'<img src=x onerror="window.__xss=1">', updated_at:'2026-06-20T10:00:00Z' },
+        { user_id:'u-six',  game:'RPG_MAT_6', data:{}, name:'Sixer',     email:'six@husovaliberec.cz',  full_name:'Adam Šestý', updated_at:'2026-06-20T10:00:00Z' },
+      ],
+      stats: [
+        { user_id:'u-neo',  game:'RPG_MAT_9', played:5, correct:30, wrong:10, wins:3, score:9000, avg_rank:1.4 },
+        { user_id:'u-trin', game:'RPG_MAT_9', played:2, correct:6,  wrong:14, wins:0, score:1800, avg_rank:3.0 },
+        { user_id:'u-six',  game:'RPG_MAT_6', played:8, correct:40, wrong:8,  wins:5, score:12000, avg_rank:1.2 },
+      ],
+    };
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    page.on('pageerror', e=>errors.push(e.message));
+    await page.addInitScript(mockScript(scenario));
+    await page.goto(`${BASE}/projects/rpg-ucitel.html`, { waitUntil:'load' });
+    await page.waitForFunction(()=>!document.getElementById('console').classList.contains('hidden'), {timeout:8000});
+
+    await page.click('.tab[data-tab="battles"]');
+    await page.waitForFunction(()=>!document.getElementById('t-battles').classList.contains('hidden'),{timeout:4000});
+    ok('záložka Souboje se otevře', true);
+
+    const opts = await page.evaluate(()=>document.getElementById('bt-game').options.length);
+    ok('výběr ročníku: 1 „vše" + 4 hry', opts===5, 'options='+opts);
+    ok('výchozí = všechny ročníky (prázdná hodnota)', await page.evaluate(()=>document.getElementById('bt-game').value)==='');
+
+    await page.waitForFunction(()=>/Odehráno/.test(document.getElementById('bt-wrap').textContent),{timeout:4000});
+    const t = await page.evaluate(()=>document.getElementById('bt-wrap').textContent);
+    ok('řádek Neo: skutečné jméno + 5 odehráno', /Tomáš Anderson/.test(t)&&/neo@/.test(t));
+    ok('úspěšnost Neo = 75 % (30/40)', /75%/.test(t), t.slice(0,200));
+    ok('Adam Šestý (6. ročník) je vidět ve „všech ročnících"', /Adam Šestý/.test(t));
+    ok('výhry: zobrazí 🥇 u žáka s výhrami', /🥇/.test(t));
+    ok('⌀ umístění Trin = 3.0', /3\.0/.test(t));
+    ok('XSS jméno žáka neprojde', await page.evaluate(()=>window.__xss||0)===0);
+
+    // řazení podle úspěšnosti (klik na hlavičku)
+    await page.evaluate(()=>btSort('acc'));
+    await page.waitForTimeout(150);
+    const firstName = await page.evaluate(()=>{
+      const tr=document.querySelector('#bt-wrap tbody tr'); return tr?tr.textContent:'';
+    });
+    ok('řazení dle úspěšnosti: nejvýš nejlepší (Adam 83 % nebo Neo 75 %)', /Adam Šestý|Tomáš Anderson/.test(firstName), firstName);
+
+    // přepnutí na 6. ročník filtruje
+    await page.evaluate(()=>{const s=document.getElementById('bt-game');s.value='RPG_MAT_6';renderBattles();});
+    await page.waitForFunction(()=>window.__rpcCalls.some(c=>c.fn==='battle_stats_all'&&c.args.p_game==='RPG_MAT_6'),{timeout:4000});
+    await page.waitForTimeout(150);
+    const t6 = await page.evaluate(()=>document.getElementById('bt-wrap').textContent);
+    ok('filtr 6. ročník: jen Adam Šestý, ne Neo', /Adam Šestý/.test(t6)&&!/Tomáš Anderson/.test(t6), t6.slice(0,200));
+
+    ok('žádné JS chyby', errors.length===0, errors.join(' | '));
+  } finally {
+    await browser.close(); srv.close();
+  }
+  console.log(`\n  VÝSLEDEK: ${pass} ✅ / ${fail} ❌\n`);
+  process.exit(fail?1:0);
+}
+run().catch(e=>{console.error(e);process.exit(1);});

--- a/tests/rpg-battle-ui.test.cjs
+++ b/tests/rpg-battle-ui.test.cjs
@@ -1,0 +1,134 @@
+/* ══════════════════════════════════════════════════════════════════
+   Test ŽIVÝ SOUBOJ — vylepšené UI (rpg-battle-ui.js).
+   Mock RPGCloud.pollBattle zachytí onState callback → testem řídíme
+   stavy souboje a ověříme: Kahoot dlaždice (4 barvy+tvary), 3-2-1
+   odpočet (skip při reduced-motion), host přehled správně/špatně,
+   průběžný žebříček, výsledky + zápis výsledku (recordBattleResult).
+   Spusť: node tests/rpg-battle-ui.test.cjs
+   ══════════════════════════════════════════════════════════════════ */
+const { chromium } = require('playwright');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const PORT = 18493;
+const BASE = `http://localhost:${PORT}`;
+const CHROMIUM = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+
+let pass = 0, fail = 0;
+function ok(name, cond, d='') { if (cond){console.log('  ✅ '+name);pass++;} else {console.log('  ❌ '+name+(d?' — '+d:''));fail++;} }
+
+function startServer() {
+  const mime={html:'text/html',js:'application/javascript',css:'text/css'};
+  const srv=http.createServer((req,res)=>{ let p=req.url.split('?')[0]; if(p==='/')p='/index.html';
+    const fp=path.normalize(path.join(ROOT,p));
+    if(!fp.startsWith(ROOT+path.sep)){res.writeHead(403);res.end('forbidden');return;}
+    try{const buf=fs.readFileSync(fp);res.writeHead(200,{'Content-Type':mime[p.split('.').pop()]||'application/octet-stream'});res.end(buf);}
+    catch{res.writeHead(404);res.end('nf');} });
+  return new Promise(r=>srv.listen(PORT,()=>r(srv)));
+}
+
+// minimální harness: mock cloud + banka, načte rpg-battle-ui.js
+function harness() {
+  return `<!doctype html><html><head><meta charset="utf-8"><style>:root{--gold:#19e6e6}</style></head>
+  <body><script>
+    window.__rec = 0;
+    window.RPGWallet = { getReducedMotion:()=>true };   // skip odpočtu/konfet pro rychlost
+    window.RPG_BATTLE_9 = { build:function(seed,count){
+      var a=[]; for(var i=0;i<count;i++) a.push({text:'Otázka '+(i+1)+'?',choices:['Alfa','Beta','Gama','Delta'],correct:0}); return a; } };
+    window.RPGCloud = {
+      currentUser:()=>({id:'u-me'}),
+      isStaff:()=>false,
+      createBattle:(g,c,n)=>Promise.resolve({id:'b1',code:'WXYZ'}),
+      joinBattle:(c,n)=>Promise.resolve({id:'b1',code:'WXYZ'}),
+      pollBattle:(id,cb,iv)=>{ window.__cb=cb; return ()=>{}; },
+      submitBattleAnswer:function(){ window.__lastSubmit=[].slice.call(arguments); },
+      advanceBattle:()=>{}, setBattleStatus:()=>{},
+      listActiveBattles:()=>Promise.resolve([]),
+      recordBattleResult:(id)=>{ window.__rec++; return Promise.resolve(true); }
+    };
+  </script>
+  <script src="${BASE}/projects/rpg-battle-ui.js"></script>
+  </body></html>`;
+}
+
+async function run() {
+  console.log('\n── Živý souboj: vylepšené UI ──\n');
+  const srv = await startServer();
+  const browser = await chromium.launch({ headless:true, executablePath:CHROMIUM });
+  const errors = [];
+  try {
+    const ctx = await browser.newContext({ viewport:{width:480,height:820} });
+    const page = await ctx.newPage();
+    page.on('pageerror', e=>errors.push(e.message));
+    await page.setContent(harness(), { waitUntil:'load' });
+    await page.waitForFunction(()=>typeof window.RPGBattle!=='undefined',{timeout:5000});
+
+    // založ souboj jako host
+    await page.evaluate(()=>{ RPGBattle.open({game:'RPG_MAT_9', name:'Me', autoAction:'host'}); });
+    await page.evaluate(()=>RPGBattle._create(5));
+    await page.waitForFunction(()=>!!window.__cb,{timeout:4000});
+    ok('host založil místnost (polling běží)', true);
+
+    const now=new Date().toISOString();
+    const P=(score,cc,lq)=>({user_id:'u-me',display_name:'Me',score:score,correct_count:cc,last_qi:lq});
+    const O=(score,cc,lq)=>({user_id:'u-op',display_name:'Soupeř',score:score,correct_count:cc,last_qi:lq});
+    const feed=(st)=>page.evaluate((s)=>window.__cb(s),st);
+
+    // lobby
+    await feed({battle:{status:'lobby',code:'WXYZ',q_seed:7,q_count:5,q_index:-1},
+      players:[{user_id:'u-me',display_name:'Me'},{user_id:'u-op',display_name:'Soupeř'}],me:'u-me'});
+    await page.waitForFunction(()=>/Čekárna/.test(document.body.textContent),{timeout:3000});
+    ok('lobby ukazuje kód a 2 hráče', await page.evaluate(()=>/WXYZ/.test(document.body.textContent)));
+
+    // start → otázka 0 (odpočet se přeskočí kvůli reduced-motion)
+    await feed({battle:{status:'active',q_seed:7,q_count:5,q_index:0,q_started_at:now},
+      players:[P(0,0,-1),O(0,0,-1)],me:'u-me'});
+    await page.waitForFunction(()=>!!document.getElementById('rpgb-choices'),{timeout:3000});
+    ok('otázka 0 vykreslena', await page.evaluate(()=>/OTÁZKA 1 \/ 5/.test(document.body.textContent)));
+
+    // Kahoot dlaždice: 4 barvy + tvary
+    const tiles = await page.evaluate(()=>{
+      const cs=[...document.querySelectorAll('.rpgb-ch')];
+      return { n:cs.length, klass:cs.map(c=>['k0','k1','k2','k3'].find(k=>c.classList.contains(k))||''),
+               shapes:cs.map(c=>{const s=c.querySelector('.rpgb-sh');return s?s.textContent:'';}) };
+    });
+    ok('4 dlaždice se 4 barvami k0–k3', tiles.n===4 && tiles.klass.join(',')==='k0,k1,k2,k3', JSON.stringify(tiles.klass));
+    ok('dlaždice mají tvary ▲◆●■', tiles.shapes.join('')==='▲◆●■', tiles.shapes.join(''));
+
+    // odpovím správně (tile 0) → zápis odpovědi + žebříček
+    await page.click('#rpgb-c0');
+    await page.waitForFunction(()=>/Správně/.test(document.body.textContent),{timeout:2000});
+    ok('správná odpověď → zelená zpětná vazba', await page.evaluate(()=>/Správně/.test(document.getElementById('rpgb-fb').textContent)));
+    ok('správná dlaždice označena .ok', await page.evaluate(()=>document.getElementById('rpgb-c0').classList.contains('ok')));
+
+    // poll s aktualizovaným skóre → host přehled + průběžný žebříček
+    await feed({battle:{status:'active',q_seed:7,q_count:5,q_index:0,q_started_at:now},
+      players:[P(1200,1,0),O(0,0,0)],me:'u-me'});
+    await page.waitForFunction(()=>/PRŮBĚŽNÉ POŘADÍ/.test(document.body.textContent),{timeout:2000});
+    ok('mezikolo: průběžný žebříček s 🥇', await page.evaluate(()=>/🥇/.test(document.getElementById('rpgb-stand').textContent)));
+    const ansTxt = await page.evaluate(()=>document.getElementById('rpgb-ans').textContent);
+    ok('host přehled: ✓1 ✗1 (jeden správně, jeden špatně)', /✓1/.test(ansTxt)&&/✗1/.test(ansTxt), ansTxt);
+
+    // konec souboje → výsledky + zápis výsledku
+    await feed({battle:{status:'finished',q_seed:7,q_count:5,q_index:5},
+      players:[P(1200,1,0),O(0,0,0)],me:'u-me'});
+    await page.waitForFunction(()=>/Konec souboje/.test(document.body.textContent),{timeout:3000});
+    ok('výsledková listina: 🥇 vítěz', await page.evaluate(()=>/🥇/.test(document.body.textContent)));
+    ok('recordBattleResult zavolán jednou', await page.evaluate(()=>window.__rec)===1);
+
+    // re-render výsledků nezapíše podruhé (idempotence na klientu)
+    await feed({battle:{status:'finished',q_seed:7,q_count:5,q_index:5},
+      players:[P(1200,1,0)],me:'u-me'});
+    await page.waitForTimeout(150);
+    ok('opakovaný „finished" nezapíše výsledek dvakrát', await page.evaluate(()=>window.__rec)===1);
+
+    ok('žádné JS chyby', errors.length===0, errors.join(' | '));
+  } finally {
+    await browser.close(); srv.close();
+  }
+  console.log(`\n  VÝSLEDEK: ${pass} ✅ / ${fail} ❌\n`);
+  process.exit(fail?1:0);
+}
+run().catch(e=>{console.error(e);process.exit(1);});


### PR DESCRIPTION
## Co je nového v živém souboji (RPG matematika)

Dvě části — trvalé statistiky pro učitele a šťavnatější UI souboje.

### 1) Trvalá historie soubojů + statistiky v učitelské konzoli (Fáze 13)
Dosud se `battle_players` mazalo s místností (cleanup po 12 h) → učitel neviděl, kolik kdo odehrál ani úspěšnost. Nově:
- **SQL** `rpg-cloud-setup-phase13.sql`: tabulka `battle_results` (bez FK na `battles` → přežije úklid), RPC `record_battle_result` (server si correct/wrong/score/rank **dopočítá** z `battle_players` → nelze podvrhnout, idempotentní), `battle_stats_all` (učitel) + `battle_stats_me` (žák). SECURITY DEFINER, `anon` revoked dle Fáze 9.
- **`rpg-cloud.js`**: `recordBattleResult` / `battleStatsAll` / `battleStatsMe`.
- **`rpg-battle-ui.js`**: zápis výsledku na výsledkové obrazovce (jednou).
- **`rpg-ucitel.html`**: nová záložka **⚔️ SOUBOJE** — per žák počet odehraných, správně/špatně, úspěšnost %, výhry 🥇 a ⌀ umístění; filtr ročníku + řazení sloupců.

### 2) Vylepšené UI živého souboje
- **Kahoot dlaždice** — 4 barvy (k0–k3) + tvary ▲◆●■ na odpovědích.
- **Mezikolo: průběžný žebříček** — top 5 + „já", animovaný posun pořadí, šipky ▲▼.
- **Host přehled odpovědí** — živě ✓správně / ✗špatně / odpovědělo (delta `correct_count` proti snímku ze začátku otázky).
- **3-2-1 odpočet** před první otázkou (skip při reduced-motion).
- **Konfety** pro umístění na bedně (1.–3.), respektují reduced-motion.

## Nasazení
Po Fázích 2 + 7 spustit `rpg-cloud-setup-phase13.sql` (idempotentní). Bez nasazení SQL se konzole jen ukáže „žádné dohrané souboje" a zápis výsledku tiše selže (graceful).

## Test plan
- [x] `tests/rpg-battle-stats-console.test.cjs` — 12/0 (záložka SOUBOJE, join na jméno, XSS, řazení, filtr)
- [x] `tests/rpg-battle-ui.test.cjs` — 13/0 (dlaždice, žebříček, host přehled, výsledky)
- [x] `tests/rpg-battle-questions.test.cjs` — 15/0
- [x] `tests/rpg-battle-minigame.test.cjs` — 24/0
- [x] `tests/rpg-tower-console.test.cjs` — 12/0 (záložky nerozbité)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_