### PR TITLE
fix: kontrola správnosti teorie — oprava 3 českých překlepů

### DIFF
--- a/projects/rpg-learn-8.js
+++ b/projects/rpg-learn-8.js
@@ -325,7 +325,7 @@ window.RPG_LEARN_8 = {
   { h: 'Rovnice se zlomky',
     p: [
       'Zbav se jmenovatelů: vynásob obě strany <b>NSN všech jmenovatelů</b>.',
-      'Příklad: x/3 + 1 = 5/6 → nastob 6: 2x + 6 = 5 → 2x = −1 → x = −1/2',
+      'Příklad: x/3 + 1 = 5/6 → násob 6: 2x + 6 = 5 → 2x = −1 → x = −1/2',
     ] },
   { h: 'Speciální případy',
     p: [
@@ -349,7 +349,7 @@ window.RPG_LEARN_8 = {
   { q: 'Vyřeš: 2(x + 3) = 3(x − 1)',
     s: ['2x + 6 = 3x − 3', '6 + 3 = 3x − 2x', 'x = <b>9</b>'] },
   { q: 'Vyřeš: x/2 − x/3 = 1',
-    s: ['NSN(2,3) = 6; nastob 6: 3x − 2x = 6', 'x = <b>6</b>'] },
+    s: ['NSN(2,3) = 6; násob 6: 3x − 2x = 6', 'x = <b>6</b>'] },
   { q: 'Vyřeš: 4(x − 2) = 2(x + 1)',
     s: ['4x − 8 = 2x + 2', '4x − 2x = 2 + 8 → 2x = 10', 'x = <b>5</b>'] },
  ],
@@ -811,7 +811,7 @@ window.RPG_LEARN_8 = {
  examples: [
   { q: 'Koberec stojí 1 440 Kč po slevě 10 %. Původní cena?',
     s: ['1 440 Kč = 90 % původní ceny', 'základ = 1 440 / 0,9 = <b>1 600 Kč</b>'] },
-  { q: 'Zeď je 2,4 m vysoká. Žebřík 3 m je opřen o zeď. Jak daleko stojí od zdě?',
+  { q: 'Zeď je 2,4 m vysoká. Žebřík 3 m je opřen o zeď. Jak daleko stojí od zdi?',
     s: ['b = √(3² − 2,4²) = √(9 − 5,76) = √3,24 = <b>1,8 m</b>'] },
   { q: 'V obchodě je sleva 30 %. Kolik zaplatíš za zboží s původní cenou 250 Kč?',
     s: ['Platíš 70 % původní ceny: 250 · 0,70', '= <b>175 Kč</b>'] },

--- a/projects/rpg-learn-9.js
+++ b/projects/rpg-learn-9.js
@@ -279,14 +279,14 @@ window.RPG_LEARN_9 = {
   ],
   examples: [
     {
-      q: 'Zjednodušš: x³ · x⁵',
+      q: 'Zjednoduš: x³ · x⁵',
       s: [
         'Stejný základ x, exponenty sečti.',
         'x³ · x⁵ = x³⁺⁵ = <b>x⁸</b>'
       ]
     },
     {
-      q: 'Zjednodušš: (y²)⁶ ÷ y⁸',
+      q: 'Zjednoduš: (y²)⁶ ÷ y⁸',
       s: [
         '(y²)⁶ = y¹²',
         'y¹² ÷ y⁸ = y¹²⁻⁸ = <b>y⁴</b>'


### PR DESCRIPTION
## Kompletní kontrola správnosti teorie (rpg-learn-6/7/8/9)

Prošel jsem **všech 84 misí** (4 ročníky × 21) — intro, vzorce a každý řešený příklad včetně mezikroků.

### ✅ Matematika je v pořádku
Ověřil jsem ručně každý výpočet napříč všemi tématy:
- **6. ročník** — pořadí operací, obvody/obsahy, dělitelnost (84 = 2²·3·7), NSD/NSN (6·36 = 216 = 12·18), úhly, objemy/povrchy, převody jednotek
- **7. ročník** — zlomky (3/4 + 2/6 = 13/12), poměry, přímá/nepřímá úměrnost, procenta (1000 → 1100 → 990), shodnost
- **8. ročník** — Pythagoras (3-4-5, 5-12-13, 8-15-17), mocniny/odmocniny, rovnice, vzorce (a±b)², kruh/válec, Thales
- **9. ročník** — lomené výrazy a podmínky, soustavy, pohybové/směšovací úlohy, lineární funkce, podobnost (k²), rotační tělesa (koule 36π, přetavení koule→válec r = 6)

Všechny výsledky i mezikroky **sedí**. Zdrojově odpovídá české školní konvenci (zaokrouhlování, značení, π ≈ 3,14, CERMAT styl).

### 🔧 Opraveny 3 překlepy (čistě jazykové, ne matematické)
- `rpg-learn-8.js` — „**nastob** 6" → „**násob** 6" (2×, mise 3-2)
- `rpg-learn-8.js` — „od **zdě**?" → „od **zdi**?" (mise 7-2)
- `rpg-learn-9.js` — „**Zjednodušš**:" → „**Zjednoduš**:" (2×, mise 2-2)

## Test plan
- [x] `tests/rpg-learn.test.cjs` — 56/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_