### PR TITLE
Živý souboj: e-mailové pozvánky (UI)

### DIFF
--- a/projects/rpg-battle-ui.js
+++ b/projects/rpg-battle-ui.js
@@ -135,7 +135,14 @@
       '#rpgb-conf i{position:absolute;top:-12px;width:9px;height:14px;border-radius:2px;animation:rpgb-fall linear forwards}' +
       '@keyframes rpgb-fall{to{transform:translateY(105vh) rotate(720deg);opacity:.4}}' +
       // ── lobby hráč: jemný nástup ──
-      '.rpgb-ply{animation:rpgb-in .25s ease}@keyframes rpgb-in{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:none}}';
+      '.rpgb-ply{animation:rpgb-in .25s ease}@keyframes rpgb-in{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:none}}' +
+      // ── pozvánky ──
+      '.rpgb-invbox{border:1px dashed var(--gold,#19e6e6);border-radius:10px;padding:10px;margin:0 0 14px;background:rgba(25,230,230,.06)}' +
+      '.rpgb-invh{font-size:12px;color:var(--gold,#19e6e6);text-align:center;margin-bottom:4px;letter-spacing:.5px}' +
+      '.rpgb-btn.invite{width:100%;display:block;margin:6px 0 0;text-align:center}' +
+      '.rpgb-invrow{display:flex;gap:8px;margin-top:10px}' +
+      '.rpgb-in.sm{font-size:13px;letter-spacing:0;text-transform:none;text-align:left;padding:10px;flex:1;width:auto}' +
+      '.rpgb-invmsg{font-size:12px;text-align:center;min-height:16px;margin-top:6px;color:var(--muted,#8895b5)}';
     document.head.appendChild(css);
   }
 
@@ -199,10 +206,38 @@
     var teacher = c && c.isStaff && c.isStaff();
     var inner = '<div class="rpgb-h">⚔️ ŽIVÝ SOUBOJ</div>' +
       '<div class="rpgb-sub">Rychlé matematické klání ve třídě — kdo nasbírá nejvíc bodů?</div>' +
+      '<div id="rpgb-invites"></div>' +
       '<button class="rpgb-btn go" onclick="RPGBattle._host()">🎮 Založit souboj</button>' +
       '<button class="rpgb-btn" onclick="RPGBattle._joinUI()">🔑 Připojit se kódem</button>';
     if (teacher) inner += '<button class="rpgb-btn sm" style="display:block;width:100%;margin-top:14px" onclick="RPGBattle._active()">👁️ Běžící souboje (učitel)</button>';
     shell(inner);
+    loadInvites();
+  }
+
+  // Načte pozvánky přihlášeného žáka a vloží je nad tlačítka (graceful, async).
+  function loadInvites() {
+    var c = cloud(); if (!c || !c.myBattleInvites) return;
+    c.myBattleInvites().then(function (list) {
+      var box = document.getElementById('rpgb-invites'); if (!box) return;
+      var mine = (list || []).filter(function (iv) { return iv.game === GAME && iv.status === 'lobby'; });
+      if (!mine.length) { box.innerHTML = ''; return; }
+      box.innerHTML = '<div class="rpgb-invbox"><div class="rpgb-invh">📨 Máš pozvánku do souboje</div>' +
+        mine.map(function (iv) {
+          return '<button class="rpgb-btn sm invite" onclick="RPGBattle._joinCode(\'' + esc(iv.code) + '\')">' +
+            '▶️ ' + esc(iv.host_name || 'Spolužák') + ' · kód ' + esc(iv.code) + '</button>';
+        }).join('') + '</div>';
+    }).catch(function () {});
+  }
+
+  // Připojení přímo daným kódem (z pozvánky), bez ručního zadávání.
+  function joinCode(code) {
+    var c = cloud(); if (!c) return;
+    shell('<div class="rpgb-sub">Připojuji…</div>');
+    c.joinBattle(code, NAME).then(function (b) {
+      if (!b || !b.id) { renderMenu(); return; }
+      B = { id: b.id, code: b.code, role: 'player', teamMode: !!(b.team_mode), questions: null, lastQi: -2, picked: -1, locked: false };
+      startPoll();
+    }).catch(function () { renderMenu(); });
   }
 
   // ════════════ HOST: režim + výběr počtu otázek ════════════
