### PR TITLE
fix(test): oprava rpg-ach testu — mini-úkoly způsobovaly falešnou smrt hráče

### DIFF
--- a/tests/rpg-ach.test.cjs
+++ b/tests/rpg-ach.test.cjs
@@ -84,6 +84,8 @@ async function finishMission(page, aid, mid, tc) {
     ok('po startu má hráč denní sérii ≥1', await page.evaluate(() => (S.streak&&S.streak.count)>=1));
 
     // dohraj celou 1. oblast (3 mise) → boot, area1, flawless možné
+    // RPGTaskTypes = null: zakáže mini-úkoly (seřazování/matching), které harness neobsluhuje
+    await page.evaluate(() => { window.RPGTaskTypes = null; });
     const a1 = await page.evaluate(() => AREAS.find(a=>a.id===1).missions.map(m=>({id:m.id,tc:m.tc})));
     for (const m of a1) await finishMission(page, 1, m.id, m.tc);
 


### PR DESCRIPTION
## Problém

`rpg-ach.test.cjs` selhával na `1. oblast splněna → odznak area1` (10/11).

**Příčina:** `miniForIdx()` vkládá s 34% pravděpodobností mini-úkol (seřazování/matching) před každý non-MC task. Test harness tyto mini-úkoly neobsluhuje — `BT.curTask.ans` je prázdný `''` → `submitAnswer()` vyhodnotí odpověď jako špatnou → po 3 špatných odpovědích hráč umírá → `S.done` flagy pro misi 1-2 a 1-3 nejsou nastaveny → `isAreaDone(area1)` vrací false → badge `area1` se neodemkne.

Mise 1-2: 0/6 done, mise 1-3: 4/6 done (potvrzeno debug výstupem).

## Oprava

Jeden řádek v testu — před spuštěním batlí:
```js
await page.evaluate(() => { window.RPGTaskTypes = null; });
```

Zakáže generování mini-úkolů v `miniForIdx()` (podmínka `window.RPGTaskTypes && ...`). Hra samotná je beze změny.

## Výsledek po opravě

```
VÝSLEDEK: 11 ✅  /  0 ❌
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_