### PR TITLE
Serverové stropy kreditů/XP + učitelské přidávání kreditů

### DIFF
--- a/projects/rpg-ucitel.html
+++ b/projects/rpg-ucitel.html
@@ -846,8 +846,10 @@ function openDetail(i){
  if(admin){
   admHtml=
    '<h4>Odměny a úpravy (superadmin)</h4>'+
-   '<div class="actrow"><input type="number" id="adj-xp" placeholder="±XP" value="100"><button class="mini gold" onclick="giveXP('+i+')">Přidat XP</button>'+
+   '<div class="actrow"><input type="number" id="adj-xp" placeholder="±XP" value="100"><button class="mini gold" onclick="giveXP('+i+')">⭐ Přidat XP</button>'+
      '<span style="font-size:11px;color:var(--muted)">level se dopočítá z XP</span></div>'+
+   '<div class="actrow"><input type="number" id="adj-cr" placeholder="±kredity" value="50"><button class="mini gold" onclick="giveCredits('+i+')">💰 Přidat kredity</button>'+
+     '<span style="font-size:11px;color:var(--muted)">peněženka žáka (musí mít alespoň 1 přihlášení)</span></div>'+
    '<div class="actrow"><button class="mini red" onclick="delChar('+i+')">🗑 Smazat celou postavu</button></div>';
  }
  document.getElementById('modal').innerHTML=
@@ -916,6 +918,18 @@ async function giveXP(i){
  d.level=Math.floor(d.xp/100)+1;
  const res=await RPGCloud.updateSaveFor(r.user_id,r.game,d);
  if(res.ok){r.data=d;toast((delta>=0?'+':'')+delta+' XP přidáno');renderStats();renderTable();openDetail(i);}
+ else toast('Chyba: '+res.error,1);
+}
+async function giveCredits(i){
+ const r=window.__filtered[i];if(!r)return;
+ const delta=parseInt(document.getElementById('adj-cr').value,10);
+ if(isNaN(delta)){toast('Zadej číslo.',1);return;}
+ const w=await RPGCloud.pullSaveFor(r.user_id,'_wallet');
+ if(!w){toast('Žák nemá peněženku — musí se alespoň jednou přihlásit do hry.',1);return;}
+ const d=Object.assign({},w);
+ d.credits=Math.max(0,(d.credits||0)+delta);
+ const res=await RPGCloud.updateSaveFor(r.user_id,'_wallet',d);
+ if(res.ok){toast((delta>=0?'+':'')+delta+' kreditů přidáno');}
  else toast('Chyba: '+res.error,1);
 }
 async function delChar(i){

--- a/rpg-cloud-setup-security.sql
+++ b/rpg-cloud-setup-security.sql
@@ -1,0 +1,90 @@
+-- ══════════════════════════════════════════════════════════════════════
+-- RPG Matematika — Serverové stropy kreditů a XP (Fáze Security)
+-- Spusť v Supabase SQL editoru JEDNOU po Fázi 1 (saves tabulka musí existovat).
+--
+-- Co to dělá:
+--   • BEFORE UPDATE trigger na tabulce `saves`
+--   • Zastaví skok kreditů > +500 za jeden save (_wallet)
+--   • Zastaví skok XP > +200 za jeden save (RPG_MAT_*)
+--   • Učitelé a superadmini mají bypass (my_role() >= teacher)
+--   • Přímý DB přístup (auth.uid() IS NULL) má bypass automaticky
+--   • INSERT se nekontroluje — první přihlášení žáka je vždy ok
+-- ══════════════════════════════════════════════════════════════════════
+
+-- ── Trigger funkce ──────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION fn_validate_save_delta()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY INVOKER
+SET search_path = public AS $$
+DECLARE
+  v_role  text   := 'student';
+  old_val bigint;
+  new_val bigint;
+  capped  bigint;
+BEGIN
+  -- Přímý DB přístup (no JWT) → bypass
+  IF auth.uid() IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Bypass pro učitele a superadminy
+  BEGIN
+    SELECT COALESCE(role, 'student') INTO v_role
+      FROM public.roles
+      WHERE email = lower(auth.jwt() ->> 'email')
+      LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_role := 'student';
+  END;
+  IF v_role IN ('teacher', 'superadmin') THEN
+    RETURN NEW;
+  END IF;
+
+  -- ── Kredity v peněžence (_wallet) ─────────────────────────────
+  IF NEW.game = '_wallet'
+     AND NEW.data ? 'credits'
+     AND OLD.data ? 'credits'
+  THEN
+    old_val := COALESCE((OLD.data ->> 'credits')::bigint, 0);
+    new_val := COALESCE((NEW.data ->> 'credits')::bigint, 0);
+    IF new_val < 0 THEN
+      NEW.data := jsonb_set(NEW.data, '{credits}', '0');
+    ELSIF new_val - old_val > 500 THEN
+      NEW.data := jsonb_set(NEW.data, '{credits}', to_jsonb(old_val + 500));
+    END IF;
+  END IF;
+
+  -- ── XP v herních savech (RPG_MAT_*) ───────────────────────────
+  IF NEW.game LIKE 'RPG_MAT_%'
+     AND NEW.data ? 'xp'
+     AND OLD.data ? 'xp'
+  THEN
+    old_val := COALESCE((OLD.data ->> 'xp')::bigint, 0);
+    new_val := COALESCE((NEW.data ->> 'xp')::bigint, 0);
+    IF new_val < 0 THEN
+      NEW.data := jsonb_set(NEW.data, '{xp}',    '0');
+      NEW.data := jsonb_set(NEW.data, '{level}', '1');
+    ELSIF new_val - old_val > 200 THEN
+      capped   := old_val + 200;
+      NEW.data := jsonb_set(NEW.data, '{xp}',    to_jsonb(capped));
+      NEW.data := jsonb_set(NEW.data, '{level}', to_jsonb(capped / 100 + 1));
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ── Trigger ─────────────────────────────────────────────────────────
+DROP TRIGGER IF EXISTS trg_validate_save_delta ON public.saves;
+CREATE TRIGGER trg_validate_save_delta
+  BEFORE UPDATE ON public.saves
+  FOR EACH ROW EXECUTE FUNCTION fn_validate_save_delta();
+
+COMMENT ON FUNCTION fn_validate_save_delta IS
+  'Serverové stropy: max +500 kr/save pro _wallet, max +200 XP/save pro RPG_MAT_*. Bypass pro teacher/superadmin a přímý DB přístup.';
+
+-- ── Rychlý test (spusť ručně pro ověření) ──────────────────────────
+-- Zkontroluje, že trigger existuje a funkce je na místě:
+-- SELECT trigger_name, event_manipulation, action_timing
+--   FROM information_schema.triggers
+--   WHERE event_object_table = 'saves' AND trigger_name = 'trg_validate_save_delta';


### PR DESCRIPTION
## Co a proč
Kredity už nejsou čistě kosmetické — v obchodě jsou powerupy (extra srdce, +čas, „druhá šance"), takže ovlivňují obtížnost boje. Žák mohl v konzoli napsat `RPGWallet.earn(9999)` nebo editovat localStorage a získat libovolné kredity/XP. Tato PR zabezpečuje stropy na serveru — přidávat smí reálně jen učitel.

## Změny

- **`rpg-cloud-setup-security.sql`** (nutno spustit v Supabase jednou):
  BEFORE UPDATE trigger `fn_validate_save_delta` na tabulce `saves`
  - max **+500 kreditů / save** pro `_wallet`
  - max **+200 XP / save** pro `RPG_MAT_*` (level dopočítán)
  - blokuje záporné hodnoty (tamper)
  - bypass pro teacher/superadmin (přes `roles`) a přímý DB přístup

- **`projects/rpg-ucitel.html`**: v detailu žáka (superadmin) přidáno pole „💰 Přidat kredity" vedle „⭐ Přidat XP"; nová funkce `giveCredits()` upraví peněženku žáka přes `updateSaveFor('_wallet', …)`.

## Nasazení
Spustit `rpg-cloud-setup-security.sql` v Supabase SQL editoru (stačí jednou, po Fázi 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_