### PR TITLE
rpg-learn-9: doplnění příkladů do finální mise 7-3

### DIFF
--- a/projects/rpg-learn-9.js
+++ b/projects/rpg-learn-9.js
@@ -1210,6 +1210,14 @@ window.RPG_LEARN_9 = {
         'Čitatel rozlož: x² − 9 = (x − 3)(x + 3)',
         'Krácení (x+3): výsledek <b>x − 3</b>'
       ]
+    },
+    {
+      q: 'V kleci jsou bažanti a králíci, celkem 12 hlav a 34 nohou. Kolik je králíků?',
+      s: [
+        'Bažant má 2 nohy, králík 4. Soustava: b + k = 12, 2b + 4k = 34.',
+        'Z první rovnice b = 12 − k, dosadíme: 2(12 − k) + 4k = 34 → 24 + 2k = 34 → 2k = 10',
+        'k = <b>5 králíků</b> (a 7 bažantů). Zkouška: 7·2 + 5·4 = 14 + 20 = 34 ✓'
+      ]
     }
   ],
   video: { id: 'FO-xAjpo3b0', title: 'CERMAT 2025 — přijímací zkoušky' }


### PR DESCRIPTION
## Audit výsledek

Prošel jsem všechny banky úloh i teorii napříč ročníky 6–9:

**Banky úloh** (`rpg-tasks-6/7/8/9.js`) — **dokonale vyrovnané**: přesně 10 variantních generátorů na každou z 21 misí, ve všech ročnících. Žádná „malá banka" neexistuje.

**Teorie** (`rpg-learn-6/7/8/9.js`) — vyrovnaná (2–5 sekcí, 2–4 příklady na misi).

## Co tato PR mění (po rebase)

Mezitím se na `main` mise 7-3 už doplnila o procentní chyták a lomený výraz. Po rebase tedy tato PR přidává **jediný unikátní příklad**, který v sadě chyběl:
- **Soustava rovnic** — bažanti a králíci (12 hlav, 34 nohou)

Sekce mise 7-3 zmiňují „soustavy dvou rovnic", ale neměly k tomu řešený příklad — teď ano. Výsledek: 4 příklady (geometrie, procenta, lomený výraz, soustava).

Test `tests/rpg-learn.test.cjs`: 56 ✅ / 0 ❌. Konflikt s `main` vyřešen rebasem.

## Pozn. k videím

6 misí má `video:null` (g6: 1-2, 1-3, 5-2; g7: 1-1, 1-3, 6-1) — dle pravidla v CLAUDE.md jde o mise, kde kanál @matematikajednoduse nemá ekvivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st