### PR TITLE
rpg-learn: doplnění chybějících videí teorie (g6, g7)

### DIFF
--- a/projects/rpg-learn-6.js
+++ b/projects/rpg-learn-6.js
@@ -69,7 +69,7 @@ window.RPG_LEARN_6 = {
   { q: 'Čtverec se stranou 6 cm. Obvod a obsah?', s: ['o = 4 · 6 = <b>24 cm</b>', 'S = 6² = <b>36 cm²</b>'] },
   { q: 'Převeď 3,5 dm² na cm²', s: ['1 dm² = 100 cm²', '3,5 · 100 = <b>350 cm²</b>'] },
  ],
- video: null,
+ video: { id: 'GcR_xKAu5kQ', title: 'Obvod a obsah čtverce a obdélníku' },
 },
 
 '1-3': {
@@ -392,7 +392,7 @@ window.RPG_LEARN_6 = {
   { q: 'Obraz bodu [−2 ; 5] podle osy x', s: ['Změní se znaménko y', 'Výsledek: <b>[−2 ; −5]</b>'] },
   { q: 'Obraz bodu [−3 ; −4] podle osy y', s: ['−(−3) = +3', 'Výsledek: <b>[3 ; −4]</b>'] },
  ],
- video: null,
+ video: { id: 'Yp5u-LyQUXQ', title: 'Osová souměrnost' },
 },
 
 '5-3': {

--- a/projects/rpg-learn-7.js
+++ b/projects/rpg-learn-7.js
@@ -106,7 +106,7 @@ window.RPG_LEARN_7 = {
   { q: 'Trojúhelník má základnu 12 cm a výšku na ni 7 cm. Obsah?', s: ['S = (12 × 7) / 2 = 84 / 2 = <b>42 cm²</b>'] },
   { q: 'Převeď: 2,5 m² = ? cm²', s: ['1 m² = 10 000 cm²', '2,5 × 10 000 = <b>25 000 cm²</b>'] },
  ],
- video: null,
+ video: { id: 'GcR_xKAu5kQ', title: 'Obvod a obsah čtverce a obdélníku' },
 },
 
 /* ─── Oblast 2: SÍŇ ZLOMKŮ ───────────────────────────────────── */
@@ -517,7 +517,7 @@ window.RPG_LEARN_7 = {
   { q: 'Bod B[5, 3] zobrazíme přes osu x. Najdi B\'.', s: ['Přes osu x: y → −y', 'B\'[<b>5, −3</b>]'] },
   { q: 'Kolik os souměrnosti má rovnoramenný (ne rovnostranný) trojúhelník?', s: ['Jen osa procházející vrcholem mezi shodnými rameny', '→ <b>1 osa</b>'] },
  ],
- video: null,
+ video: { id: 'Yp5u-LyQUXQ', title: 'Osová souměrnost' },
 },
 
 '6-2': {


### PR DESCRIPTION
## Co a proč
Čtyři mise v teorii (`rpg-learn-6/7.js`) měly `video: null`. Doplněna reálná, ověřitelná videa, kde téma sedí.

| Mise | Téma | Video | Zdroj |
|------|------|-------|-------|
| g6 **1-2** | Obvod a obsah | `GcR_xKAu5kQ` | Matýskova matematika (tradiční) |
| g7 **1-3** | Obvod a obsah | `GcR_xKAu5kQ` | — stejné video |
| g6 **5-2** | Osová souměrnost v souřadnicích | `Yp5u-LyQUXQ` | znovupoužití z g6 5-1 (@matematikajednoduse) |
| g7 **6-1** | Osová souměrnost | `Yp5u-LyQUXQ` | — stejné video |

## Ponecháno `null`
- **g6 1-3** (logické uvažování / slovní úlohy)
- **g7 1-1** (pamětné počítání)

Pro tato dvě témata se nepodařilo dohledat vhodné samostatné video z ověřeného zdroje (jen procvičovací stránky a články), takže zůstávají bez videa — tlačítko Teorie se prostě nezobrazí.

## Pozn. k výběru
- g6 5-2 vypadalo podle názvu mise na „soustavu souřadnic", ale obsah mise je reflexe bodu podle osy → správnější je video o osové souměrnosti.
- Khan Academy stránky se nedaly spolehlivě namapovat na YouTube ID (a YouTube blokuje přímé ověření), proto byla zvolena indexovaná videa s přímým `youtube.com/watch` odkazem.

## Test
`node tests/rpg-learn.test.cjs` → **56 ✅ / 0 ❌** (validace struktury `{id,title}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_