### PR TITLE
feat(sprites): tematická aréna pozadí + death burst (g6/7/8/9)

### DIFF
--- a/projects/rpg-sprites-6.js
+++ b/projects/rpg-sprites-6.js
@@ -989,14 +989,14 @@ window.RPGSprites6 = (function () {
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
       } else if (f.kind === 'shock') {
-        const p = Math.min(1, f.t / 420);
+        const p = Math.min(1, f.t / 260);
         ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
         ctx.lineWidth = 4 - p * 3;
         ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
         if (p >= 1) ST.fx.splice(i, 1);
       } else if (f.kind === 'debris') {
         f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
-        const p = Math.min(1, f.t / 760);
+        const p = Math.min(1, f.t / 380);
         ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
         const s = f.s || 4;
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);

--- a/projects/rpg-sprites-6.js
+++ b/projects/rpg-sprites-6.js
@@ -652,6 +652,64 @@ window.RPGSprites6 = (function () {
     }
   }
 
+  // ── deterministický seedovaný RNG → stabilní rozložení pozadí pro danou oblast ──
+  function srnd(seed) {
+    let s = (seed * 2654435761) >>> 0;
+    return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+  }
+  function pxDisc(cx, cy, r, step, color) {
+    ctx.fillStyle = color;
+    const rr = r * r;
+    for (let y = -r; y <= r; y += step)
+      for (let x = -r; x <= r; x += step)
+        if (x * x + y * y <= rr) ctx.fillRect(Math.round(cx + x), Math.round(cy + y), step, step);
+  }
+
+  // ── vesmírné pozadí (planeta + hvězdy + mlhovina, per oblast) ──
+  const G6_PLANETS = {
+    1: { c: '#b85a2a', h: '#e08a4a', ring: 0, neb: '#5a2a1a' }, // rezavá
+    2: { c: '#c8a24a', h: '#ecd28a', ring: 1, neb: '#4a3a1a' }, // prstencová zlatá
+    3: { c: '#5a5a6e', h: '#8a8aa0', ring: 0, neb: '#2a2a3a' }, // kamenná šedá
+    4: { c: '#6a44b0', h: '#a070e0', ring: 0, neb: '#3a1f6a' }, // fialová mlhovina
+    5: { c: '#5aa0c8', h: '#aee0f0', ring: 0, neb: '#1f3a5a' }, // ledová modrá
+    6: { c: '#2f8a5a', h: '#5ad08a', ring: 1, neb: '#1a4a2f' }, // zelený plyn
+    7: { c: '#9a3a7a', h: '#d06ab0', ring: 0, neb: '#4a1a3a' }  // purpurová
+  };
+  function drawBackdrop(now) {
+    const W = cv.width, H = cv.height, animOK = !rm();
+    const pl = G6_PLANETS[curArea] || G6_PLANETS[1];
+    const rnd = srnd(curArea * 97 + 13);
+    // mlhovinný opar
+    ctx.globalAlpha = 0.10; pxDisc(Math.round(W * 0.30), 78, 64, 6, pl.neb);
+    ctx.globalAlpha = 0.07; pxDisc(Math.round(W * 0.62), 50, 48, 6, pl.neb);
+    ctx.globalAlpha = 1;
+    // hvězdy
+    for (let i = 0; i < 48; i++) {
+      const x = Math.floor(rnd() * W), y = Math.floor(rnd() * (H - 26));
+      const base = 0.30 + rnd() * 0.5;
+      const tw = animOK ? 0.28 * Math.sin(now / 600 + i * 1.7) : 0;
+      ctx.globalAlpha = Math.max(0.10, base + tw);
+      ctx.fillStyle = rnd() < 0.28 ? '#aee0ff' : '#ffffff';
+      const s = rnd() < 0.16 ? 2 : 1;
+      ctx.fillRect(x, y, s, s);
+    }
+    ctx.globalAlpha = 1;
+    // planeta vpravo nahoře
+    const pcx = Math.round(W * 0.82), pcy = 50, pr = 28;
+    if (pl.ring) {
+      ctx.globalAlpha = 0.45; ctx.strokeStyle = pl.h; ctx.lineWidth = 3;
+      ctx.beginPath(); ctx.ellipse(pcx, pcy, pr + 17, 7, -0.42, 0, Math.PI * 2); ctx.stroke();
+      ctx.globalAlpha = 1;
+    }
+    ctx.globalAlpha = 0.85; pxDisc(pcx, pcy, pr, 3, pl.c);
+    ctx.globalAlpha = 0.5; pxDisc(pcx - 8, pcy - 8, Math.round(pr * 0.5), 3, pl.h);
+    if (pl.ring) {
+      ctx.globalAlpha = 0.7; ctx.strokeStyle = pl.h; ctx.lineWidth = 3;
+      ctx.beginPath(); ctx.ellipse(pcx, pcy, pr + 17, 7, -0.42, 0.35, Math.PI - 0.35); ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+  }
+
   function heroPos() { return { x: Math.round(cv.width * 0.12), y: 200 - 24 * SCALE - 14 }; }
   function bossPos() {
     const fr = BOSS_SPRITES[curArea] || BOSS_SPRITES[1];
@@ -672,6 +730,7 @@ window.RPGSprites6 = (function () {
   function render(now) {
     if (!ctx) return;
     ctx.clearRect(0, 0, cv.width, cv.height);
+    drawBackdrop(now);
     const hp = heroPos(), bp = bossPos();
     const pal = Object.assign({}, COMMON, BOSS_PALS[curArea] || BOSS_PALS[1]);
     const b = ST.boss;
@@ -929,6 +988,19 @@ window.RPGSprites6 = (function () {
         ctx.fillStyle = 'rgba(80,65,55,' + (0.45 - p * 0.44) + ')';
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
+      } else if (f.kind === 'shock') {
+        const p = Math.min(1, f.t / 420);
+        ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
+        ctx.lineWidth = 4 - p * 3;
+        ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
+        if (p >= 1) ST.fx.splice(i, 1);
+      } else if (f.kind === 'debris') {
+        f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
+        const p = Math.min(1, f.t / 760);
+        ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
+        const s = f.s || 4;
+        ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
+        if (p >= 1 || f.y > 212) ST.fx.splice(i, 1);
       }
     }
   }
@@ -976,7 +1048,7 @@ window.RPGSprites6 = (function () {
     if (!force && kind === lastAtk) kind = ATTACKS[(ATTACKS.indexOf(kind) + 1) % ATTACKS.length];
     lastAtk = kind;
     const hp = heroPos(), bp = bossPos();
-    const bcx = bp.x + 9 * BSCALE, bcy = bp.y + 8 * BSCALE;
+    const bcx = bp.x + 9 * bp.sc, bcy = bp.y + 9 * bp.sc;
     const gy = 200 - 12;
     if (rm()) { ST.boss.flash = 130; ST.boss.t = 0; return; }
     ST.hero.mode = kind === 'slash' ? 'slash' : kind === 'shoot' ? 'shoot' : 'cast';
@@ -1016,7 +1088,7 @@ window.RPGSprites6 = (function () {
     if (rm()) { ST.hero.mode = 'hit'; setTimeout(() => { ST.hero.mode = 'idle'; }, 300); return; }
     ST.boss.mode = 'charge'; ST.boss.t = 0;
     setTimeout(() => {
-      ST.fx.push({ kind: 'bossproj', x0: bp.x + 4 * BSCALE, y0: bp.y + 8 * BSCALE, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
+      ST.fx.push({ kind: 'bossproj', x0: bp.x + 5 * bp.sc, y0: bp.y + 9 * bp.sc, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
     }, 520);
   }
 
@@ -1025,8 +1097,20 @@ window.RPGSprites6 = (function () {
     const bp = bossPos();
     ST.boss.mode = 'defeat'; ST.boss.t = 0;
     const pal = BOSS_PALS[curArea] || BOSS_PALS[1];
-    const rgb = parseInt(pal.A.slice(1), 16);
-    ST.fx.push({ kind: 'boom', x: bp.x + 9 * BSCALE, y: bp.y + 8 * BSCALE, t: 0, rgb: ((rgb >> 16) & 255) + ',' + ((rgb >> 8) & 255) + ',' + (rgb & 255) });
+    const n = parseInt(pal.A.slice(1), 16);
+    const rgb = ((n >> 16) & 255) + ',' + ((n >> 8) & 255) + ',' + (n & 255);
+    const cx = bp.x + 9 * bp.sc, cy = bp.y + 9 * bp.sc;
+    ST.fx.push({ kind: 'boom', x: cx, y: cy, t: 0, rgb });
+    if (rm()) return;
+    ST.fx.push({ kind: 'shock', x: cx, y: cy, t: 0, rgb });
+    for (let k = 0; k < 18; k++) {
+      const a = Math.random() * Math.PI * 2, sp = 1.5 + Math.random() * 3.4;
+      ST.fx.push({ kind: 'debris', x: cx, y: cy, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp - 1.4,
+        s: 3 + Math.floor(Math.random() * 3), rgb, t: 0 });
+    }
+    for (let k = 0; k < 7; k++)
+      ST.fx.push({ kind: 'smoke', x: cx + (Math.random() - 0.5) * 34, y: cy + (Math.random() - 0.5) * 22,
+        vx: (Math.random() - 0.5) * 1.3, vy: -0.6 - Math.random() * 0.9, t: 0 });
   }
 
   window.addEventListener('resize', resize);

--- a/projects/rpg-sprites-7.js
+++ b/projects/rpg-sprites-7.js
@@ -992,14 +992,14 @@ window.RPGSprites7 = (function () {
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
       } else if (f.kind === 'shock') {
-        const p = Math.min(1, f.t / 420);
+        const p = Math.min(1, f.t / 260);
         ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
         ctx.lineWidth = 4 - p * 3;
         ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
         if (p >= 1) ST.fx.splice(i, 1);
       } else if (f.kind === 'debris') {
         f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
-        const p = Math.min(1, f.t / 760);
+        const p = Math.min(1, f.t / 380);
         ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
         const s = f.s || 4;
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);

--- a/projects/rpg-sprites-7.js
+++ b/projects/rpg-sprites-7.js
@@ -652,6 +652,68 @@ window.RPGSprites7 = (function () {
     }
   }
 
+  // ── deterministický seedovaný RNG → stabilní rozložení pozadí pro danou oblast ──
+  function srnd(seed) {
+    let s = (seed * 2654435761) >>> 0;
+    return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+  }
+  function pxDisc(cx, cy, r, step, color) {
+    ctx.fillStyle = color;
+    const rr = r * r;
+    for (let y = -r; y <= r; y += step)
+      for (let x = -r; x <= r; x += step)
+        if (x * x + y * y <= rr) ctx.fillRect(Math.round(cx + x), Math.round(cy + y), step, step);
+  }
+
+  // ── chrámové / pouštní pozadí (slunce + pyramidy + sloupy, per oblast) ──
+  const G7_TH = {
+    1: { sun: '#e8a23a', pyr: '#43321c' }, // úsvit
+    2: { sun: '#e0c050', pyr: '#4a3a1e' }, // zlatá
+    3: { sun: '#bfe0f0', pyr: '#33414e' }, // ledová oblast — chladnější
+    4: { sun: '#f0d060', pyr: '#46361c' },
+    5: { sun: '#e8b040', pyr: '#3e2e16' },
+    6: { sun: '#d8c068', pyr: '#403420' },
+    7: { sun: '#f0c040', pyr: '#46351a' }
+  };
+  function drawBackdrop(now) {
+    const W = cv.width, H = cv.height, animOK = !rm();
+    const th = G7_TH[curArea] || G7_TH[1];
+    const rnd = srnd(curArea * 131 + 7);
+    const fy = H - 30;
+    // noční hvězdy
+    for (let i = 0; i < 22; i++) {
+      const x = Math.floor(rnd() * W), y = Math.floor(rnd() * (fy - 50));
+      ctx.globalAlpha = animOK ? 0.28 + 0.3 * Math.abs(Math.sin(now / 700 + i * 1.3)) : 0.4;
+      ctx.fillStyle = '#f0e0b0'; ctx.fillRect(x, y, 1, 1);
+    }
+    ctx.globalAlpha = 1;
+    // slunce / měsíc vlevo nahoře
+    const scx = Math.round(W * 0.30), scy = 40, sr = 17;
+    ctx.globalAlpha = 0.25; pxDisc(scx, scy, sr + 6, 3, th.sun);
+    ctx.globalAlpha = 0.85; pxDisc(scx, scy, sr, 3, th.sun);
+    ctx.globalAlpha = 1;
+    // pyramidy na horizontu
+    function pyr(px, w, col) {
+      ctx.fillStyle = col;
+      for (let yy = 0; yy < w / 2; yy++) { const ww = w - yy * 2; ctx.fillRect(Math.round(px - ww / 2), fy - yy * 2, ww, 2); }
+    }
+    ctx.globalAlpha = 0.55;
+    pyr(Math.round(W * 0.54), 52, th.pyr);
+    pyr(Math.round(W * 0.70), 40, th.pyr);
+    pyr(Math.round(W * 0.84), 30, th.pyr);
+    pyr(Math.round(W * 0.20), 38, th.pyr);
+    ctx.globalAlpha = 1;
+    // rámující chrámové sloupy
+    function pillar(px) {
+      ctx.globalAlpha = 0.55; ctx.fillStyle = '#2c2418';
+      ctx.fillRect(px, 26, 16, fy - 26);
+      ctx.fillStyle = '#3a3020'; ctx.fillRect(px - 3, 22, 22, 6); ctx.fillRect(px - 3, fy - 6, 22, 6);
+      ctx.fillStyle = '#1f190f'; for (let yy = 32; yy < fy - 8; yy += 9) ctx.fillRect(px + 4, yy, 2, 5);
+      ctx.globalAlpha = 1;
+    }
+    pillar(4); pillar(W - 20);
+  }
+
   function heroPos() { return { x: Math.round(cv.width * 0.12), y: 200 - 24 * SCALE - 14 }; }
   function bossPos() {
     const fr = BOSS_SPRITES[curArea] || BOSS_SPRITES[1];
@@ -672,6 +734,7 @@ window.RPGSprites7 = (function () {
   function render(now) {
     if (!ctx) return;
     ctx.clearRect(0, 0, cv.width, cv.height);
+    drawBackdrop(now);
     const hp = heroPos(), bp = bossPos();
     const pal = Object.assign({}, COMMON, BOSS_PALS[curArea] || BOSS_PALS[1]);
     const b = ST.boss;
@@ -928,6 +991,19 @@ window.RPGSprites7 = (function () {
         ctx.fillStyle = 'rgba(80,65,55,' + (0.45 - p * 0.44) + ')';
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
+      } else if (f.kind === 'shock') {
+        const p = Math.min(1, f.t / 420);
+        ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
+        ctx.lineWidth = 4 - p * 3;
+        ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
+        if (p >= 1) ST.fx.splice(i, 1);
+      } else if (f.kind === 'debris') {
+        f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
+        const p = Math.min(1, f.t / 760);
+        ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
+        const s = f.s || 4;
+        ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
+        if (p >= 1 || f.y > 212) ST.fx.splice(i, 1);
       }
     }
   }
@@ -975,7 +1051,7 @@ window.RPGSprites7 = (function () {
     if (!force && kind === lastAtk) kind = ATTACKS[(ATTACKS.indexOf(kind) + 1) % ATTACKS.length];
     lastAtk = kind;
     const hp = heroPos(), bp = bossPos();
-    const bcx = bp.x + 9 * BSCALE, bcy = bp.y + 8 * BSCALE;
+    const bcx = bp.x + 9 * bp.sc, bcy = bp.y + 9 * bp.sc;
     const gy = 200 - 12;
     if (rm()) { ST.boss.flash = 130; ST.boss.t = 0; return; }
     ST.hero.mode = kind === 'slash' ? 'slash' : kind === 'shoot' ? 'shoot' : 'cast';
@@ -1015,7 +1091,7 @@ window.RPGSprites7 = (function () {
     if (rm()) { ST.hero.mode = 'hit'; setTimeout(() => { ST.hero.mode = 'idle'; }, 300); return; }
     ST.boss.mode = 'charge'; ST.boss.t = 0;
     setTimeout(() => {
-      ST.fx.push({ kind: 'bossproj', x0: bp.x + 4 * BSCALE, y0: bp.y + 8 * BSCALE, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
+      ST.fx.push({ kind: 'bossproj', x0: bp.x + 5 * bp.sc, y0: bp.y + 9 * bp.sc, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
     }, 520);
   }
 
@@ -1024,8 +1100,20 @@ window.RPGSprites7 = (function () {
     const bp = bossPos();
     ST.boss.mode = 'defeat'; ST.boss.t = 0;
     const pal = BOSS_PALS[curArea] || BOSS_PALS[1];
-    const rgb = parseInt(pal.A.slice(1), 16);
-    ST.fx.push({ kind: 'boom', x: bp.x + 9 * BSCALE, y: bp.y + 8 * BSCALE, t: 0, rgb: ((rgb >> 16) & 255) + ',' + ((rgb >> 8) & 255) + ',' + (rgb & 255) });
+    const n = parseInt(pal.A.slice(1), 16);
+    const rgb = ((n >> 16) & 255) + ',' + ((n >> 8) & 255) + ',' + (n & 255);
+    const cx = bp.x + 9 * bp.sc, cy = bp.y + 9 * bp.sc;
+    ST.fx.push({ kind: 'boom', x: cx, y: cy, t: 0, rgb });
+    if (rm()) return;
+    ST.fx.push({ kind: 'shock', x: cx, y: cy, t: 0, rgb });
+    for (let k = 0; k < 18; k++) {
+      const a = Math.random() * Math.PI * 2, sp = 1.5 + Math.random() * 3.4;
+      ST.fx.push({ kind: 'debris', x: cx, y: cy, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp - 1.4,
+        s: 3 + Math.floor(Math.random() * 3), rgb, t: 0 });
+    }
+    for (let k = 0; k < 7; k++)
+      ST.fx.push({ kind: 'smoke', x: cx + (Math.random() - 0.5) * 34, y: cy + (Math.random() - 0.5) * 22,
+        vx: (Math.random() - 0.5) * 1.3, vy: -0.6 - Math.random() * 0.9, t: 0 });
   }
 
   window.addEventListener('resize', resize);

--- a/projects/rpg-sprites-8.js
+++ b/projects/rpg-sprites-8.js
@@ -997,14 +997,14 @@ window.RPGSprites8 = (function () {
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
       } else if (f.kind === 'shock') {
-        const p = Math.min(1, f.t / 420);
+        const p = Math.min(1, f.t / 260);
         ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
         ctx.lineWidth = 4 - p * 3;
         ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
         if (p >= 1) ST.fx.splice(i, 1);
       } else if (f.kind === 'debris') {
         f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
-        const p = Math.min(1, f.t / 760);
+        const p = Math.min(1, f.t / 380);
         ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
         const s = f.s || 4;
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);

--- a/projects/rpg-sprites-8.js
+++ b/projects/rpg-sprites-8.js
@@ -652,6 +652,72 @@ window.RPGSprites8 = (function () {
     }
   }
 
+  // ── deterministický seedovaný RNG → stabilní rozložení pozadí pro danou oblast ──
+  function srnd(seed) {
+    let s = (seed * 2654435761) >>> 0;
+    return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+  }
+  function pxDisc(cx, cy, r, step, color) {
+    ctx.fillStyle = color;
+    const rr = r * r;
+    for (let y = -r; y <= r; y += step)
+      for (let x = -r; x <= r; x += step)
+        if (x * x + y * y <= rr) ctx.fillRect(Math.round(cx + x), Math.round(cy + y), step, step);
+  }
+
+  // ── akademie: klenuté okno + sloupy + arkánový kruh + plovoucí symboly (per oblast) ──
+  const G8_TH = {
+    1: { rune: '#7a9ad0', glow: '#33406e' }, // modrá
+    2: { rune: '#e0964a', glow: '#5a3a1a' }, // procenta oranžová
+    3: { rune: '#5ac88a', glow: '#1c4a32' }, // algebra zelená
+    4: { rune: '#c86ad0', glow: '#451f56' }, // alchymie fialová
+    5: { rune: '#4ac8d0', glow: '#1a4654' }, // chobotnice tyrkys
+    6: { rune: '#d0c04a', glow: '#544619' }, // rýsování zlatá
+    7: { rune: '#d04a6a', glow: '#551a2f' }  // arcimág rudá
+  };
+  const G8_GLYPHS = ['+', '−', '×', '÷', 'π', '√', '%', '∞', '=', 'x²', 'Σ', '½'];
+  function drawBackdrop(now) {
+    const W = cv.width, H = cv.height, animOK = !rm();
+    const th = G8_TH[curArea] || G8_TH[1];
+    const rnd = srnd(curArea * 149 + 5);
+    const fy = H - 30;
+    // klenuté okno (měsíční svit) za bossem
+    const wx = Math.round(W * 0.72), wtop = 26, ww = 54;
+    ctx.globalAlpha = 0.16; ctx.fillStyle = th.glow;
+    ctx.fillRect(wx - ww / 2, wtop, ww, fy - wtop);
+    pxDisc(wx, wtop, ww / 2, 3, th.glow);
+    ctx.globalAlpha = 0.5; ctx.strokeStyle = '#23273a'; ctx.lineWidth = 3;
+    ctx.strokeRect(wx - ww / 2, wtop, ww, fy - wtop);
+    ctx.beginPath(); ctx.moveTo(wx, wtop); ctx.lineTo(wx, fy);
+    ctx.moveTo(wx - ww / 2, (wtop + fy) / 2); ctx.lineTo(wx + ww / 2, (wtop + fy) / 2); ctx.stroke();
+    ctx.globalAlpha = 1;
+    // rámující kamenné sloupy
+    function col(px) {
+      ctx.globalAlpha = 0.6; ctx.fillStyle = '#262a3a';
+      ctx.fillRect(px, 20, 18, fy - 20);
+      ctx.fillStyle = '#343a52'; ctx.fillRect(px - 3, 16, 24, 7); ctx.fillRect(px - 3, fy - 7, 24, 7);
+      ctx.fillStyle = '#1b1f30'; for (let yy = 28; yy < fy - 10; yy += 10) ctx.fillRect(px + 5, yy, 2, 6);
+      ctx.globalAlpha = 1;
+    }
+    col(3); col(W - 21);
+    // arkánový kruh na podlaze
+    ctx.globalAlpha = 0.38; ctx.strokeStyle = th.rune; ctx.lineWidth = 2;
+    ctx.beginPath(); ctx.ellipse(Math.round(W * 0.5), fy - 3, 118, 13, 0, 0, Math.PI * 2); ctx.stroke();
+    ctx.beginPath(); ctx.ellipse(Math.round(W * 0.5), fy - 3, 94, 10, 0, 0, Math.PI * 2); ctx.stroke();
+    ctx.globalAlpha = 1;
+    // plovoucí matematické symboly
+    ctx.font = '12px monospace'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    for (let i = 0; i < 9; i++) {
+      const gx = 22 + rnd() * (W - 44);
+      const drift = animOK ? Math.sin(now / 900 + i * 1.7) * 6 : 0;
+      const gyy = 24 + rnd() * (fy - 64) + drift;
+      ctx.globalAlpha = 0.20 + 0.14 * rnd();
+      ctx.fillStyle = th.rune;
+      ctx.fillText(G8_GLYPHS[Math.floor(rnd() * G8_GLYPHS.length)], gx, gyy);
+    }
+    ctx.globalAlpha = 1; ctx.textAlign = 'left'; ctx.textBaseline = 'alphabetic';
+  }
+
   function heroPos() { return { x: Math.round(cv.width * 0.12), y: 200 - 24 * SCALE - 14 }; }
   function bossPos() {
     const fr = BOSS_SPRITES[curArea] || BOSS_SPRITES[1];
@@ -672,6 +738,7 @@ window.RPGSprites8 = (function () {
   function render(now) {
     if (!ctx) return;
     ctx.clearRect(0, 0, cv.width, cv.height);
+    drawBackdrop(now);
     const hp = heroPos(), bp = bossPos();
     const pal = Object.assign({}, COMMON, BOSS_PALS[curArea] || BOSS_PALS[1]);
     const b = ST.boss;
@@ -929,6 +996,19 @@ window.RPGSprites8 = (function () {
         ctx.fillStyle = 'rgba(80,65,55,' + (0.45 - p * 0.44) + ')';
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
+      } else if (f.kind === 'shock') {
+        const p = Math.min(1, f.t / 420);
+        ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
+        ctx.lineWidth = 4 - p * 3;
+        ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
+        if (p >= 1) ST.fx.splice(i, 1);
+      } else if (f.kind === 'debris') {
+        f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
+        const p = Math.min(1, f.t / 760);
+        ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
+        const s = f.s || 4;
+        ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
+        if (p >= 1 || f.y > 212) ST.fx.splice(i, 1);
       }
     }
   }
@@ -976,7 +1056,7 @@ window.RPGSprites8 = (function () {
     if (!force && kind === lastAtk) kind = ATTACKS[(ATTACKS.indexOf(kind) + 1) % ATTACKS.length];
     lastAtk = kind;
     const hp = heroPos(), bp = bossPos();
-    const bcx = bp.x + 9 * BSCALE, bcy = bp.y + 8 * BSCALE;
+    const bcx = bp.x + 9 * bp.sc, bcy = bp.y + 9 * bp.sc;
     const gy = 200 - 12;
     if (rm()) { ST.boss.flash = 130; ST.boss.t = 0; return; }
     ST.hero.mode = kind === 'slash' ? 'slash' : kind === 'shoot' ? 'shoot' : 'cast';
@@ -1016,7 +1096,7 @@ window.RPGSprites8 = (function () {
     if (rm()) { ST.hero.mode = 'hit'; setTimeout(() => { ST.hero.mode = 'idle'; }, 300); return; }
     ST.boss.mode = 'charge'; ST.boss.t = 0;
     setTimeout(() => {
-      ST.fx.push({ kind: 'bossproj', x0: bp.x + 4 * BSCALE, y0: bp.y + 8 * BSCALE, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
+      ST.fx.push({ kind: 'bossproj', x0: bp.x + 5 * bp.sc, y0: bp.y + 9 * bp.sc, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
     }, 520);
   }
 
@@ -1025,8 +1105,20 @@ window.RPGSprites8 = (function () {
     const bp = bossPos();
     ST.boss.mode = 'defeat'; ST.boss.t = 0;
     const pal = BOSS_PALS[curArea] || BOSS_PALS[1];
-    const rgb = parseInt(pal.A.slice(1), 16);
-    ST.fx.push({ kind: 'boom', x: bp.x + 9 * BSCALE, y: bp.y + 8 * BSCALE, t: 0, rgb: ((rgb >> 16) & 255) + ',' + ((rgb >> 8) & 255) + ',' + (rgb & 255) });
+    const n = parseInt(pal.A.slice(1), 16);
+    const rgb = ((n >> 16) & 255) + ',' + ((n >> 8) & 255) + ',' + (n & 255);
+    const cx = bp.x + 9 * bp.sc, cy = bp.y + 9 * bp.sc;
+    ST.fx.push({ kind: 'boom', x: cx, y: cy, t: 0, rgb });
+    if (rm()) return;
+    ST.fx.push({ kind: 'shock', x: cx, y: cy, t: 0, rgb });
+    for (let k = 0; k < 18; k++) {
+      const a = Math.random() * Math.PI * 2, sp = 1.5 + Math.random() * 3.4;
+      ST.fx.push({ kind: 'debris', x: cx, y: cy, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp - 1.4,
+        s: 3 + Math.floor(Math.random() * 3), rgb, t: 0 });
+    }
+    for (let k = 0; k < 7; k++)
+      ST.fx.push({ kind: 'smoke', x: cx + (Math.random() - 0.5) * 34, y: cy + (Math.random() - 0.5) * 22,
+        vx: (Math.random() - 0.5) * 1.3, vy: -0.6 - Math.random() * 0.9, t: 0 });
   }
 
   window.addEventListener('resize', resize);

--- a/projects/rpg-sprites-9.js
+++ b/projects/rpg-sprites-9.js
@@ -659,6 +659,73 @@ window.RPGSprites9 = (function () {
     }
   }
 
+  // ── deterministický seedovaný RNG → stabilní rozložení pozadí pro danou oblast ──
+  function srnd(seed) {
+    let s = (seed * 2654435761) >>> 0;
+    return function () { s = (s * 1664525 + 1013904223) >>> 0; return s / 4294967296; };
+  }
+
+  // ── cyberpunk: neonová perspektivní mřížka + věže + datový déšť (per oblast) ──
+  const G9_TH = {
+    1: '#3fd6e0', 2: '#ff5a8a', 3: '#5affc0', 4: '#c06aff',
+    5: '#ffb03a', 6: '#4a8aff', 7: '#3fe06a'
+  };
+  function drawBackdrop(now) {
+    const W = cv.width, H = cv.height, animOK = !rm();
+    const neon = G9_TH[curArea] || G9_TH[1];
+    const nr = parseInt(neon.slice(1, 3), 16), ng = parseInt(neon.slice(3, 5), 16), nb = parseInt(neon.slice(5, 7), 16);
+    const RGBA = a => 'rgba(' + nr + ',' + ng + ',' + nb + ',' + a + ')';
+    const rnd = srnd(curArea * 173 + 11);
+    const horizon = Math.round(H * 0.46);
+    // datové tečky nad horizontem
+    for (let i = 0; i < 24; i++) {
+      const x = Math.floor(rnd() * W), y = Math.floor(rnd() * (horizon - 6));
+      ctx.globalAlpha = animOK ? 0.22 + 0.3 * Math.abs(Math.sin(now / 500 + i * 1.1)) : 0.4;
+      ctx.fillStyle = rnd() < 0.5 ? RGBA(1) : '#6a7a98'; ctx.fillRect(x, y, 1, 1);
+    }
+    ctx.globalAlpha = 1;
+    // vzdálená silueta věží s neonovými okny
+    let tx = 8;
+    while (tx < W) {
+      const tw = 14 + Math.floor(rnd() * 22), thh = 18 + Math.floor(rnd() * 48);
+      ctx.globalAlpha = 0.85; ctx.fillStyle = '#0d1019'; ctx.fillRect(tx, horizon - thh, tw, thh);
+      for (let wy = horizon - thh + 4; wy < horizon - 4; wy += 6)
+        for (let wx = tx + 3; wx < tx + tw - 2; wx += 5)
+          if (rnd() < 0.45) { ctx.globalAlpha = 0.4 + rnd() * 0.4; ctx.fillStyle = RGBA(1); ctx.fillRect(wx, wy, 2, 2); }
+      tx += tw + 5 + Math.floor(rnd() * 10);
+    }
+    ctx.globalAlpha = 1;
+    // zářící horizont
+    ctx.globalAlpha = 0.7; ctx.fillStyle = RGBA(1); ctx.fillRect(0, horizon - 1, W, 1);
+    ctx.globalAlpha = 0.12; ctx.fillStyle = neon; ctx.fillRect(0, horizon, W, 4);
+    ctx.globalAlpha = 1;
+    // perspektivní mřížka pod horizontem
+    const vpx = Math.round(W * 0.5);
+    ctx.strokeStyle = RGBA(0.32); ctx.lineWidth = 1;
+    for (let gx = -6; gx <= 6; gx++) {
+      const fx = W / 2 + gx * (W / 9);
+      ctx.beginPath(); ctx.moveTo(vpx, horizon); ctx.lineTo(fx, H); ctx.stroke();
+    }
+    const scroll = animOK ? (now / 1400) % 1 : 0;
+    for (let r = 0; r < 8; r++) {
+      const t = (r + scroll) / 8;
+      const y = horizon + t * t * (H - horizon);
+      ctx.globalAlpha = 0.08 + 0.3 * t;
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(W, y); ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+    // datový déšť (svislé pruhy nad horizontem)
+    if (animOK) {
+      for (let i = 0; i < 9; i++) {
+        const x = Math.floor((i / 9) * W) + Math.floor(rnd() * 8);
+        const speed = 36 + rnd() * 60;
+        const yy = ((now / 1000 * speed) + rnd() * H) % (horizon + 18);
+        for (let k = 0; k < 5; k++) { ctx.globalAlpha = 0.5 - k * 0.1; ctx.fillStyle = RGBA(1); ctx.fillRect(x, yy - k * 5, 1, 3); }
+      }
+      ctx.globalAlpha = 1;
+    }
+  }
+
   /* pozice: hrdina vlevo dole, boss vpravo */
   function heroPos() { return { x: Math.round(cv.width * 0.12), y: 200 - 24 * SCALE - 14 }; }
   function bossPos() {
@@ -680,6 +747,7 @@ window.RPGSprites9 = (function () {
   function render(now) {
     if (!ctx) return;
     ctx.clearRect(0, 0, cv.width, cv.height);
+    drawBackdrop(now);
     const hp = heroPos(), bp = bossPos();
     const pal = Object.assign({}, COMMON, BOSS_PALS[curArea] || BOSS_PALS[1]);
     // ── boss ──
@@ -946,6 +1014,19 @@ window.RPGSprites9 = (function () {
         ctx.fillStyle = 'rgba(80,65,55,' + (0.45 - p * 0.44) + ')';
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
+      } else if (f.kind === 'shock') {
+        const p = Math.min(1, f.t / 420);
+        ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
+        ctx.lineWidth = 4 - p * 3;
+        ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
+        if (p >= 1) ST.fx.splice(i, 1);
+      } else if (f.kind === 'debris') {
+        f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
+        const p = Math.min(1, f.t / 760);
+        ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
+        const s = f.s || 4;
+        ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
+        if (p >= 1 || f.y > 212) ST.fx.splice(i, 1);
       }
     }
   }
@@ -995,7 +1076,7 @@ window.RPGSprites9 = (function () {
     if (!force && kind === lastAtk) kind = ATTACKS[(ATTACKS.indexOf(kind) + 1) % ATTACKS.length];
     lastAtk = kind;
     const hp = heroPos(), bp = bossPos();
-    const bcx = bp.x + 9 * BSCALE, bcy = bp.y + 8 * BSCALE;
+    const bcx = bp.x + 9 * bp.sc, bcy = bp.y + 9 * bp.sc;
     const gy = 200 - 12;                       // úroveň země
     if (rm()) { ST.boss.flash = 130; ST.boss.t = 0; return; }
     ST.hero.mode = kind === 'slash' ? 'slash' : kind === 'shoot' ? 'shoot' : 'cast';
@@ -1036,7 +1117,7 @@ window.RPGSprites9 = (function () {
     if (rm()) { ST.hero.mode = 'hit'; setTimeout(() => { ST.hero.mode = 'idle'; }, 300); return; }
     ST.boss.mode = 'charge'; ST.boss.t = 0;
     setTimeout(() => {
-      ST.fx.push({ kind: 'bossproj', x0: bp.x + 4 * BSCALE, y0: bp.y + 8 * BSCALE, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
+      ST.fx.push({ kind: 'bossproj', x0: bp.x + 5 * bp.sc, y0: bp.y + 9 * bp.sc, x1: hp.x + 6 * SCALE, y1: hp.y + 13 * SCALE, t: 0 });
     }, 520);
   }
 
@@ -1045,8 +1126,20 @@ window.RPGSprites9 = (function () {
     const bp = bossPos();
     ST.boss.mode = 'defeat'; ST.boss.t = 0;
     const pal = BOSS_PALS[curArea] || BOSS_PALS[1];
-    const rgb = parseInt(pal.A.slice(1), 16);
-    ST.fx.push({ kind: 'boom', x: bp.x + 9 * BSCALE, y: bp.y + 8 * BSCALE, t: 0, rgb: ((rgb >> 16) & 255) + ',' + ((rgb >> 8) & 255) + ',' + (rgb & 255) });
+    const n = parseInt(pal.A.slice(1), 16);
+    const rgb = ((n >> 16) & 255) + ',' + ((n >> 8) & 255) + ',' + (n & 255);
+    const cx = bp.x + 9 * bp.sc, cy = bp.y + 9 * bp.sc;
+    ST.fx.push({ kind: 'boom', x: cx, y: cy, t: 0, rgb });
+    if (rm()) return;
+    ST.fx.push({ kind: 'shock', x: cx, y: cy, t: 0, rgb });
+    for (let k = 0; k < 18; k++) {
+      const a = Math.random() * Math.PI * 2, sp = 1.5 + Math.random() * 3.4;
+      ST.fx.push({ kind: 'debris', x: cx, y: cy, vx: Math.cos(a) * sp, vy: Math.sin(a) * sp - 1.4,
+        s: 3 + Math.floor(Math.random() * 3), rgb, t: 0 });
+    }
+    for (let k = 0; k < 7; k++)
+      ST.fx.push({ kind: 'smoke', x: cx + (Math.random() - 0.5) * 34, y: cy + (Math.random() - 0.5) * 22,
+        vx: (Math.random() - 0.5) * 1.3, vy: -0.6 - Math.random() * 0.9, t: 0 });
   }
 
   window.addEventListener('resize', resize);

--- a/projects/rpg-sprites-9.js
+++ b/projects/rpg-sprites-9.js
@@ -1015,14 +1015,14 @@ window.RPGSprites9 = (function () {
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);
         if (p >= 1 || f.y < -10) ST.fx.splice(i, 1);
       } else if (f.kind === 'shock') {
-        const p = Math.min(1, f.t / 420);
+        const p = Math.min(1, f.t / 260);
         ctx.strokeStyle = 'rgba(' + f.rgb + ',' + (0.9 - p * 0.9) + ')';
         ctx.lineWidth = 4 - p * 3;
         ctx.beginPath(); ctx.arc(f.x, f.y, 8 + p * 58, 0, Math.PI * 2); ctx.stroke();
         if (p >= 1) ST.fx.splice(i, 1);
       } else if (f.kind === 'debris') {
         f.x += f.vx; f.y += f.vy; f.vy += 0.18; f.vx *= 0.99;
-        const p = Math.min(1, f.t / 760);
+        const p = Math.min(1, f.t / 380);
         ctx.fillStyle = 'rgba(' + f.rgb + ',' + (1 - p) + ')';
         const s = f.s || 4;
         ctx.fillRect(f.x - s / 2, f.y - s / 2, s, s);


### PR DESCRIPTION
## Co je nového

Vizuální upgrade bojové scény ve všech 4 ročnících — pokračování po hi-res bossech (#136).

### 1. Tematické pozadí arény (`drawBackdrop()` per engine)
Procedurální, seedované oblastí (každá ze 7 oblastí má vlastní rozložení), aditivní nad stávající CSS podlahou, respektuje `reduced-motion`:

- **g6 — Vesmír 🚀**: hvězdné pole (twinkle) + mlhovinný opar + planeta vpravo nahoře (prstenec u některých oblastí), barva planety per oblast
- **g7 — Ztracený chrám ⛏️**: noční hvězdy + slunce/měsíc + pyramidy na horizontu + rámující chrámové sloupy (chladnější tón pro ledovou oblast 3)
- **g8 — Akademie 🎓**: klenuté měsíční okno za bossem + kamenné sloupy + arkánový kruh na podlaze + plovoucí matematické symboly (π, √, ∞, x²…)
- **g9 — NULL_BYTE 💻**: neonová perspektivní mřížka (synthwave) + panorama věží s neonovými okny + zářící horizont + datový déšť; neonový odstín per oblast

### 2. Death burst
Nové fx druhy `shock` (rázová vlna) + `debris` (úlomky v akcentní barvě bosse) + kouř při `defeat()`. V `reduced-motion` zůstává jen jemný fade+propad (beze změny).

### 3. Oprava míření zásahů
`heroAttack`/`bossAttack`/`defeat` počítaly střed bosse přes konstantu `BSCALE` (7), ale hi-res bossové (24 řádků) mají scale `bp.sc` (5) → projektily/exploze mířily mimo střed. Opraveno na `bp.sc`.

## Testy
- 🟢 `tests/sprite-magenta.audit.cjs` — čistý (4×336 snímků, žádný `#f0f`)
- 🟢 `tests/vstudents-deep.harness.cjs` — 65/65
- 🟢 `tests/rpg-tower-game.test.cjs` — 108/108

Vizuálně ověřeno všech 28 oblastí (7×4) + death burst ve všech hrách.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_