@@ -346,11 +381,36 @@
       '<div class="rpgb-code">' + esc(B.code) + '</div>' + plyHtml;
     if (B.role === 'host') {
       inner += '<button id="rpgb-startbtn" class="rpgb-btn go" style="margin-top:16px"' + (players.length < 1 ? ' disabled' : '') +
-        ' onclick="RPGBattle._start()">▶️ Spustit souboj</button>';
+        ' onclick="RPGBattle._start()">▶️ Spustit souboj</button>' +
+        '<div class="rpgb-invrow">' +
+        '<input class="rpgb-in sm" id="rpgb-invmail" type="email" autocomplete="off" spellcheck="false" placeholder="spolužák@husovaliberec.cz" oninput="RPGBattle._invDraft(this.value)">' +
+        '<button class="rpgb-btn sm" onclick="RPGBattle._invite()">📨 Pozvat</button></div>' +
+        '<div id="rpgb-invmsg" class="rpgb-invmsg"></div>';
     }
     inner += '<button class="rpgb-btn sm red" style="display:block;width:100%" onclick="RPGBattle._leave()">' +
       (B.role === 'host' ? '✕ Zrušit místnost' : '← Odejít') + '</button>';
     shell(inner);
+    if (B.role === 'host') {
+      var im = document.getElementById('rpgb-invmail');
+      if (im && B._invDraft) im.value = B._invDraft;   // přežij re-render při příchodu hráče
+    }
+  }
+
+  function invDraft(v) { if (B) B._invDraft = v; }
+
+  // Host pozve spolužáka e-mailem (backend RPC invite_battle_email).
+  function invite() {
+    var c = cloud(); if (!c || !B || !c.inviteBattleEmail) return;
+    var el = document.getElementById('rpgb-invmail');
+    var msg = document.getElementById('rpgb-invmsg');
+    var email = (el && el.value || '').trim().toLowerCase();
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) { if (el) el.style.borderColor = '#ff6b6b'; return; }
+    if (el) el.style.borderColor = '';
+    if (msg) { msg.textContent = 'Posílám…'; msg.style.color = ''; }
+    c.inviteBattleEmail(B.id, email).then(function (ok) {
+      if (msg) { msg.textContent = ok ? '✓ Pozvánka odeslána: ' + email : '✗ Pozvánku se nepodařilo odeslat'; msg.style.color = ok ? '#4ade80' : '#ff6b6b'; }
+      if (ok && el) { el.value = ''; B._invDraft = ''; }
+    });
   }
 
   function startBattle() {
@@ -598,6 +658,7 @@
     _menu: renderMenu, _host: hostUI, _mode: setMode, _create: createRoom,
     _joinUI: joinUI, _join: joinRoom, _start: startBattle,
     _pick: pick, _next: nextQuestion, _leave: leave,
-    _active: activeUI, _kill: kill, _rematch: rematch
+    _active: activeUI, _kill: kill, _rematch: rematch,
+    _joinCode: joinCode, _invite: invite, _invDraft: invDraft
   };
 })();

