### PR TITLE
feat: živý souboj — týmový režim, rychlá odveta, žebříček nejaktivnějších

### DIFF
--- a/projects/rpg-battle-ui.js
+++ b/projects/rpg-battle-ui.js
@@ -205,9 +205,16 @@
     shell(inner);
   }
 
-  // ════════════ HOST: výběr počtu otázek ════════════
+  // ════════════ HOST: režim + výběr počtu otázek ════════════
+  var HTEAM = false;                 // zvolený režim hosta: false = sólo, true = týmy
+  function setMode(team) { HTEAM = !!team; hostUI(); }
   function hostUI() {
     shell('<div class="rpgb-h">🎮 Nový souboj</div>' +
+      '<div class="rpgb-sub">Režim klání:</div>' +
+      '<div style="display:flex;gap:8px;margin:6px 0 14px">' +
+      '<button class="rpgb-btn sm' + (HTEAM ? '' : ' go') + '" style="flex:1;margin:0" onclick="RPGBattle._mode(0)">🙋 Každý sám</button>' +
+      '<button class="rpgb-btn sm' + (HTEAM ? ' go' : '') + '" style="flex:1;margin:0" onclick="RPGBattle._mode(1)">🛡️ Týmy (modří vs. červení)</button>' +
+      '</div>' +
       '<div class="rpgb-sub">Kolik otázek? Všichni dostanou stejné.</div>' +
       '<div style="text-align:center;margin:10px 0">' +
       [5, 10, 15, 20].map(function (n) {
@@ -219,7 +226,7 @@
   function createRoom(count) {
     var c = cloud(); if (!c) return;
     shell('<div class="rpgb-sub">Zakládám místnost…</div>');
-    c.createBattle(GAME, count, NAME).then(function (b) {
+    c.createBattle(GAME, count, NAME, HTEAM).then(function (b) {
       if (!b || !b.id) {
         var errMsg = (b && b.error) ? esc(b.error) : 'Zkus to znovu nebo obnov stránku.';
         shell('<div class="rpgb-h">❌ Chyba</div>' +
@@ -227,7 +234,7 @@
           '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle._menu()">← zpět</button>');
         return;
       }
-      B = { id: b.id, code: b.code, role: 'host', questions: null, lastQi: -2, picked: -1, locked: false };
+      B = { id: b.id, code: b.code, role: 'host', questions: null, lastQi: -2, picked: -1, locked: false, teamMode: !!b.team_mode };
       startPoll();
     }).catch(function (err) {
       shell('<div class="rpgb-h">❌ Chyba</div>' +
@@ -273,6 +280,12 @@
     if (!B || !st || !st.battle) return;
     B.state = st;
     var bt = st.battle;
+    if (typeof bt.team_mode !== 'undefined') B.teamMode = !!bt.team_mode;
+    // odveta: místnost se vrátila do lobby → vyrob novou sadu otázek a vynuluj klientské příznaky kola
+    if (bt.status === 'lobby' && B.lastQi !== -2) {
+      B.questions = null; B.lastQi = -2; B.didCountdown = false;
+      B.recorded = false; B.celebrated = false; B.resultSent = false; B.rankPrev = null; B.lastLobbyKey = null;
+    }
     if (!B.questions && bt.q_seed != null) B.questions = BANK.build(Number(bt.q_seed), bt.q_count);
     if (bt.status === 'lobby') renderLobby(st);
     else if (bt.status === 'finished') renderResults(st);
@@ -308,13 +321,29 @@
       return;
     }
     B.lastLobbyKey = pKey;
+    var plyHtml;
+    if (B.teamMode) {
+      // dvě kolonky: modří (0) vs. červení (1)
+      var t0 = players.filter(function (p) { return p.team === 0; });
+      var t1 = players.filter(function (p) { return p.team === 1; });
+      var col = function (arr, color, name) {
+        return '<div style="flex:1;min-width:0"><div style="font-weight:700;font-size:13px;color:' + color + ';margin-bottom:4px">' + name + ' (' + arr.length + ')</div>' +
+          arr.map(function (p) {
+            return '<div class="rpgb-ply' + (p.user_id === st.me ? ' me' : '') + '" style="border-left:3px solid ' + color + '">' + esc(p.display_name) + (p.user_id === st.me ? ' (ty)' : '') + '</div>';
+          }).join('') + '</div>';
+      };
+      plyHtml = '<div class="rpgb-row"><span>HRÁČI</span><span id="rpgb-plycount">' + players.length + '</span></div>' +
+        '<div style="display:flex;gap:10px">' + col(t0, '#3b82f6', '🔵 Modří') + col(t1, '#e8475f', '🔴 Červení') + '</div>';
+    } else {
+      plyHtml = '<div class="rpgb-row"><span>HRÁČI</span><span id="rpgb-plycount">' + players.length + '</span></div>' +
+        players.map(function (p) {
+          return '<div class="rpgb-ply' + (p.user_id === st.me ? ' me' : '') + '">👤 ' + esc(p.display_name) + (p.user_id === st.me ? ' (ty)' : '') + '</div>';
+        }).join('');
+    }
     var inner = '<div class="rpgb-h">⏳ Čekárna</div>' +
-      '<div class="rpgb-sub">' + (B.role === 'host' ? 'Nadiktuj kód spolužákům. Až se sejdou, spusť.' : 'Čekej, až host spustí souboj.') + '</div>' +
-      '<div class="rpgb-code">' + esc(B.code) + '</div>' +
-      '<div class="rpgb-row"><span>HRÁČI</span><span id="rpgb-plycount">' + players.length + '</span></div>' +
-      players.map(function (p) {
-        return '<div class="rpgb-ply' + (p.user_id === st.me ? ' me' : '') + '">👤 ' + esc(p.display_name) + (p.user_id === st.me ? ' (ty)' : '') + '</div>';
-      }).join('');
+      '<div class="rpgb-sub">' + (B.role === 'host' ? 'Nadiktuj kód spolužákům. Až se sejdou, spusť.' : 'Čekej, až host spustí souboj.') +
+      (B.teamMode ? ' <b style="color:var(--gold,#19e6e6)">Týmový režim</b> — nováčci se přidají do menšího týmu.' : '') + '</div>' +
+      '<div class="rpgb-code">' + esc(B.code) + '</div>' + plyHtml;
     if (B.role === 'host') {
       inner += '<button id="rpgb-startbtn" class="rpgb-btn go" style="margin-top:16px"' + (players.length < 1 ? ' disabled' : '') +
         ' onclick="RPGBattle._start()">▶️ Spustit souboj</button>';
@@ -378,6 +407,18 @@
     if (B.locked) renderStandings(st);
   }
 
+  // týmové skóre (jen v týmovém režimu) — modří vs. červení s poměrovým pruhem
+  function teamScoreBar(st) {
+    if (!B.teamMode || !st.teams) return '';
+    var s0 = Number(st.teams['0'] || 0), s1 = Number(st.teams['1'] || 0), sum = s0 + s1;
+    var p0 = sum ? Math.round(100 * s0 / sum) : 50;
+    return '<div style="margin:2px 0 10px">' +
+      '<div style="display:flex;justify-content:space-between;font-size:13px;font-weight:700;margin-bottom:3px">' +
+      '<span style="color:#3b82f6">🔵 ' + s0 + '</span><span style="color:#e8475f">' + s1 + ' 🔴</span></div>' +
+      '<div style="height:10px;border-radius:5px;overflow:hidden;display:flex;background:#e8475f">' +
+      '<i style="display:block;height:100%;width:' + p0 + '%;background:#3b82f6"></i></div></div>';
+  }
+
   // průběžný žebříček (top 5 + já), animovaný posun pořadí přes CSS transition
   function renderStandings(st) {
     var el = document.getElementById('rpgb-stand'); if (!el) return;
@@ -386,7 +427,7 @@
     var show = ranked.slice(0, 5);
     if (meIdx >= 5) show.push(ranked[meIdx]);   // přilep „mě", když jsem mimo top 5
     var medal = function (i) { return i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : (i + 1) + '.'; };
-    el.innerHTML = '<div class="rpgb-row" style="margin-bottom:2px"><span>PRŮBĚŽNÉ POŘADÍ</span><span></span></div>' +
+    el.innerHTML = teamScoreBar(st) + '<div class="rpgb-row" style="margin-bottom:2px"><span>PRŮBĚŽNÉ POŘADÍ</span><span></span></div>' +
       show.map(function (p) {
         var i = ranked.indexOf(p);
         var up = B.rankPrev && B.rankPrev[p.user_id] != null && B.rankPrev[p.user_id] > i;
@@ -448,7 +489,8 @@
 
   // ════════════ VÝSLEDKY ════════════
   function renderResults(st) {
-    stopPoll();
+    // Pozn.: polling NEzastavujeme — host může spustit odvetu a ostatní
+    // klienti tak sami spadnou zpět do lobby (rematch_battle resetuje místnost).
     // Trvalá historie (Fáze 13): každý hráč zapíše vlastní výsledek (jednou).
     var c0 = cloud();
     if (c0 && c0.recordBattleResult && B && B.id && !B.recorded) {
@@ -457,23 +499,40 @@
     }
     var players = (st.players || []).slice().sort(function (a, b) { return b.score - a.score; });
     var medal = function (i) { return i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : (i + 1) + '.'; };
+    // týmový vítěz (banner nahoře)
+    var teamBanner = '';
+    if (B.teamMode && st.teams) {
+      var s0 = Number(st.teams['0'] || 0), s1 = Number(st.teams['1'] || 0);
+      var win = s0 === s1 ? 'remíza' : (s0 > s1 ? '🔵 Vyhráli modří!' : '🔴 Vyhráli červení!');
+      teamBanner = '<div style="text-align:center;font-weight:700;font-size:17px;margin:4px 0 8px;color:' +
+        (s0 === s1 ? 'var(--gold,#19e6e6)' : (s0 > s1 ? '#3b82f6' : '#e8475f')) + '">' + win +
+        ' <span style="color:var(--muted,#8895b5);font-size:13px">(' + s0 + ' : ' + s1 + ')</span></div>';
+    }
     var inner = '<div class="rpgb-h">🏁 Konec souboje</div>' +
-      '<div class="rpgb-sub">Výsledková listina</div>' +
+      '<div class="rpgb-sub">Výsledková listina</div>' + teamBanner +
       players.map(function (p, i) {
-        return '<div class="rpgb-ply' + (p.user_id === st.me ? ' me' : '') + '">' +
+        var tc = p.team === 0 ? '#3b82f6' : p.team === 1 ? '#e8475f' : '';
+        return '<div class="rpgb-ply' + (p.user_id === st.me ? ' me' : '') + '"' + (tc ? ' style="border-left:3px solid ' + tc + '"' : '') + '>' +
           '<span style="min-width:30px">' + medal(i) + '</span>' +
           '<span style="flex:1;font-weight:700">' + esc(p.display_name) + (p.user_id === st.me ? ' (ty)' : '') + '</span>' +
           '<span style="color:var(--muted,#8895b5);font-size:12px">' + (p.correct_count || 0) + '✓</span>' +
           '<span style="color:var(--gold,#19e6e6);min-width:64px;text-align:right">' + (p.score || 0) + '</span></div>';
-      }).join('') +
-      '<button class="rpgb-btn go" style="margin-top:16px" onclick="RPGBattle._menu()">⚔️ Nový souboj</button>' +
-      '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle.close()">Zavřít</button>';
+      }).join('');
+    if (B.role === 'host') {
+      inner += '<button class="rpgb-btn go" style="margin-top:16px" onclick="RPGBattle._rematch()">🔁 Odveta (stejní hráči)</button>' +
+        '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle._menu()">⚔️ Nový souboj</button>';
+    } else {
+      inner += '<div class="rpgb-sub" style="margin-top:14px">Host může spustit odvetu — počkej, nebo se vrať do menu.</div>' +
+        '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle._menu()">⚔️ Nový souboj</button>';
+    }
+    inner += '<button class="rpgb-btn sm" style="display:block;width:100%" onclick="RPGBattle.close()">Zavřít</button>';
     shell(inner);
-    // konfety, když jsem skončil na bedně (1.–3.)
+    // konfety, když jsem skončil na bedně (1.–3.) — jen jednou
     var myRank = players.findIndex(function (p) { return p.user_id === st.me; });
-    if (myRank >= 0 && myRank < 3) confetti();
-    // Odměny: zavolej hru zpět s výsledky (XP/kredity/odznaky řeší hra, ne UI)
-    if (B && typeof onResult === 'function') {
+    if (!B.celebrated && myRank >= 0 && myRank < 3) { B.celebrated = true; confetti(); }
+    // Odměny: zavolej hru zpět s výsledky (jednou; XP/kredity/odznaky řeší hra)
+    if (B && !B.resultSent && typeof onResult === 'function') {
+      B.resultSent = true;
       var me = st.me;
       var myRow = (st.players || []).find(function (p) { return p.user_id === me; });
       var rank = players.findIndex(function (p) { return p.user_id === me; }) + 1;
@@ -510,6 +569,17 @@
     c.setBattleStatus(id, 'finished').then(function () { activeUI(); });
   }
 
+  // ════════════ ODVETA (host) ════════════
+  function rematch() {
+    var c = cloud(); if (!c || !B || !c.rematchBattle) return;
+    // reset klientského stavu — poll pak ukáže lobby (i ostatním hráčům)
+    B.recorded = false; B.didCountdown = false; B.lastQi = -2;
+    B.celebrated = false; B.resultSent = false; B.rankPrev = null;
+    B.lastLobbyKey = null; B.questions = null;
+    if (!B.stop) startPoll();       // pojistka, kdyby polling neběžel
+    c.rematchBattle(B.id);
+  }
+
   function leave() {
     var c = cloud();
     if (B && B.role === 'host' && c) c.setBattleStatus(B.id, 'finished');
@@ -525,9 +595,9 @@
 
   window.RPGBattle = {
     open: open, close: close,
-    _menu: renderMenu, _host: hostUI, _create: createRoom,
+    _menu: renderMenu, _host: hostUI, _mode: setMode, _create: createRoom,
     _joinUI: joinUI, _join: joinRoom, _start: startBattle,
     _pick: pick, _next: nextQuestion, _leave: leave,
-    _active: activeUI, _kill: kill
+    _active: activeUI, _kill: kill, _rematch: rematch
   };
 })();

--- a/projects/rpg-cloud-setup-phase14.sql
+++ b/projects/rpg-cloud-setup-phase14.sql
@@ -1,0 +1,124 @@
+-- ═══════════════════════════════════════════════════════════════════
+-- RPG Matematika — Fáze 14: TÝMOVÝ REŽIM + RYCHLÁ ODVETA živého souboje
+-- Spustit po Fázi 7 (živý souboj). Idempotentní.
+--
+-- Přidává:
+--   • týmový režim (2 týmy: 0 = modří, 1 = červení) — hráči se při
+--     připojení vyvažují do menšího týmu; battle_state vrací tým u hráče
+--     i součty týmů,
+--   • rychlou odvetu — reset STEJNÉ místnosti zpět do lobby s novou sadou
+--     otázek a vynulovaným skóre (hráči zůstávají i s týmy → klienti, co
+--     stále pollují, sami spadnou zpět do čekárny, není třeba nový kód).
+--
+-- Bezpečnost: stejný model jako Fáze 7 — RLS deny-all, vše přes SECURITY
+-- DEFINER funkce, řízení jen host/staff (_battle_can_control).
+-- ═══════════════════════════════════════════════════════════════════
+
+-- ── Schéma ───────────────────────────────────────────────────────────
+alter table battles        add column if not exists team_mode boolean not null default false;
+alter table battle_players add column if not exists team smallint;   -- null = FFA, 0/1 = tým
+
+-- ── Vytvoření místnosti s volbou týmového režimu ─────────────────────
+--    (samostatná funkce, aby původní create_battle zůstal beze změny)
+create or replace function public.create_battle_tm(
+  p_game text, p_qcount int, p_host_name text, p_team_mode boolean)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles;
+begin
+  if auth.uid() is null then raise exception 'not authenticated'; end if;
+  insert into battles (code, host_id, host_name, game, q_count, q_seed, team_mode)
+  values (_battle_gen_code(), auth.uid(), coalesce(nullif(p_host_name, ''), 'Host'),
+          coalesce(nullif(p_game, ''), 'RPG_MAT_9'),
+          greatest(3, least(40, coalesce(p_qcount, 10))),
+          (floor(random() * 2000000000))::bigint,
+          coalesce(p_team_mode, false))
+  returning * into b;
+  insert into battle_players (battle_id, user_id, display_name, team)
+  values (b.id, auth.uid(), coalesce(nullif(p_host_name, ''), 'Host'),
+          case when coalesce(p_team_mode, false) then 0 else null end);
+  return b;
+end; $$;
+
+-- ── Připojení podle kódu (nahrazuje Fázi 7 — přidává vyvážení týmů) ───
+create or replace function public.join_battle(p_code text, p_name text)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles; t smallint; c0 int; c1 int;
+begin
+  if auth.uid() is null then raise exception 'not authenticated'; end if;
+  select * into b from battles
+   where upper(code) = upper(trim(p_code)) and status <> 'finished'
+   order by created_at desc limit 1;
+  if b.id is null then raise exception 'battle not found'; end if;
+  -- vyber tým: do menšího (remíza → modří)
+  if b.team_mode then
+    select count(*) filter (where team = 0), count(*) filter (where team = 1)
+      into c0, c1 from battle_players where battle_id = b.id;
+    t := case when coalesce(c1,0) < coalesce(c0,0) then 1 else 0 end;
+  else
+    t := null;
+  end if;
+  insert into battle_players (battle_id, user_id, display_name, team)
+  values (b.id, auth.uid(), coalesce(nullif(p_name, ''), 'Hráč'), t)
+  on conflict (battle_id, user_id)
+    do update set display_name = excluded.display_name, last_seen = now();
+  return b;
+end; $$;
+
+-- ── Snapshot stavu (nahrazuje Fázi 7 — přidává team + součty týmů) ────
+create or replace function public.battle_state(p_battle uuid)
+returns json language plpgsql security definer set search_path = public as $$
+declare b battles; allowed boolean;
+begin
+  select * into b from battles where id = p_battle;
+  if b.id is null then return null; end if;
+  allowed := b.host_id = auth.uid()
+          or (select my_role()) in ('teacher', 'superadmin')
+          or exists (select 1 from battle_players where battle_id = p_battle and user_id = auth.uid());
+  if not allowed then raise exception 'forbidden'; end if;
+  update battle_players set last_seen = now()
+   where battle_id = p_battle and user_id = auth.uid();
+  return json_build_object(
+    'battle',  row_to_json(b),
+    'players', coalesce((
+       select json_agg(row_to_json(p))
+       from (select user_id, display_name, score, correct_count, last_qi, last_seen, team
+             from battle_players where battle_id = p_battle
+             order by score desc, display_name) p), '[]'::json),
+    'teams', case when b.team_mode then (
+       select json_build_object(
+         '0', coalesce(sum(score) filter (where team = 0), 0),
+         '1', coalesce(sum(score) filter (where team = 1), 0))
+       from battle_players where battle_id = p_battle) else null end,
+    'me', auth.uid()
+  );
+end; $$;
+
+-- ── Rychlá odveta: reset STEJNÉ místnosti do lobby (host/staff) ───────
+create or replace function public.rematch_battle(p_battle uuid)
+returns battles language plpgsql security definer set search_path = public as $$
+declare b battles;
+begin
+  if not _battle_can_control(p_battle) then raise exception 'forbidden'; end if;
+  update battles
+     set status = 'lobby', q_index = -1, q_started_at = null,
+         q_seed = (floor(random() * 2000000000))::bigint, updated_at = now()
+   where id = p_battle returning * into b;
+  -- vynuluj skóre, ponech hráče i jejich týmy
+  update battle_players
+     set score = 0, correct_count = 0, last_qi = -1, last_seen = now()
+   where battle_id = p_battle;
+  return b;
+end; $$;
+
+-- ── Práva (vzor Fáze 9: anon nikam) ─────────────────────────────────
+revoke execute on function public.create_battle_tm(text, int, text, boolean) from public, anon;
+revoke execute on function public.rematch_battle(uuid)                       from public, anon;
+grant   execute on function public.create_battle_tm(text, int, text, boolean) to authenticated;
+grant   execute on function public.rematch_battle(uuid)                       to authenticated;
+-- join_battle/battle_state už mají grant z Fáze 7/9 (CREATE OR REPLACE práva zachová)
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Hotovo. Klient: create_battle_tm při zapnutém týmovém režimu, jinak
+-- původní create_battle. battle_state nově nese team + teams součty.
+-- rematch_battle drží stejné battle_id → poll hráčů sám spadne do lobby.
+-- ═══════════════════════════════════════════════════════════════════

--- a/projects/rpg-cloud.js
+++ b/projects/rpg-cloud.js
@@ -535,14 +535,26 @@ window.RPGCloud = (function () {
   // ════════════ Fáze 7 — živý souboj (Kahoot-style) ════════════
   // Tenké wrappery nad SECURITY DEFINER RPC funkcemi (viz phase7.sql).
   // Vše graceful: bez clienta/přihlášení vrací null/[]/false.
-  async function createBattle(game, qcount, hostName) {
+  async function createBattle(game, qcount, hostName, teamMode) {
     if (!client || !user) return { error: 'Nejsi přihlášen.' };
     try {
-      const { data, error } = await client.rpc('create_battle',
-        { p_game: game, p_qcount: qcount, p_host_name: hostName });
+      // Fáze 14: týmový režim přes create_battle_tm; jinak původní create_battle.
+      const fn = teamMode ? 'create_battle_tm' : 'create_battle';
+      const args = teamMode
+        ? { p_game: game, p_qcount: qcount, p_host_name: hostName, p_team_mode: true }
+        : { p_game: game, p_qcount: qcount, p_host_name: hostName };
+      const { data, error } = await client.rpc(fn, args);
       if (error) return { error: error.message || String(error) };
       return data;
     } catch (e) { console.warn('[RPGCloud] createBattle:', e); return { error: String(e) }; }
+  }
+  /* Fáze 14: rychlá odveta — reset stejné místnosti zpět do lobby. */
+  async function rematchBattle(battleId) {
+    if (!client || !user) return null;
+    try {
+      const { data, error } = await client.rpc('rematch_battle', { p_battle: battleId });
+      if (error) throw error; return data;
+    } catch (e) { console.warn('[RPGCloud] rematchBattle:', e); return null; }
   }
   async function joinBattle(code, name) {
     if (!client || !user) return { error: 'Nejsi přihlášen.' };
@@ -1078,6 +1090,8 @@ window.RPGCloud = (function () {
            createBattle, joinBattle, battleState, submitBattleAnswer,
            advanceBattle, setBattleStatus, listActiveBattles,
            inviteBattleEmail, myBattleInvites, pollBattle,
+           // Fáze 14 — týmový režim + odveta
+           rematchBattle,
            // Fáze 13 — trvalá historie soubojů
            recordBattleResult, battleStatsAll, battleStatsMe,
            // Fáze 11 — věž legend

--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -1510,7 +1510,18 @@ async function renderBattles(){
  const th=(c,lbl,al)=>'<th style="cursor:pointer;user-select:none;text-align:'+(al||'right')+'" onclick="btSort(\''+c+'\')">'+lbl+ico(c)+'</th>';
  // barva úspěšnosti: zeleně→červeně
  const accCol=p=>'hsl('+Math.round(p*1.2)+',60%,55%)';
- let html='<table class="tbl"><thead><tr>'+
+ // žebříček nejaktivnějších: top 3 podle počtu odehraných (remíza → víc výher)
+ const top=rows.slice().sort((a,b)=>b.played-a.played||b.wins-a.wins).slice(0,3).filter(r=>r.played>0);
+ let html='';
+ if(top.length){
+  const med=['🥇','🥈','🥉'];
+  html+='<div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px">'+top.map((r,i)=>
+   '<div style="flex:1;min-width:150px;background:var(--panel2);border:1px solid '+(i===0?'var(--gold)':'var(--line)')+';border-radius:10px;padding:10px 14px">'+
+   '<div style="font-size:20px">'+med[i]+'</div>'+
+   '<div style="font-weight:700;color:#fff;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">'+esc(r.name)+'</div>'+
+   '<div style="font-size:12px;color:var(--muted)">'+r.played+'× souboj · 🥇 '+r.wins+' · '+r.acc+' %</div></div>').join('')+'</div>';
+ }
+ html+='<table class="tbl"><thead><tr>'+
   th('name','Žák','left')+th('played','Odehráno')+th('correct','Správně')+
   th('wrong','Špatně')+th('acc','Úspěšnost')+th('wins','Výhry')+th('avg','⌀ umístění')+
   '</tr></thead><tbody>';

--- a/tests/rpg-battle-ui.test.cjs
+++ b/tests/rpg-battle-ui.test.cjs
@@ -37,16 +37,18 @@ function harness() {
     window.RPGWallet = { getReducedMotion:()=>true };   // skip odpočtu/konfet pro rychlost
     window.RPG_BATTLE_9 = { build:function(seed,count){
       var a=[]; for(var i=0;i<count;i++) a.push({text:'Otázka '+(i+1)+'?',choices:['Alfa','Beta','Gama','Delta'],correct:0}); return a; } };
+    window.__rematch=0;
     window.RPGCloud = {
       currentUser:()=>({id:'u-me'}),
       isStaff:()=>false,
-      createBattle:(g,c,n)=>Promise.resolve({id:'b1',code:'WXYZ'}),
+      createBattle:(g,c,n,tm)=>Promise.resolve({id:'b1',code:'WXYZ',team_mode:!!tm}),
       joinBattle:(c,n)=>Promise.resolve({id:'b1',code:'WXYZ'}),
       pollBattle:(id,cb,iv)=>{ window.__cb=cb; return ()=>{}; },
       submitBattleAnswer:function(){ window.__lastSubmit=[].slice.call(arguments); },
       advanceBattle:()=>{}, setBattleStatus:()=>{},
       listActiveBattles:()=>Promise.resolve([]),
-      recordBattleResult:(id)=>{ window.__rec++; return Promise.resolve(true); }
+      recordBattleResult:(id)=>{ window.__rec++; return Promise.resolve(true); },
+      rematchBattle:(id)=>{ window.__rematch++; return Promise.resolve({id:'b1',code:'WXYZ'}); }
     };
   </script>
   <script src="${BASE}/projects/rpg-battle-ui.js"></script>
@@ -123,6 +125,33 @@ async function run() {
       players:[P(1200,1,0)],me:'u-me'});
     await page.waitForTimeout(150);
     ok('opakovaný „finished" nezapíše výsledek dvakrát', await page.evaluate(()=>window.__rec)===1);
+
+    // ── ODVETA (host) ──
+    ok('výsledky mají tlačítko Odveta', await page.evaluate(()=>/Odveta/.test(document.body.textContent)));
+    await page.evaluate(()=>RPGBattle._rematch());
+    await page.waitForFunction(()=>window.__rematch===1,{timeout:2000});
+    ok('Odveta volá rematchBattle', true);
+    // poll po odvetě vrátí lobby → klient sám spadne do čekárny
+    await feed({battle:{status:'lobby',code:'WXYZ',q_seed:99,q_count:5,q_index:-1},
+      players:[{user_id:'u-me',display_name:'Me'},{user_id:'u-op',display_name:'Soupeř'}],me:'u-me'});
+    await page.waitForFunction(()=>/Čekárna/.test(document.body.textContent),{timeout:3000});
+    ok('po odvetě zpět v čekárně (stejná místnost)', true);
+
+    // ── TÝMOVÝ REŽIM ──
+    await page.evaluate(()=>{ RPGBattle.open({game:'RPG_MAT_9', name:'Me', autoAction:'host'}); RPGBattle._mode(1); });
+    await page.evaluate(()=>RPGBattle._create(5));
+    await page.waitForFunction(()=>!!window.__cb,{timeout:3000});
+    const T=(id,nm,score,team)=>({user_id:id,display_name:nm,score:score,correct_count:0,last_qi:-1,team:team});
+    await feed({battle:{status:'lobby',code:'WXYZ',q_seed:7,q_count:5,q_index:-1,team_mode:true},
+      players:[T('u-me','Me',0,0),T('u-op','Soupeř',0,1)],teams:{'0':0,'1':0},me:'u-me'});
+    await page.waitForFunction(()=>/Modří/.test(document.body.textContent),{timeout:3000});
+    ok('týmové lobby: Modří vs. Červení', await page.evaluate(()=>/Modří/.test(document.body.textContent)&&/Červení/.test(document.body.textContent)));
+
+    // konec týmového souboje → banner vítězného týmu
+    await feed({battle:{status:'finished',q_seed:7,q_count:5,q_index:5,team_mode:true},
+      players:[T('u-me','Me',1500,0),T('u-op','Soupeř',300,1)],teams:{'0':1500,'1':300},me:'u-me'});
+    await page.waitForFunction(()=>/Vyhráli modří/.test(document.body.textContent),{timeout:3000});
+    ok('týmové výsledky: banner „Vyhráli modří!"', await page.evaluate(()=>/Vyhráli modří/.test(document.body.textContent)&&/1500 : 300/.test(document.body.textContent)));
 
     ok('žádné JS chyby', errors.length===0, errors.join(' | '));
   } finally {


### PR DESCRIPTION
## Dotažení živého souboje (Fáze 14)

### 🛡️ Týmový režim (2 týmy)
- Host při zakládání volí **🙋 Každý sám** / **🛡️ Týmy**.
- Hráči se při připojení **vyvažují do menšího týmu** (server, `join_battle`).
- Lobby zobrazí dvě kolonky 🔵 Modří vs. 🔴 Červení; průběžný žebříček i výsledky mají **poměrový pruh** týmů a **banner vítězného týmu**.
- `battle_state` nově nese `team` u hráče + součty `teams`.

### 🔁 Rychlá odveta
- Na výsledkové obrazovce má host tlačítko **Odveta** → `rematch_battle` resetuje **stejnou místnost** zpět do lobby (nový seed, skóre 0, hráči i týmy zůstávají).
- Klienti dál pollují stejné `battle_id`, takže **sami spadnou do čekárny** — není třeba diktovat nový kód.

### 🏆 Žebříček nejaktivnějších (konzole)
- Záložka **⚔️ SOUBOJE** má nahoře **podium top 3** podle počtu odehraných soubojů (+ výhry, úspěšnost). Staví na datech Fáze 13.

## Soubory
- `rpg-cloud-setup-phase14.sql` — `team_mode`/`team` sloupce, `create_battle_tm`, `join_battle`+`battle_state` replace (týmy), `rematch_battle`. SECURITY DEFINER, `anon` revoked dle Fáze 9.
- `rpg-cloud.js` — `createBattle(…, teamMode)` + `rematchBattle`.
- `rpg-battle-ui.js` — režim v hostUI, týmové lobby/žebříček/výsledky, odveta, polling drží i na výsledcích.
- `rpg-ucitel.html` — podium v záložce SOUBOJE.

## Nasazení
Po Fázi 7 spustit `rpg-cloud-setup-phase14.sql` (idempotentní). Bez nasazení: týmový režim/odveta se prostě nenabídnou funkčně (graceful — `create_battle_tm`/`rematch_battle` chybí → tichý fallback).

## Test plan
- [x] `tests/rpg-battle-ui.test.cjs` — 18/0 (dlaždice, žebříček, host přehled, **odveta**, **týmy**)
- [x] `tests/rpg-battle-stats-console.test.cjs` — 12/0 (podium nerozbil tab)
- [x] `tests/rpg-battle-questions.test.cjs` — 15/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_