--- a/tests/rpg-battle-invite.test.cjs
+++ b/tests/rpg-battle-invite.test.cjs
@@ -1,0 +1,103 @@
+/* ══════════════════════════════════════════════════════════════════
+   Test: živý souboj — pozvánky (rpg-battle-ui.js)
+   • Žák vidí čekající pozvánku v menu a připojí se kliknutím
+   • Pozvánka pro jiný ročník (game) se nezobrazí
+   • Host v čekárně pozve spolužáka e-mailem (invite_battle_email)
+   • Neplatný e-mail se neodešle
+   Mock RPGCloud (žádné Supabase CDN). Chromium headless.
+   ══════════════════════════════════════════════════════════════════ */
+const { chromium } = require('playwright');
+const fs = require('fs');
+const path = require('path');
+
+const EXEC = '/opt/pw-browsers/chromium-1194/chrome-linux/chrome';
+const UI = fs.readFileSync(path.join(__dirname, '..', 'projects', 'rpg-battle-ui.js'), 'utf8');
+
+let pass = 0, fail = 0;
+function ok(c, m){ if(c){pass++;console.log('  ✅ '+m);} else {fail++;console.log('  ❌ '+m);} }
+
+const MOCK = `
+window.__calls = { join: [], invite: [] };
+window.__cfg = {};
+window.RPG_BATTLE_9 = { build: function(seed,count){ var a=[]; for(var i=0;i<count;i++) a.push({text:'Q'+i,choices:['1','2','3','4'],correct:0}); return a; } };
+window.RPGCloud = {
+  currentUser: function(){ return { id:'u-self', email:'vojta@husovaliberec.cz' }; },
+  isStaff: function(){ return false; },
+  myBattleInvites: function(){ return Promise.resolve(window.__cfg.invites || []); },
+  joinBattle: function(code,name){ window.__calls.join.push([code,name]); return Promise.resolve(window.__cfg.joinResult || null); },
+  inviteBattleEmail: function(id,email){ window.__calls.invite.push([id,email]); return Promise.resolve(window.__cfg.inviteOk !== false); },
+  createBattle: function(game,count,name){ return Promise.resolve(window.__cfg.createResult || null); },
+  pollBattle: function(id,cb){ setTimeout(function(){ if(window.__cfg.state) cb(window.__cfg.state); }, 0); return function(){}; },
+  advanceBattle: function(){}, submitBattleAnswer: function(){},
+  setBattleStatus: function(){ return Promise.resolve(); }
+};
+`;
+
+(async () => {
+  const browser = await chromium.launch({ executablePath: EXEC });
+  const page = await browser.newPage();
+  page.on('pageerror', e => { fail++; console.log('  ❌ JS error: ' + e.message); });
+  await page.setContent('<!doctype html><html><body></body></html>');
+  await page.addScriptTag({ content: MOCK });
+  await page.addScriptTag({ content: UI });
+
+  const BANK = { _: 1 }; // open() bere bank z opts; použijeme RPG_BATTLE_9 přes GAME
+  const openMenu = async (invites) => {
+    await page.evaluate((inv) => {
+      window.__cfg = { invites: inv };
+      window.__calls = { join: [], invite: [] };
+      window.RPGBattle.open({ game: 'RPG_MAT_9', name: 'Vojta' });
+    }, invites);
+  };
+
+  // ── A: pozvánka pro tento ročník se zobrazí ──────────────────────
+  await openMenu([{ id:'i1', code:'ABCD', host_name:'Karel', game:'RPG_MAT_9', status:'lobby' }]);
+  await page.waitForFunction(() => /Máš pozvánku/.test(document.getElementById('rpgb-invites')?.textContent || ''), { timeout: 3000 }).catch(()=>{});
+  const invHtml = await page.evaluate(() => document.getElementById('rpgb-invites').innerHTML);
+  ok(/Máš pozvánku/.test(invHtml), 'menu ukáže box s pozvánkou');
+  ok(/ABCD/.test(invHtml) && /Karel/.test(invHtml), 'pozvánka obsahuje kód i jméno hosta');
+
+  // ── B: klik na pozvánku připojí daným kódem ──────────────────────
+  await page.evaluate(() => { window.__cfg.joinResult = { id:'b1', code:'ABCD' }; window.__cfg.state = { battle:{ status:'lobby', q_count:5 }, players:[{user_id:'u-self',display_name:'Vojta'}], me:'u-self' }; });
+  await page.click('#rpgb-invites button.invite');
+  await page.waitForTimeout(50);
+  const joinCalls = await page.evaluate(() => window.__calls.join);
+  ok(joinCalls.length === 1 && joinCalls[0][0] === 'ABCD', 'klik na pozvánku zavolá joinBattle("ABCD")');
+
+  // ── C: pozvánka pro jiný ročník se NEzobrazí ─────────────────────
+  await openMenu([{ id:'i2', code:'WXYZ', host_name:'Eva', game:'RPG_MAT_8', status:'lobby' }]);
+  await page.waitForTimeout(80);
+  const invHtml2 = await page.evaluate(() => document.getElementById('rpgb-invites').innerHTML);
+  ok(invHtml2 === '' , 'pozvánka z jiného ročníku (RPG_MAT_8) je odfiltrovaná');
+
+  // ── D: host v čekárně — formulář pozvánky + odeslání ─────────────
+  await page.evaluate(() => {
+    window.__cfg = { createResult: { id:'b9', code:'QWER' }, state: { battle:{ status:'lobby', q_count:5 }, players:[{user_id:'u-self',display_name:'Vojta'}], me:'u-self' } };
+    window.__calls = { join: [], invite: [] };
+    window.RPGBattle.open({ game:'RPG_MAT_9', name:'Vojta' });
+    window.RPGBattle._create(5);
+  });
+  await page.waitForSelector('#rpgb-invmail', { timeout: 3000 });
+  ok(true, 'host čekárna ukáže pole pro pozvání e-mailem');
+  await page.fill('#rpgb-invmail', 'zak@husovaliberec.cz');
+  await page.click('button[onclick="RPGBattle._invite()"]');
+  await page.waitForFunction(() => /odeslána/.test(document.getElementById('rpgb-invmsg')?.textContent || ''), { timeout: 3000 }).catch(()=>{});
+  const inviteCalls = await page.evaluate(() => window.__calls.invite);
+  ok(inviteCalls.length === 1 && inviteCalls[0][0] === 'b9' && inviteCalls[0][1] === 'zak@husovaliberec.cz', 'Pozvat zavolá inviteBattleEmail(battleId, email)');
+  const msg = await page.evaluate(() => document.getElementById('rpgb-invmsg').textContent);
+  ok(/✓/.test(msg), 'po odeslání se ukáže potvrzení');
+
+  // ── E: neplatný e-mail se neodešle ───────────────────────────────
+  await page.evaluate(() => { window.__calls.invite = []; });
+  await page.fill('#rpgb-invmail', 'neplatny-email');
+  await page.click('button[onclick="RPGBattle._invite()"]');
+  await page.waitForTimeout(60);
+  const inviteCalls2 = await page.evaluate(() => window.__calls.invite);
+  ok(inviteCalls2.length === 0, 'neplatný e-mail neodešle pozvánku');
+
+  await browser.close();
+  console.log('\n══════════════════════════════════════════');
+  console.log('  VÝSLEDEK: ' + pass + ' ✅  /  ' + fail + ' ❌');
+  console.log('══════════════════════════════════════════');
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
## QoL: e-mailové pozvánky do živého souboje

Backend pro pozvánky byl hotový už od Fáze 7 (`battle_invites` tabulka, RPC `invite_battle_email` / `my_battle_invites`, wrappery v `rpg-cloud.js`), ale **nebylo k tomu žádné UI**. Tato PR doplňuje jen frontend v `rpg-battle-ui.js` — **žádné nové SQL**.

### Co přibylo
- **Host v čekárně** — pole pro pozvání spolužáka e-mailem + tlačítko „📨 Pozvat" s potvrzením (✓/✗). Validace formátu e-mailu, draft přežije re-render při příchodu hráče.
- **Žák v menu** — box „📨 Máš pozvánku do souboje" s tlačítkem pro připojení **jedním klikem** (bez opisování kódu). Filtrováno na aktuální ročník (`game`) a stav `lobby`.

### Bezpečnost / robustnost
- Graceful: bez cloudu/přihlášení/RPC se nic nezobrazí, nic se nerozbije.
- Kódy v `onclick` jsou serverem generované alfanumerické (bez uvozovek); jména hostů jdou přes `esc()`.
- Cross-grade pozvánky odfiltrované (jiný ročník = jiná banka otázek).

### Test
`tests/rpg-battle-invite.test.cjs` — 8 ✅ (Playwright + mock RPGCloud): zobrazení pozvánky, klik = join, filtr ročníku, hostí formulář, odeslání, blokace neplatného e-mailu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_