### PR TITLE
fix(tasks): čitelnost — ÷→: + font spojovačky/řazení/pexesa

### DIFF
--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -922,7 +922,7 @@ const AREAS = [
  (()=>{const a=ri(120,460),b=ri(120,460);return{text:`Vypočítej:\n${a} + ${b} =`,ans:String(a+b),hints:[`Sčítej po řádech (jednotky, desítky, stovky).`,`${a} + ${b}`],skill:'calc'};})(),
  (()=>{const a=ri(550,950),b=ri(120,480);return{text:`Vypočítej:\n${a} - ${b} =`,ans:String(a-b),hints:[`Odečítej pod sebou, pozor na výpůjčky.`,`${a} - ${b}`],skill:'calc'};})(),
  (()=>{const a=ri(13,39),b=ri(3,9);return{text:`Vypočítej:\n${a} × ${b} =`,ans:String(a*b),hints:[`Násob po řádech a sečti.`,`${a} × ${b}`],skill:'calc'};})(),
- (()=>{const b=ri(3,8),q=ri(12,40),a=b*q;return{text:`Vypočítej:\n${a} ÷ ${b} =`,ans:String(q),hints:[`Kolikrát se ${b} vejde do ${a}?`,`${a} ÷ ${b}`],skill:'calc'};})(),
+ (()=>{const b=ri(3,8),q=ri(12,40),a=b*q;return{text:`Vypočítej:\n${a} : ${b} =`,ans:String(q),hints:[`Kolikrát se ${b} vejde do ${a}?`,`${a} : ${b}`],skill:'calc'};})(),
  (()=>{const a=ri(123,887);const r=Math.round(a/10)*10;return{text:`Zaokrouhli na desítky:\n${a} ≈`,ans:String(r),hints:[`Rozhoduje číslice jednotek (${a%10}).`,`${a%10>=5?'Zaokrouhli nahoru.':'Zaokrouhli dolů.'}`],skill:'calc'};})(),
  (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);return{text:`Vypočítej (pozor na závorku):\n${a} × (${b} + ${c}) =`,ans:String(a*(b+c)),hints:[`Nejdřív spočítej závorku.`,`${a} × ${b+c}`],skill:'calc'};})()
  ]
@@ -937,7 +937,7 @@ const AREAS = [
  (()=>{const a=ri(3,12),b=ri(3,12);return{text:`Obdélník: a = ${a} cm, b = ${b} cm.\nVypočítej obsah S. (cm²)`,ans:String(a*b),hints:[`S = a × b.`,`${a} × ${b}`],skill:'geo'};})(),
  (()=>{const a=ri(3,15);return{text:`Čtverec se stranou a = ${a} cm.\nVypočítej obvod O. (cm)`,ans:String(4*a),hints:[`O = 4 × a.`,`4 × ${a}`],skill:'geo'};})(),
  (()=>{const a=ri(3,15);return{text:`Čtverec se stranou a = ${a} cm.\nVypočítej obsah S. (cm²)`,ans:String(a*a),hints:[`S = a × a.`,`${a} × ${a}`],skill:'geo'};})(),
- (()=>{const a=ri(4,12),b=ri(2,9),S=a*b;return{text:`Obdélník má obsah ${S} cm² a stranu a = ${a} cm.\nJak dlouhá je strana b? (cm)`,ans:String(b),hints:[`b = S ÷ a.`,`${S} ÷ ${a}`],skill:'anal'};})(),
+ (()=>{const a=ri(4,12),b=ri(2,9),S=a*b;return{text:`Obdélník má obsah ${S} cm² a stranu a = ${a} cm.\nJak dlouhá je strana b? (cm)`,ans:String(b),hints:[`b = S : a.`,`${S} : ${a}`],skill:'anal'};})(),
  (()=>{const a=ri(5,12),b=ri(5,12);return{text:`Zahrada tvaru obdélníku má rozměry ${a} m × ${b} m.\nKolik metrů pletiva je potřeba na oplocení? (m)`,ans:String(2*(a+b)),hints:[`Oplocení = obvod obdélníku.`,`2 × (${a} + ${b})`],skill:'anal'};})()
  ]
  },
@@ -948,7 +948,7 @@ const AREAS = [
  tc:6,
  tasks:()=>[
  (()=>{const n=ri(3,9),s=n+7;return{text:`Myslím si číslo. Když ho zvětším o 7, dostanu ${s}.\nJaké číslo si myslím?`,ans:String(n),hints:[`Udělej opačnou operaci — odečti 7.`,`${s} - 7`],skill:'anal'};})(),
- (()=>{const a=ri(3,8),b=ri(3,9);return{text:`V košíku je ${a*b} jablek. Rozdělíš je do ${a} ${skl(a,'sáčku','sáčků','sáčků')} rovným dílem.\nKolik jablek je v jednom sáčku?`,ans:String(b),hints:[`Děl počtem sáčků.`,`${a*b} ÷ ${a}`],skill:'anal'};})(),
+ (()=>{const a=ri(3,8),b=ri(3,9);return{text:`V košíku je ${a*b} jablek. Rozdělíš je do ${a} ${skl(a,'sáčku','sáčků','sáčků')} rovným dílem.\nKolik jablek je v jednom sáčku?`,ans:String(b),hints:[`Děl počtem sáčků.`,`${a*b} : ${a}`],skill:'anal'};})(),
  (()=>{const start=ri(7,11),dur=ri(2,4);return{text:`Film začal v ${start}:00 a trval ${dur} ${skl(dur,'hodinu','hodiny','hodin')}.\nV kolik hodin skončil? (jen hodina)`,ans:String(start+dur),hints:[`Přičti délku k začátku.`,`${start} + ${dur}`],skill:'anal'};})(),
  (()=>{const x=ri(2,9),y=ri(2,9);return{text:`Bod B má souřadnice [${x}, ${y}].\nSečti obě jeho souřadnice.`,ans:String(x+y),hints:[`Souřadnice jsou [x, y].`,`${x} + ${y}`],skill:'anal'};})(),
  (()=>{const a=ri(22,60),b=ri(10,a-5);return{text:`Ve třídě je ${a} žáků, z toho ${b} dívek.\nKolik je chlapců?`,ans:String(a-b),hints:[`Celek − dívky.`,`${a} - ${b}`],skill:'anal'};})(),
@@ -971,14 +971,14 @@ const AREAS = [
  tasks:()=>[
  (()=>{const a=ri(2,9),b=ri(1,9),v=a+b/10;return{text:`Zapiš jako desetinné číslo:\n${a} celých a ${b} desetin =`,ans:String(v),hints:[`Desetiny jsou první místo za čárkou.`,`${a},${b}`],skill:'calc'};})(),
  (()=>{const v=ri(11,98)/10;return{text:`Vynásob:\n${cz(v)} × 10 =`,ans:String(Math.round(v*100)/10),hints:[`× 10 = posuň čárku o 1 doprava.`,`Výsledek: ${Math.round(v*100)/10}`],skill:'calc'};})(),
- (()=>{const v=ri(15,98)/10;return{text:`Vyděl:\n${cz(Math.round(v*100)/10)} ÷ 10 =`,ans:String(v),hints:[`÷ 10 = posuň čárku o 1 doleva.`,`Výsledek: ${v}`],skill:'calc'};})(),
+ (()=>{const v=ri(15,98)/10;return{text:`Vyděl:\n${cz(Math.round(v*100)/10)} : 10 =`,ans:String(v),hints:[`: 10 = posuň čárku o 1 doleva.`,`Výsledek: ${v}`],skill:'calc'};})(),
  (()=>{const v=ri(105,995)/100;const r=Math.round(v*10)/10;return{text:`Zaokrouhli na desetiny:\n${cz(v)} ≈`,ans:String(r),hints:[`Rozhoduje místo setin (druhé za čárkou).`,`Výsledek: ${r}`],skill:'calc'};})(),
  (()=>{const a=ri(20,79)/10,b=a+ri(2,30)/10;return{text:`Které číslo je větší?\n${cz(a)}  nebo  ${cz(b)}\n(napiš to větší)`,ans:String(b),hints:[`Porovnej nejdřív celé části, pak desetiny.`,`Výsledek: ${b}`],skill:'calc'};})(),
  (()=>{const v=ri(105,985)/100;const r=Math.round(v);return{text:`Zaokrouhli na celé číslo:\n${cz(v)} ≈`,ans:String(r),hints:[`Rozhoduje místo desetin.`,`Výsledek: ${r}`],skill:'calc'};})()
  ]
  },
  {
- id:'2-2', name:'Počítání s desetinnými', sub:'+ − × ÷',
+ id:'2-2', name:'Počítání s desetinnými', sub:'+ − × :',
  mon:'🌟', mname:'JISKŘÍCÍ MLHOVINA',
  intro:'Jiskřící mlhovina se rozzáří, jen když správně sečteš a vynásobíš desetinná čísla.',
  tc:6,
@@ -986,7 +986,7 @@ const AREAS = [
  (()=>{const a=ri(11,89)/10,b=ri(11,89)/10;const ans=Math.round((a+b)*10)/10;return{text:`Vypočítej:\n${cz(a)} + ${cz(b)} =`,ans:String(ans),hints:[`Zarovnej desetinné čárky pod sebe.`,`Sečti po sloupcích.`],skill:'calc'};})(),
  (()=>{const a=ri(50,98)/10,b=ri(11,Math.round(a*10)-5)/10;const ans=Math.round((a-b)*10)/10;return{text:`Vypočítej:\n${cz(a)} - ${cz(b)} =`,ans:String(ans),hints:[`Zarovnej čárky a odečti.`,`Výsledek: ${ans}`],skill:'calc'};})(),
  (()=>{const a=ri(11,49)/10,b=ri(2,9);const ans=Math.round(a*b*10)/10;return{text:`Vypočítej:\n${cz(a)} × ${b} =`,ans:String(ans),hints:[`Násob jako celá čísla, pak umísti čárku.`,`Výsledek má 1 desetinné místo.`],skill:'calc'};})(),
- (()=>{const b=ri(2,8),q=ri(11,49)/10;const a=Math.round(q*b*10)/10;return{text:`Vypočítej:\n${cz(a)} ÷ ${b} =`,ans:String(q),hints:[`Děl jako obvykle, čárku piš nad čárkou.`,`Výsledek: ${q}`],skill:'calc'};})(),
+ (()=>{const b=ri(2,8),q=ri(11,49)/10;const a=Math.round(q*b*10)/10;return{text:`Vypočítej:\n${cz(a)} : ${b} =`,ans:String(q),hints:[`Děl jako obvykle, čárku piš nad čárkou.`,`Výsledek: ${q}`],skill:'calc'};})(),
  (()=>{const a=ri(2,9),b=ri(11,89)/10;const ans=Math.round((a+b)*10)/10;return{text:`Vypočítej:\n${a} + ${cz(b)} =`,ans:String(ans),hints:[`Celé číslo = ${a},0.`,`Výsledek: ${ans}`],skill:'calc'};})(),
  (()=>{const a=ri(15,45)/10,b=ri(15,45)/10;const ans=Math.round(a*b*100)/100;return{text:`Vypočítej:\n${cz(a)} × ${cz(b)} =`,ans:String(ans),hints:[`Násob bez čárek, pak součet desetinných míst = 2.`,`Výsledek: ${ans}`],skill:'calc'};})()
  ]
@@ -999,10 +999,10 @@ const AREAS = [
  tasks:()=>[
  (()=>{const d=ri(5,12),a=ri(1,d-2),b=ri(1,d-a-1);const num=a+b,g=gcd(num,d);const ans=d/g===1?String(num/g):`${num/g}/${d/g}`;return{text:`Vypočítej (zkrať):\n${a}/${d} + ${b}/${d} =`,ans,hints:[`Stejný jmenovatel — sečti čitatele.`,`(${a} + ${b})/${d}`],skill:'calc'};})(),
  (()=>{const d=ri(5,12),a=ri(2,d-1),b=ri(1,a-1);const num=a-b,g=gcd(num,d);const ans=d/g===1?String(num/g):`${num/g}/${d/g}`;return{text:`Vypočítej (zkrať):\n${a}/${d} - ${b}/${d} =`,ans,hints:[`Stejný jmenovatel — odečti čitatele.`,`(${a} - ${b})/${d}`],skill:'calc'};})(),
- (()=>{let n=[ri(2,9),ri(2,9),ri(2,9)];let s=n[0]+n[1]+n[2];n[2]+=(3-s%3)%3;const sum=n[0]+n[1]+n[2];return{text:`Vypočítej aritmetický průměr:\n${n.join(', ')}`,ans:String(sum/3),hints:[`Průměr = součet ÷ počet.`,`(${n.join(' + ')}) ÷ 3`],skill:'anal'};})(),
+ (()=>{let n=[ri(2,9),ri(2,9),ri(2,9)];let s=n[0]+n[1]+n[2];n[2]+=(3-s%3)%3;const sum=n[0]+n[1]+n[2];return{text:`Vypočítej aritmetický průměr:\n${n.join(', ')}`,ans:String(sum/3),hints:[`Průměr = součet : počet.`,`(${n.join(' + ')}) : 3`],skill:'anal'};})(),
  (()=>{const whole=ri(2,6),d=ri(3,8),num=ri(1,d-1);const imp=whole*d+num;return{text:`Převeď na nepravý zlomek:\n${whole} a ${num}/${d}  =  ?/${d}\n(napiš čitatel)`,ans:String(imp),hints:[`Celé × jmenovatel + čitatel.`,`${whole} × ${d} + ${num}`],skill:'calc'};})(),
- (()=>{const a=ri(10,40),b=ri(10,40),c0=ri(10,40);const c=c0+(3-(a+b+c0)%3)%3;return{text:`Tři skoky do dálky: ${a} cm, ${b} cm, ${c} cm.\nJaký byl průměrný skok? (cm)`,ans:String((a+b+c)/3),hints:[`Součet ÷ 3.`,`(${a} + ${b} + ${c}) ÷ 3`],skill:'anal'};})(),
- (()=>{const d=ri(4,10),a=ri(1,d-1);const ans=Math.round(a/d*100)/100;return{text:`Převeď zlomek na desetinné číslo:\n${a}/${d} =\n(zaokrouhli na setiny)`,ans:String(ans),hints:[`Zlomek = čitatel ÷ jmenovatel.`,`${a} ÷ ${d}`],skill:'calc'};})()
+ (()=>{const a=ri(10,40),b=ri(10,40),c0=ri(10,40);const c=c0+(3-(a+b+c0)%3)%3;return{text:`Tři skoky do dálky: ${a} cm, ${b} cm, ${c} cm.\nJaký byl průměrný skok? (cm)`,ans:String((a+b+c)/3),hints:[`Součet : 3.`,`(${a} + ${b} + ${c}) : 3`],skill:'anal'};})(),
+ (()=>{const d=ri(4,10),a=ri(1,d-1);const ans=Math.round(a/d*100)/100;return{text:`Převeď zlomek na desetinné číslo:\n${a}/${d} =\n(zaokrouhli na setiny)`,ans:String(ans),hints:[`Zlomek = čitatel : jmenovatel.`,`${a} : ${d}`],skill:'calc'};})()
  ]
  }
  ]
@@ -1073,7 +1073,7 @@ const AREAS = [
  (()=>{const deg=ri(2,8)*10;return{svg:svgAngle(deg,{label:deg+'°'}),text:`Doplň úhel do přímého úhlu (180°).\nKolik stupňů chybí?`,ans:String(180-deg),hints:[`Přímý úhel má 180°.`,`180 - ${deg}`],skill:'geo'};})(),
  (()=>{const deg=ri(10,80);return{svg:svgAngle(deg,{label:'?'}),text:`Úhel na obrázku je menší než 90°.\nJaký je to druh úhlu?\n(ostrý / pravý / tupý)`,ans:'ostrý',hints:[`Menší než 90° = ostrý.`,`Výsledek: ostrý`],skill:'geo'};})(),
  (()=>{const deg=ri(100,160);return{svg:svgAngle(deg,{label:'?'}),text:`Úhel na obrázku je větší než 90°, ale menší než 180°.\nJaký je to druh úhlu?\n(ostrý / pravý / tupý)`,ans:'tupý',hints:[`Mezi 90° a 180° = tupý.`,`Výsledek: tupý`],skill:'geo'};})(),
- (()=>{const deg=ri(3,8)*10;return{svg:svgAngle(deg,{label:deg+'°'}),text:`Polovina tohoto úhlu (osa úhlu ho dělí na dvě části).\nKolik stupňů má jedna část?`,ans:String(deg/2),hints:[`Osa úhlu dělí úhel na dvě stejné poloviny.`,`${deg} ÷ 2`],skill:'geo'};})(),
+ (()=>{const deg=ri(3,8)*10;return{svg:svgAngle(deg,{label:deg+'°'}),text:`Polovina tohoto úhlu (osa úhlu ho dělí na dvě části).\nKolik stupňů má jedna část?`,ans:String(deg/2),hints:[`Osa úhlu dělí úhel na dvě stejné poloviny.`,`${deg} : 2`],skill:'geo'};})(),
  (()=>{const a=ri(2,8)*10,b=ri(2,8)*10;return{text:`Sečti dva úhly:\n${a}° + ${b}° =\n(napiš ve stupních)`,ans:String(a+b),hints:[`Úhly sčítáš jako čísla.`,`${a} + ${b}`],skill:'geo'};})()
  ]
  },
@@ -1088,7 +1088,7 @@ const AREAS = [
  (()=>{const a=ri(20,70);return{text:`Vedlejší úhel má ${180-a}°.\nKolik stupňů má původní úhel?`,ans:String(a),hints:[`Doplň do 180°.`,`180 - ${180-a}`],skill:'geo'};})(),
  (()=>{const a=ri(30,80);return{svg:svgCross(a,{label:'α'}),text:`Vrcholový úhel k α má ${a}°.\nKolik stupňů má α?`,ans:String(a),hints:[`Vrcholové úhly jsou stejné.`,`Výsledek: ${a}`],skill:'geo'};})(),
  (()=>{const a=ri(2,7)*10;return{text:`Dva vedlejší úhly. Jeden má ${a}°.\nO kolik stupňů je druhý větší než první?`,ans:String((180-a)-a),hints:[`Druhý = 180 − ${a} = ${180-a}.`,`${180-a} - ${a}`],skill:'geo'};})(),
- (()=>{const a=ri(40,80);return{text:`Úhel a jeho vedlejší úhel jsou stejně velké.\nKolik stupňů má každý z nich?`,ans:'90',hints:[`Když jsou stejné a dají 180°...`,`180 ÷ 2`],skill:'geo'};})()
+ (()=>{const a=ri(40,80);return{text:`Úhel a jeho vedlejší úhel jsou stejně velké.\nKolik stupňů má každý z nich?`,ans:'90',hints:[`Když jsou stejné a dají 180°...`,`180 : 2`],skill:'geo'};})()
  ]
  },
  {
@@ -1098,10 +1098,10 @@ const AREAS = [
  tc:6,
  tasks:()=>[
  (()=>{const d=ri(2,5);return{text:`Kolik minut je ${d}°?\n(1° = 60′)`,ans:String(d*60),hints:[`Každý stupeň má 60 minut.`,`${d} × 60`],skill:'geo'};})(),
- (()=>{const m=ri(2,9)*60;return{text:`Kolik stupňů je ${m}′?\n(1° = 60′)`,ans:String(m/60),hints:[`Vyděl 60.`,`${m} ÷ 60`],skill:'geo'};})(),
+ (()=>{const m=ri(2,9)*60;return{text:`Kolik stupňů je ${m}′?\n(1° = 60′)`,ans:String(m/60),hints:[`Vyděl 60.`,`${m} : 60`],skill:'geo'};})(),
  (()=>{const m1=ri(10,25),m2=ri(10,25);return{text:`Sečti minuty:\n${m1}′ + ${m2}′ = ?′`,ans:String(m1+m2),hints:[`Minuty sčítáš jako čísla.`,`${m1} + ${m2}`],skill:'geo'};})(),
  (()=>{const a1=ri(20,50),m1=ri(10,40),a2=ri(5,a1-5),m2=ri(0,m1-1);return{text:`Odečti:\n${a1}° ${m1}′ - ${a2}° ${m2}′\nNapiš stupně výsledku.`,ans:String(a1-a2),hints:[`Odečti zvlášť stupně a minuty.`,`${a1} - ${a2}`],skill:'geo'};})(),
- (()=>{const half=ri(10,40);return{text:`Úhel má ${half*2}°.\nKolik stupňů má jeho polovina?`,ans:String(half),hints:[`Polovina = ÷ 2.`,`${half*2} ÷ 2`],skill:'geo'};})(),
+ (()=>{const half=ri(10,40);return{text:`Úhel má ${half*2}°.\nKolik stupňů má jeho polovina?`,ans:String(half),hints:[`Polovina = : 2.`,`${half*2} : 2`],skill:'geo'};})(),
  (()=>{const a=ri(15,40),m=30;return{text:`Kolik minut je ${a}° ${m}′ celkem?\n(převeď vše na minuty)`,ans:String(a*60+m),hints:[`Stupně × 60 + minuty.`,`${a} × 60 + ${m}`],skill:'geo'};})()
  ]
  }
@@ -1173,7 +1173,7 @@ const AREAS = [
  (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);return{svg:svgCuboid(a,b,c),text:`Kvádr: a = ${a} cm, b = ${b} cm, c = ${c} cm.\nVypočítej objem V. (cm³)`,ans:String(a*b*c),hints:[`V = a × b × c.`,`${a} × ${b} × ${c}`],skill:'geo'};})(),
  (()=>{const a=ri(2,6),b=ri(2,6),c=ri(2,6);return{svg:svgCuboid(a,b,c),text:`Akvárium tvaru kvádru: ${a} dm × ${b} dm × ${c} dm.\nKolik litrů vody se vejde?\n(1 dm³ = 1 litr)`,ans:String(a*b*c),hints:[`Objem v dm³ = počet litrů.`,`${a} × ${b} × ${c}`],skill:'anal'};})(),
  (()=>{const a=ri(2,8);return{text:`Krychle má objem ${a*a*a} cm³.\nJak dlouhá je její hrana? (cm)`,ans:String(a),hints:[`Hledej číslo, které × samo × samo = objem.`,`Třetí odmocnina z ${a*a*a}.`],skill:'anal'};})(),
- (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);const V=a*b*c;return{text:`Kvádr má objem ${V} cm³, podstavu a = ${a} cm a b = ${b} cm.\nJak vysoký je? (c v cm)`,ans:String(c),hints:[`c = V ÷ (a × b).`,`${V} ÷ ${a*b}`],skill:'anal'};})(),
+ (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);const V=a*b*c;return{text:`Kvádr má objem ${V} cm³, podstavu a = ${a} cm a b = ${b} cm.\nJak vysoký je? (c v cm)`,ans:String(c),hints:[`c = V : (a × b).`,`${V} : ${a*b}`],skill:'anal'};})(),
  (()=>{const a=ri(2,5);return{text:`Kolik krychliček s hranou 1 cm se vejde do krychle s hranou ${a} cm?`,ans:String(a*a*a),hints:[`To je objem velké krychle v cm³.`,`${a} × ${a} × ${a}`],skill:'geo'};})()
  ]
  },
@@ -1185,7 +1185,7 @@ const AREAS = [
  tasks:()=>[
  (()=>{const a=ri(2,9);return{svg:svgCuboid(a,a,a),text:`Krychle s hranou a = ${a} cm.\nVypočítej povrch S. (cm²)`,ans:String(6*a*a),hints:[`Krychle má 6 stejných stěn.`,`6 × ${a} × ${a}`],skill:'geo'};})(),
  (()=>{const a=ri(2,7),b=ri(2,7),c=ri(2,7);return{svg:svgCuboid(a,b,c),text:`Kvádr: a = ${a}, b = ${b}, c = ${c} cm.\nVypočítej povrch S. (cm²)`,ans:String(2*(a*b+a*c+b*c)),hints:[`S = 2 × (ab + ac + bc).`,`2 × (${a*b} + ${a*c} + ${b*c})`],skill:'geo'};})(),
- (()=>{const a=ri(2,9);return{text:`Krychle má povrch ${6*a*a} cm².\nJaký je obsah jedné stěny? (cm²)`,ans:String(a*a),hints:[`Krychle má 6 stejných stěn.`,`${6*a*a} ÷ 6`],skill:'anal'};})(),
+ (()=>{const a=ri(2,9);return{text:`Krychle má povrch ${6*a*a} cm².\nJaký je obsah jedné stěny? (cm²)`,ans:String(a*a),hints:[`Krychle má 6 stejných stěn.`,`${6*a*a} : 6`],skill:'anal'};})(),
  (()=>{const a=ri(2,8);return{text:`Jedna stěna krychle má obsah ${a*a} cm².\nJaký je povrch celé krychle? (cm²)`,ans:String(6*a*a),hints:[`Povrch = 6 × jedna stěna.`,`6 × ${a*a}`],skill:'anal'};})(),
  (()=>{return{text:`Kolik stěn má kvádr?`,ans:'6',hints:[`Stejně jako krychle.`,`Výsledek: 6`],skill:'craft'};})(),
  (()=>{return{text:`Kolik hran má krychle?`,ans:'12',hints:[`4 dole, 4 nahoře, 4 svislé.`,`4 + 4 + 4`],skill:'craft'};})()
@@ -1199,7 +1199,7 @@ const AREAS = [
  tasks:()=>[
  (()=>{const l=ri(2,9);return{text:`Kolik cm³ je ${l} dm³?\n(1 dm³ = 1000 cm³)`,ans:String(l*1000),hints:[`Násob 1000.`,`${l} × 1000`],skill:'anal'};})(),
  (()=>{const l=ri(2,9);return{text:`Kolik litrů je ${l} dm³?\n(1 dm³ = 1 litr)`,ans:String(l),hints:[`Dm³ a litr jsou totéž.`,`Výsledek: ${l}`],skill:'anal'};})(),
- (()=>{const m=ri(2,9)*1000;return{text:`Kolik dm³ je ${m} cm³?\n(1000 cm³ = 1 dm³)`,ans:String(m/1000),hints:[`Vyděl 1000.`,`${m} ÷ 1000`],skill:'anal'};})(),
+ (()=>{const m=ri(2,9)*1000;return{text:`Kolik dm³ je ${m} cm³?\n(1000 cm³ = 1 dm³)`,ans:String(m/1000),hints:[`Vyděl 1000.`,`${m} : 1000`],skill:'anal'};})(),
  (()=>{return{text:`Z kolika čtverců se skládá síť krychle?`,ans:'6',hints:[`Tolik, kolik má krychle stěn.`,`Výsledek: 6`],skill:'craft'};})(),
  (()=>{const a=ri(2,6);return{text:`Síť krychle se skládá ze 6 čtverců se stranou ${a} cm.\nJaký je celkový obsah sítě? (cm²)`,ans:String(6*a*a),hints:[`To je povrch krychle.`,`6 × ${a} × ${a}`],skill:'craft'};})(),
  (()=>{const l=ri(2,8);return{text:`Nádrž pojme ${l} ${skl(l,'litr','litry','litrů')}.\nKolik je to dm³?`,ans:String(l),hints:[`1 litr = 1 dm³.`,`Výsledek: ${l}`],skill:'anal'};})()
@@ -1220,8 +1220,8 @@ const AREAS = [
  tc:6,
  tasks:()=>[
  (()=>{const a=ri(40,80),b=ri(30,80);const c=180-a-b;if(c<10){return{svg:svgTriangle('obecny'),text:`Trojúhelník: α = 50°, β = 60°.\nJaký je úhel γ? (°)`,ans:'70',hints:[`Součet úhlů = 180°.`,`180 - 50 - 60`],skill:'geo'};}return{svg:svgTriangle('obecny'),text:`Trojúhelník: α = ${a}°, β = ${b}°.\nJaký je úhel γ? (°)`,ans:String(c),hints:[`Součet vnitřních úhlů = 180°.`,`180 - ${a} - ${b}`],skill:'geo'};})(),
- (()=>{const a=ri(15,40)*2;return{svg:svgTriangle('rovnoram'),text:`Rovnoramenný trojúhelník má úhel u hlavního vrcholu ${a}°.\nJaké jsou oba úhly při základně? (každý °)`,ans:String((180-a)/2),hints:[`Zbývá 180 − ${a}, rozdělíš na 2 stejné.`,`(180 - ${a}) ÷ 2`],skill:'geo'};})(),
- (()=>{return{svg:svgTriangle('rovnostr',{v:['','','']}),text:`Rovnostranný trojúhelník.\nKolik stupňů má každý jeho úhel?`,ans:'60',hints:[`Všechny tři úhly jsou stejné a dají 180°.`,`180 ÷ 3`],skill:'geo'};})(),
+ (()=>{const a=ri(15,40)*2;return{svg:svgTriangle('rovnoram'),text:`Rovnoramenný trojúhelník má úhel u hlavního vrcholu ${a}°.\nJaké jsou oba úhly při základně? (každý °)`,ans:String((180-a)/2),hints:[`Zbývá 180 − ${a}, rozdělíš na 2 stejné.`,`(180 - ${a}) : 2`],skill:'geo'};})(),
+ (()=>{return{svg:svgTriangle('rovnostr',{v:['','','']}),text:`Rovnostranný trojúhelník.\nKolik stupňů má každý jeho úhel?`,ans:'60',hints:[`Všechny tři úhly jsou stejné a dají 180°.`,`180 : 3`],skill:'geo'};})(),
  (()=>{const a=ri(30,70),b=ri(30,70);const c=180-a-b;if(c<20||c>120){return{text:`Trojúhelník: α = 60°, γ = 70°.\nJaký je úhel β? (°)`,ans:'50',hints:[`180 − součet zbylých.`,`180 - 60 - 70`],skill:'geo'};}return{text:`Trojúhelník: α = ${a}°, γ = ${c}°.\nJaký je úhel β? (°)`,ans:String(b),hints:[`Součet úhlů = 180°.`,`180 - ${a} - ${c}`],skill:'geo'};})(),
  (()=>{const a=ri(35,75);return{svg:svgTriangle('pravo'),text:`Pravoúhlý trojúhelník (jeden úhel 90°) má další úhel ${a}°.\nKolik stupňů má třetí úhel?`,ans:String(90-a),hints:[`90 + ${a} + ? = 180.`,`90 - ${a}`],skill:'geo'};})(),
  (()=>{const a=ri(40,80);return{text:`Vnější úhel trojúhelníku má ${a}°.\nKolik stupňů má vnitřní úhel u téhož vrcholu?`,ans:String(180-a),hints:[`Vnitřní a vnější úhel = 180°.`,`180 - ${a}`],skill:'geo'};})()
@@ -1237,7 +1237,7 @@ const AREAS = [
  (()=>{const r=ri(3,8),s=2*r;return{text:`Rameno rovnoramenného trojúhelníku je ${r} cm, základna ${s} cm.\nJaký je obvod? (cm)`,ans:String(r+r+s),hints:[`Dvě stejná ramena + základna.`,`${r} + ${r} + ${s}`],skill:'geo'};})(),
  (()=>{return{text:`Kolik výšek má trojúhelník?`,ans:'3',hints:[`Z každého vrcholu jedna, kolmá na protější stranu.`,`Výsledek: 3`],skill:'craft'};})(),
  (()=>{return{text:`Kolik těžnic má trojúhelník?`,ans:'3',hints:[`Z každého vrcholu do středu protější strany.`,`Výsledek: 3`],skill:'craft'};})(),
- (()=>{const o=ri(12,30);const s=o/3;if(o%3!==0){return{text:`Rovnostranný trojúhelník má obvod 18 cm.\nJak dlouhá je jedna strana? (cm)`,ans:'6',hints:[`Obvod ÷ 3.`,`18 ÷ 3`],skill:'geo'};}return{text:`Rovnostranný trojúhelník má obvod ${o} cm.\nJak dlouhá je jedna strana? (cm)`,ans:String(s),hints:[`Obvod ÷ 3.`,`${o} ÷ 3`],skill:'geo'};})(),
+ (()=>{const o=ri(12,30);const s=o/3;if(o%3!==0){return{text:`Rovnostranný trojúhelník má obvod 18 cm.\nJak dlouhá je jedna strana? (cm)`,ans:'6',hints:[`Obvod : 3.`,`18 : 3`],skill:'geo'};}return{text:`Rovnostranný trojúhelník má obvod ${o} cm.\nJak dlouhá je jedna strana? (cm)`,ans:String(s),hints:[`Obvod : 3.`,`${o} : 3`],skill:'geo'};})(),
  (()=>{const a=ri(4,9),b=ri(4,9),c=ri(4,9);return{text:`Trojúhelník má strany ${a}, ${b} a ${c} cm.\nJaký je jeho obvod? (cm)`,ans:String(a+b+c),hints:[`Obvod = součet všech stran.`,`${a} + ${b} + ${c}`],skill:'geo'};})()
  ]
  },

--- a/projects/rpg-mat-6.html
+++ b/projects/rpg-mat-6.html
@@ -312,7 +312,7 @@ body::before{
 @keyframes fail-skull{0%,100%{transform:scale(1) rotate(-4deg)}50%{transform:scale(1.1) rotate(4deg)}}
 .fail-overlay .ti{font-family:var(--px);font-weight:700;font-size:26px;color:var(--red);text-shadow:3px 3px 0 #000,0 0 16px #e74c3c;margin-bottom:8px;letter-spacing:2px;position:relative;z-index:1;animation:fail-ti .5s steps(4)}
 @keyframes fail-ti{0%{transform:scale(2);opacity:0}100%{transform:scale(1);opacity:1}}
-.fail-overlay .sb{font-family:var(--vt);font-size:21px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
+.fail-overlay .sb{font-family:var(--read);font-size:17px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
 .fail-overlay .btn{position:relative;z-index:1}
 /* combo badge */
 .combo{position:absolute;right:14px;top:12px;font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);text-shadow:2px 2px 0 #000;z-index:6;opacity:0;transition:opacity .25s,font-size .25s}
@@ -360,7 +360,7 @@ body::before{
 .bt-input:focus{animation:input-pulse 1.4s ease-in-out infinite}
 @keyframes input-pulse{0%,100%{opacity:.8}50%{opacity:1}}
 .bt-input:disabled{opacity:.5;animation:none}
-.hint-box{font-family:var(--vt);font-size:21px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
+.hint-box{font-family:var(--read);font-size:17px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
 .hint-box.show{display:block;animation:hint-slide .35s ease-out}
 @keyframes hint-slide{0%{opacity:0;transform:translateY(-10px);max-height:0}100%{opacity:1;transform:translateY(0);max-height:300px}}
 .credits-chip{display:inline-flex;align-items:center;gap:5px;font-family:var(--px);font-size:13px;color:#f4d03f;background:#1a1500;border:2px solid #7a5c00;padding:2px 9px;border-radius:2px}
@@ -746,7 +746,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="bt-fb" class="feedback"></div>
  <div id="bt-explain" style="display:none;margin:8px 0">
   <label style="font-size:13px;color:var(--green);opacity:.85;display:block;margin-bottom:4px">✍ Jak jsi na to přišel? <span style="opacity:.6">(volitelně, 1–2 věty)</span></label>
-  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
+  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--read);font-size:15px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
  <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
@@ -823,7 +823,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 <div class="modal-box">
  <div id="modal-ic" style="font-size:56px;margin-bottom:10px">🎉</div>
  <div id="modal-title" style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);margin-bottom:12px;line-height:1.3;letter-spacing:.5px"></div>
- <div id="modal-txt" style="font-family:var(--vt);font-size:22px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
+ <div id="modal-txt" style="font-family:var(--read);font-size:16px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
  <button class="btn full" onclick="closeModal()">▶ POKRAČOVAT</button>
 </div>
 </div>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -298,7 +298,7 @@ body::before{
 @keyframes fail-skull{0%,100%{transform:scale(1) rotate(-4deg)}50%{transform:scale(1.1) rotate(4deg)}}
 .fail-overlay .ti{font-family:var(--px);font-weight:700;font-size:26px;color:var(--red);text-shadow:3px 3px 0 #000,0 0 16px #e74c3c;margin-bottom:8px;letter-spacing:2px;position:relative;z-index:1;animation:fail-ti .5s steps(4)}
 @keyframes fail-ti{0%{transform:scale(2);opacity:0}100%{transform:scale(1);opacity:1}}
-.fail-overlay .sb{font-family:var(--vt);font-size:21px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
+.fail-overlay .sb{font-family:var(--read);font-size:17px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
 .fail-overlay .btn{position:relative;z-index:1}
 /* combo badge */
 .combo{position:absolute;right:14px;top:12px;font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);text-shadow:2px 2px 0 #000;z-index:6;opacity:0;transition:opacity .25s,font-size .25s}
@@ -346,7 +346,7 @@ body::before{
 .bt-input:focus{animation:input-pulse 1.4s ease-in-out infinite}
 @keyframes input-pulse{0%,100%{opacity:.8}50%{opacity:1}}
 .bt-input:disabled{opacity:.5;animation:none}
-.hint-box{font-family:var(--vt);font-size:21px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
+.hint-box{font-family:var(--read);font-size:17px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
 .hint-box.show{display:block;animation:hint-slide .35s ease-out}
 .credits-chip{display:inline-flex;align-items:center;gap:5px;font-family:var(--px);font-size:13px;color:#f4d03f;background:#1a1500;border:2px solid #7a5c00;padding:2px 9px;border-radius:2px}
 #pr-avatar{display:inline-block;font-size:48px;line-height:1}
@@ -746,7 +746,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="bt-fb" class="feedback"></div>
  <div id="bt-explain" style="display:none;margin:8px 0">
   <label style="font-size:13px;color:var(--green);opacity:.85;display:block;margin-bottom:4px">✍ Jak jsi na to přišel? <span style="opacity:.6">(volitelně, 1–2 věty)</span></label>
-  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
+  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--read);font-size:15px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
  <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
@@ -823,7 +823,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 <div class="modal-box">
  <div id="modal-ic" style="font-size:56px;margin-bottom:10px">🎉</div>
  <div id="modal-title" style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);margin-bottom:12px;line-height:1.3;letter-spacing:.5px"></div>
- <div id="modal-txt" style="font-family:var(--vt);font-size:22px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
+ <div id="modal-txt" style="font-family:var(--read);font-size:16px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
  <button class="btn full" onclick="closeModal()">▶ POKRAČOVAT</button>
 </div>
 </div>

--- a/projects/rpg-mat-7.html
+++ b/projects/rpg-mat-7.html
@@ -934,13 +934,13 @@ const AREAS = [
    (()=>{const a=ri(220,680),b=ri(120,460);return{text:`Vypočítej:\n${a} + ${b} =`,ans:String(a+b),hints:[`Sčítej po řádech.`,`${a} + ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(550,990),b=ri(120,520);return{text:`Vypočítej:\n${a} - ${b} =`,ans:String(a-b),hints:[`Odečítej pod sebou, pozor na výpůjčky.`,`${a} - ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(13,49),b=ri(4,9);return{text:`Vypočítej:\n${a} × ${b} =`,ans:String(a*b),hints:[`Násob po řádech a sečti.`,`${a} × ${b}`],skill:'calc'};})(),
-   (()=>{const b=ri(3,9),q=ri(13,40),a=b*q;return{text:`Vypočítej:\n${a} ÷ ${b} =`,ans:String(q),hints:[`Kolikrát se ${b} vejde do ${a}?`,`${a} ÷ ${b}`],skill:'calc'};})(),
+   (()=>{const b=ri(3,9),q=ri(13,40),a=b*q;return{text:`Vypočítej:\n${a} : ${b} =`,ans:String(q),hints:[`Kolikrát se ${b} vejde do ${a}?`,`${a} : ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);return{text:`Vypočítej (pozor na závorku):\n${a} × (${b} + ${c}) =`,ans:String(a*(b+c)),hints:[`Nejdřív spočítej závorku.`,`${a} × ${b+c}`],skill:'calc'};})(),
    (()=>{const a=ri(1234,8765);const r=Math.round(a/100)*100;return{text:`Zaokrouhli na stovky:\n${a} ≈`,ans:String(r),hints:[`Rozhoduje číslice desítek (${Math.floor(a/10)%10}).`,`${(a%100)>=50?'Nahoru.':'Dolů.'}`],skill:'calc'};})()
   ]
  },
  {
-  id:'1-2', name:'Desetinná čísla', sub:'+ − × ÷ s čárkou',
+  id:'1-2', name:'Desetinná čísla', sub:'+ − × : s čárkou',
   mon:'🏺', mname:'HLÍNĚNÝ DŽBÁN',
   intro:'Z prasklého džbánu vytékají kapky. Spočítej desetinná čísla, než se vyprázdní.',
   tc:6,
@@ -948,7 +948,7 @@ const AREAS = [
    (()=>{const a=ri(11,89)/10,b=ri(11,89)/10;const ans=Math.round((a+b)*10)/10;return{text:`Vypočítej:\n${cz(a)} + ${cz(b)} =`,ans:String(ans),hints:[`Zarovnej desetinné čárky pod sebe.`,`Sečti po sloupcích.`],skill:'calc'};})(),
    (()=>{const a=ri(50,98)/10,b=ri(11,Math.round(a*10)-5)/10;const ans=Math.round((a-b)*10)/10;return{text:`Vypočítej:\n${cz(a)} - ${cz(b)} =`,ans:String(ans),hints:[`Zarovnej čárky a odečti.`,`Výsledek: ${ans}`],skill:'calc'};})(),
    (()=>{const a=ri(11,49)/10,b=ri(2,9);const ans=Math.round(a*b*10)/10;return{text:`Vypočítej:\n${cz(a)} × ${b} =`,ans:String(ans),hints:[`Násob jako celá čísla, pak umísti čárku.`,`Výsledek má 1 desetinné místo.`],skill:'calc'};})(),
-   (()=>{const b=ri(2,8),q=ri(11,49)/10;const a=Math.round(q*b*10)/10;return{text:`Vypočítej:\n${cz(a)} ÷ ${b} =`,ans:String(q),hints:[`Děl jako obvykle, čárku piš nad čárkou.`,`Výsledek: ${q}`],skill:'calc'};})(),
+   (()=>{const b=ri(2,8),q=ri(11,49)/10;const a=Math.round(q*b*10)/10;return{text:`Vypočítej:\n${cz(a)} : ${b} =`,ans:String(q),hints:[`Děl jako obvykle, čárku piš nad čárkou.`,`Výsledek: ${q}`],skill:'calc'};})(),
    (()=>{const v=ri(115,985)/100;const r=Math.round(v*10)/10;return{text:`Zaokrouhli na desetiny:\n${cz(v)} ≈`,ans:String(r),hints:[`Rozhoduje místo setin.`,`Výsledek: ${r}`],skill:'calc'};})(),
    (()=>{const a=ri(15,45)/10,b=ri(15,45)/10;const ans=Math.round(a*b*100)/100;return{text:`Vypočítej:\n${cz(a)} × ${cz(b)} =`,ans:String(ans),hints:[`Násob bez čárek, pak součet des. míst = 2.`,`Výsledek: ${ans}`],skill:'calc'};})()
   ]
@@ -962,8 +962,8 @@ const AREAS = [
    (()=>{const a=ri(3,13),b=ri(3,13);return{text:`Obdélník: a = ${a} cm, b = ${b} cm.\nVypočítej obvod O. (cm)`,ans:String(2*(a+b)),hints:[`O = 2 × (a + b).`,`2 × (${a} + ${b})`],skill:'geo'};})(),
    (()=>{const a=ri(3,13),b=ri(3,13);return{text:`Obdélník: a = ${a} cm, b = ${b} cm.\nVypočítej obsah S. (cm²)`,ans:String(a*b),hints:[`S = a × b.`,`${a} × ${b}`],skill:'geo'};})(),
    (()=>{const a=ri(4,15);return{text:`Čtverec se stranou a = ${a} cm.\nVypočítej obsah S. (cm²)`,ans:String(a*a),hints:[`S = a × a.`,`${a} × ${a}`],skill:'geo'};})(),
-   (()=>{const z=ri(4,12),v=ri(3,10);const S=z*v/2;const ans=Number.isInteger(S)?String(S):cz(S);return{svg:svgTriangle('obecny'),text:`Trojúhelník: základna z = ${z} cm, výška v = ${v} cm.\nVypočítej obsah S. (cm²)`,ans,hints:[`S = (z × v) ÷ 2.`,`(${z} × ${v}) ÷ 2`],skill:'geo'};})(),
-   (()=>{const a=ri(4,12),b=ri(2,9),S=a*b;return{text:`Obdélník má obsah ${S} cm² a stranu a = ${a} cm.\nJak dlouhá je strana b? (cm)`,ans:String(b),hints:[`b = S ÷ a.`,`${S} ÷ ${a}`],skill:'anal'};})(),
+   (()=>{const z=ri(4,12),v=ri(3,10);const S=z*v/2;const ans=Number.isInteger(S)?String(S):cz(S);return{svg:svgTriangle('obecny'),text:`Trojúhelník: základna z = ${z} cm, výška v = ${v} cm.\nVypočítej obsah S. (cm²)`,ans,hints:[`S = (z × v) : 2.`,`(${z} × ${v}) : 2`],skill:'geo'};})(),
+   (()=>{const a=ri(4,12),b=ri(2,9),S=a*b;return{text:`Obdélník má obsah ${S} cm² a stranu a = ${a} cm.\nJak dlouhá je strana b? (cm)`,ans:String(b),hints:[`b = S : a.`,`${S} : ${a}`],skill:'anal'};})(),
    (()=>{const a=ri(5,12),b=ri(5,12);return{text:`Zahrada chrámu má rozměry ${a} m × ${b} m.\nKolik metrů provazu je třeba na obvod? (m)`,ans:String(2*(a+b)),hints:[`Obvod obdélníku.`,`2 × (${a} + ${b})`],skill:'anal'};})()
   ]
  }
@@ -981,11 +981,11 @@ const AREAS = [
   intro:'Starý písař zapisuje zlomky na papyrus. Pomoz mu je zkrátit na základní tvar.',
   mc:true, tc:6,
   tasks:()=>[
-   (()=>{const g=ri(2,6),a=ri(1,4),b=ri(a+1,7);return{text:`Zkrať zlomek a napiš nový ČITATEL:\n${a*g}/${b*g}`,ans:String(a),hints:[`Vyděl čitatele i jmenovatele číslem ${g}.`,`${a*g} ÷ ${g}`],skill:'calc'};})(),
-   (()=>{const g=ri(2,6),a=ri(1,4),b=ri(a+1,7);return{text:`Zkrať zlomek a napiš nový JMENOVATEL:\n${a*g}/${b*g}`,ans:String(b),hints:[`Vyděl obě čísla jejich společným dělitelem ${g}.`,`${b*g} ÷ ${g}`],skill:'calc'};})(),
+   (()=>{const g=ri(2,6),a=ri(1,4),b=ri(a+1,7);return{text:`Zkrať zlomek a napiš nový ČITATEL:\n${a*g}/${b*g}`,ans:String(a),hints:[`Vyděl čitatele i jmenovatele číslem ${g}.`,`${a*g} : ${g}`],skill:'calc'};})(),
+   (()=>{const g=ri(2,6),a=ri(1,4),b=ri(a+1,7);return{text:`Zkrať zlomek a napiš nový JMENOVATEL:\n${a*g}/${b*g}`,ans:String(b),hints:[`Vyděl obě čísla jejich společným dělitelem ${g}.`,`${b*g} : ${g}`],skill:'calc'};})(),
    (()=>{const a=ri(1,5),b=ri(a+1,8),k=ri(2,5);return{text:`Rozšiř zlomek ${k}× a napiš nový ČITATEL:\n${a}/${b}`,ans:String(a*k),hints:[`Násob čitatele i jmenovatele ${k}.`,`${a} × ${k}`],skill:'calc'};})(),
    (()=>{const a=ri(1,5),b=ri(a+1,8);const g=gcd(a,b);return{text:`Je zlomek ${a}/${b} v základním tvaru?\n(napiš jeho největšího společného dělitele čitatele a jmenovatele)`,ans:String(g),hints:[`NSD(${a}, ${b}). Je-li 1, zlomek už zkrátit nejde.`,`Výsledek: ${g}`],skill:'anal'};})(),
-   (()=>{const d=ri(3,9),num=ri(d+1,d*3);const w=Math.floor(num/d);return{text:`Kolikrát se celek vejde do zlomku ${num}/${d}?\n(celá část smíšeného čísla)`,ans:String(w),hints:[`Kolikrát se ${d} vejde do ${num}?`,`${num} ÷ ${d} (celá část)`],skill:'calc'};})(),
+   (()=>{const d=ri(3,9),num=ri(d+1,d*3);const w=Math.floor(num/d);return{text:`Kolikrát se celek vejde do zlomku ${num}/${d}?\n(celá část smíšeného čísla)`,ans:String(w),hints:[`Kolikrát se ${d} vejde do ${num}?`,`${num} : ${d} (celá část)`],skill:'calc'};})(),
    (()=>{const w=ri(2,5),d=ri(3,7),num=ri(1,d-1);const imp=w*d+num;return{text:`Převeď na nepravý zlomek a napiš ČITATEL:\n${w} a ${num}/${d}`,ans:String(imp),hints:[`Celé × jmenovatel + čitatel.`,`${w} × ${d} + ${num}`],skill:'calc'};})()
   ]
  },
@@ -1004,15 +1004,15 @@ const AREAS = [
   ]
  },
  {
-  id:'2-3', name:'Násobení a dělení zlomků', sub:'× ÷ a zlomkem z čísla',
+  id:'2-3', name:'Násobení a dělení zlomků', sub:'× : a zlomkem z čísla',
   mon:'🐍', mname:'HAD HIEROGLYFŮ',
   intro:'Posvátný had se svíjí kolem sloupu. Rozluští hieroglyfy, když zvládneš násobit zlomky.',
   tc:6,
   tasks:()=>[
    (()=>{const a=ri(1,4),b=ri(2,5),c=ri(1,4),d=ri(2,5);const num=a*c,den=b*d,g=gcd(num,den);const an=num/g,ad=den/g;const ans=ad===1?String(an):`${an}/${ad}`;return{text:`Vypočítej (zkrať):\n${a}/${b} × ${c}/${d} =`,ans,hints:[`Násob čitatel × čitatel, jmenovatel × jmenovatel.`,`(${a}×${c})/(${b}×${d})`],skill:'calc'};})(),
-   (()=>{const b=ri(2,6),a=ri(1,b-1),n=ri(2,6)*b;const ans=n/b*a;return{text:`Vypočítej zlomek z čísla:\n${a}/${b} z ${n} =`,ans:String(ans),hints:[`Vyděl ${n} jmenovatelem, pak × čitatel.`,`${n} ÷ ${b} × ${a}`],skill:'calc'};})(),
-   (()=>{const a=ri(1,4),b=ri(2,6),c=ri(2,5);const num=a,den=b*c,g=gcd(num,den);const an=num/g,ad=den/g;const ans=ad===1?String(an):`${an}/${ad}`;return{text:`Vypočítej (zkrať):\n${a}/${b} ÷ ${c} =`,ans,hints:[`Dělení = násobení převrácenou hodnotou (× 1/${c}).`,`${a}/(${b}×${c})`],skill:'calc'};})(),
-   (()=>{const a=ri(1,4),b=ri(2,5),c=ri(1,4),d=ri(2,5);const num=a*d,den=b*c,g=gcd(num,den);const an=num/g,ad=den/g;const ans=ad===1?String(an):`${an}/${ad}`;return{text:`Vypočítej (zkrať):\n${a}/${b} ÷ ${c}/${d} =`,ans,hints:[`Děleno zlomkem = násob převráceným: × ${d}/${c}.`,`(${a}×${d})/(${b}×${c})`],skill:'calc'};})(),
+   (()=>{const b=ri(2,6),a=ri(1,b-1),n=ri(2,6)*b;const ans=n/b*a;return{text:`Vypočítej zlomek z čísla:\n${a}/${b} z ${n} =`,ans:String(ans),hints:[`Vyděl ${n} jmenovatelem, pak × čitatel.`,`${n} : ${b} × ${a}`],skill:'calc'};})(),
+   (()=>{const a=ri(1,4),b=ri(2,6),c=ri(2,5);const num=a,den=b*c,g=gcd(num,den);const an=num/g,ad=den/g;const ans=ad===1?String(an):`${an}/${ad}`;return{text:`Vypočítej (zkrať):\n${a}/${b} : ${c} =`,ans,hints:[`Dělení = násobení převrácenou hodnotou (× 1/${c}).`,`${a}/(${b}×${c})`],skill:'calc'};})(),
+   (()=>{const a=ri(1,4),b=ri(2,5),c=ri(1,4),d=ri(2,5);const num=a*d,den=b*c,g=gcd(num,den);const an=num/g,ad=den/g;const ans=ad===1?String(an):`${an}/${ad}`;return{text:`Vypočítej (zkrať):\n${a}/${b} : ${c}/${d} =`,ans,hints:[`Děleno zlomkem = násob převráceným: × ${d}/${c}.`,`(${a}×${d})/(${b}×${c})`],skill:'calc'};})(),
    (()=>{const b=ri(2,5),k=ri(2,4),a=ri(1,b-1>=1?b-1:1);const ans=`${a*k}/${b}`;const g=gcd(a*k,b);const sans=b/g===1?String(a*k/g):`${a*k/g}/${b/g}`;return{text:`Vypočítej (zkrať):\n${a}/${b} × ${k} =`,ans:sans,hints:[`Násob jen čitatel.`,`(${a}×${k})/${b}`],skill:'calc'};})(),
    (()=>{const den=ri(3,6),a=ri(1,den-1);const pizza=den;const eaten=a;return{text:`Pizza má ${den} ${skl(den,'díl','díly','dílů')}. Každý kamarád snědl 1 díl a bylo jich ${a}.\nJakou částí pizzy to je? (zlomek)`,ans:`${eaten}/${pizza}`,hints:[`Snědené díly / všechny díly.`,`${a}/${den}`],skill:'anal'};})()
   ]
@@ -1047,8 +1047,8 @@ const AREAS = [
   tasks:()=>[
    (()=>{const a=ri(2,12),b=ri(2,9);return{text:`Vypočítej:\n(-${a}) × ${b} =`,ans:String(-a*b),hints:[`Mínus × plus = mínus.`,`-(${a} × ${b})`],skill:'calc'};})(),
    (()=>{const a=ri(2,12),b=ri(2,9);return{text:`Vypočítej:\n(-${a}) × (-${b}) =`,ans:String(a*b),hints:[`Mínus × mínus = plus.`,`${a} × ${b}`],skill:'calc'};})(),
-   (()=>{const b=ri(2,9),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ ${b} =`,ans:String(-q),hints:[`Různá znaménka → výsledek záporný.`,`-(${a} ÷ ${b})`],skill:'calc'};})(),
-   (()=>{const b=ri(2,9),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ (-${b}) =`,ans:String(q),hints:[`Stejná znaménka → výsledek kladný.`,`${a} ÷ ${b}`],skill:'calc'};})(),
+   (()=>{const b=ri(2,9),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) : ${b} =`,ans:String(-q),hints:[`Různá znaménka → výsledek záporný.`,`-(${a} : ${b})`],skill:'calc'};})(),
+   (()=>{const b=ri(2,9),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) : (-${b}) =`,ans:String(q),hints:[`Stejná znaménka → výsledek kladný.`,`${a} : ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(2,9),b=ri(2,6);return{text:`Vypočítej:\n${a} × (-${b}) + ${a} =`,ans:String(-a*b+a),hints:[`Nejdřív násobení: ${a}×(-${b})=${-a*b}, pak přičti ${a}.`,`${-a*b}+${a} = ${-a*b+a}`],skill:'calc'};})(),
    (()=>{const dluh=ri(3,8),mes=ri(3,6);return{text:`Každý měsíc se zadlužíš o ${dluh} Kč (tedy -${dluh}).\nJaký je stav po ${mes} ${skl(mes,'měsíci','měsících','měsících')}? (Kč)`,ans:String(-dluh*mes),hints:[`${mes} × (-${dluh}).`,`-(${mes} × ${dluh})`],skill:'anal'};})()
   ]
@@ -1081,8 +1081,8 @@ const AREAS = [
   intro:'Strážce vah rozděluje poklady ve správném poměru. Ukaž, že poměrům rozumíš.',
   mc:true, tc:6,
   tasks:()=>[
-   (()=>{const g=ri(2,6),a=ri(1,5),b=ri(1,5);return{text:`Zkrať poměr a napiš PRVNÍ člen:\n${a*g} : ${b*g}`,ans:String(a),hints:[`Vyděl oba členy číslem ${g}.`,`${a*g} ÷ ${g}`],skill:'calc'};})(),
-   (()=>{const g=ri(2,6),a=ri(1,5),b=ri(1,5);return{text:`Zkrať poměr a napiš DRUHÝ člen:\n${a*g} : ${b*g}`,ans:String(b),hints:[`Vyděl oba členy společným dělitelem ${g}.`,`${b*g} ÷ ${g}`],skill:'calc'};})(),
+   (()=>{const g=ri(2,6),a=ri(1,5),b=ri(1,5);return{text:`Zkrať poměr a napiš PRVNÍ člen:\n${a*g} : ${b*g}`,ans:String(a),hints:[`Vyděl oba členy číslem ${g}.`,`${a*g} : ${g}`],skill:'calc'};})(),
+   (()=>{const g=ri(2,6),a=ri(1,5),b=ri(1,5);return{text:`Zkrať poměr a napiš DRUHÝ člen:\n${a*g} : ${b*g}`,ans:String(b),hints:[`Vyděl oba členy společným dělitelem ${g}.`,`${b*g} : ${g}`],skill:'calc'};})(),
    (()=>{const a=ri(2,6),b=ri(2,6);return{text:`Jaký je převrácený poměr k ${a} : ${b}?\nNapiš jeho PRVNÍ člen.`,ans:String(b),hints:[`Převrácený poměr má členy prohozené.`,`${b} : ${a}`],skill:'anal'};})(),
    (()=>{const a=ri(2,5),b=ri(2,5),cel=ri(2,5);const sum=a+b;const dil=cel;return{text:`Poměr ${a} : ${b}, jeden díl = ${dil}.\nJaká je celková hodnota? (součet obou částí)`,ans:String(sum*dil),hints:[`Počet dílů = ${a}+${b}=${sum}. Vynásob hodnotou dílu.`,`${sum} × ${dil}`],skill:'anal'};})(),
    (()=>{const dil=ri(3,9),a=ri(2,5);return{text:`Poměr je ${a} : 1 a jeden díl má hodnotu ${dil}.\nJak velká je první část?`,ans:String(a*dil),hints:[`První část = ${a} ${skl(a,'díl','díly','dílů')}.`,`${a} × ${dil}`],skill:'anal'};})(),
@@ -1095,12 +1095,12 @@ const AREAS = [
   intro:'Pán karavany počítá zásoby na cestu pouští. Vyřeš trojčlenku — přímou i nepřímou.',
   tc:6,
   tasks:()=>[
-   (()=>{const k=ri(2,5),cena1=ri(2,8)*k;const ks=ri(2,6);return{text:`${k} ${skl(k,'sešit stojí','sešity stojí','sešitů stojí')} ${cena1} Kč.\nKolik stojí ${k*ks} stejných sešitů? (Kč)`,ans:String(cena1*ks),hints:[`Přímá úměrnost: víc kusů → víc peněz.`,`${cena1} ÷ ${k} × ${k*ks}`],skill:'anal'};})(),
-   (()=>{const naJednu=ri(3,8),lidi=ri(2,5);return{text:`1 dělník vykope studnu za ${naJednu*lidi} dní.\nZa kolik dní ji vykope ${lidi} dělníků? (nepřímá úměrnost)`,ans:String(naJednu),hints:[`Nepřímá úměrnost: víc dělníků → méně dní.`,`${naJednu*lidi} ÷ ${lidi}`],skill:'anal'};})(),
+   (()=>{const k=ri(2,5),cena1=ri(2,8)*k;const ks=ri(2,6);return{text:`${k} ${skl(k,'sešit stojí','sešity stojí','sešitů stojí')} ${cena1} Kč.\nKolik stojí ${k*ks} stejných sešitů? (Kč)`,ans:String(cena1*ks),hints:[`Přímá úměrnost: víc kusů → víc peněz.`,`${cena1} : ${k} × ${k*ks}`],skill:'anal'};})(),
+   (()=>{const naJednu=ri(3,8),lidi=ri(2,5);return{text:`1 dělník vykope studnu za ${naJednu*lidi} dní.\nZa kolik dní ji vykope ${lidi} dělníků? (nepřímá úměrnost)`,ans:String(naJednu),hints:[`Nepřímá úměrnost: víc dělníků → méně dní.`,`${naJednu*lidi} : ${lidi}`],skill:'anal'};})(),
    (()=>{const naKm=ri(2,4),km=ri(3,8);return{text:`Auto spotřebuje ${naKm} litry na 10 km.\nKolik litrů spotřebuje na ${km*10} km?`,ans:String(naKm*km),hints:[`Přímá úměrnost.`,`${naKm} × ${km}`],skill:'anal'};})(),
-   (()=>{const rychlost=ri(2,5),cas=ri(2,6);const draha=rychlost*cas;return{text:`Při rychlosti ${rychlost*10} km/h trvá cesta ${cas} h.\nJak dlouho potrvá při dvojnásobné rychlosti? (h)`,ans:cz(cas/2),hints:[`Nepřímá úměrnost: 2× rychleji → poloviční čas.`,`${cas} ÷ 2`],skill:'anal'};})(),
+   (()=>{const rychlost=ri(2,5),cas=ri(2,6);const draha=rychlost*cas;return{text:`Při rychlosti ${rychlost*10} km/h trvá cesta ${cas} h.\nJak dlouho potrvá při dvojnásobné rychlosti? (h)`,ans:cz(cas/2),hints:[`Nepřímá úměrnost: 2× rychleji → poloviční čas.`,`${cas} : 2`],skill:'anal'};})(),
    (()=>{const balik=ri(2,5),koni=ri(2,4),dny=ri(2,5);return{text:`${koni} koně snědí ${balik*koni} ${skl(balik*koni,'balík','balíky','balíků')} sena za den.\nKolik balíků sní za ${dny} ${skl(dny,'den','dny','dní')}?`,ans:String(balik*koni*dny),hints:[`Přímá úměrnost s počtem dní.`,`${balik*koni} × ${dny}`],skill:'anal'};})(),
-   (()=>{const za3=ri(2,5)*3;const ks=za3/3;return{text:`Za 3 hodiny práce dostaneš ${za3*10} Kč.\nKolik dostaneš za 5 hodin? (Kč)`,ans:String(ks*10*5),hints:[`Spočítej odměnu za 1 hodinu, pak × 5.`,`${za3*10} ÷ 3 × 5`],skill:'anal'};})()
+   (()=>{const za3=ri(2,5)*3;const ks=za3/3;return{text:`Za 3 hodiny práce dostaneš ${za3*10} Kč.\nKolik dostaneš za 5 hodin? (Kč)`,ans:String(ks*10*5),hints:[`Spočítej odměnu za 1 hodinu, pak × 5.`,`${za3*10} : 3 × 5`],skill:'anal'};})()
   ]
  },
  {
@@ -1110,11 +1110,11 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const mer=[100,200,500][ri(0,2)];const cm=ri(2,8);return{text:`Měřítko mapy 1 : ${mer}.\nÚsečka na mapě měří ${cm} cm. Kolik cm je to ve skutečnosti?`,ans:String(cm*mer),hints:[`Skutečnost = mapa × měřítko.`,`${cm} × ${mer}`],skill:'anal'};})(),
-   (()=>{const mer=[100,1000][ri(0,1)];const cm=ri(2,9);const skut=cm*mer;const m=skut/100;return{text:`Měřítko 1 : ${mer}. Na mapě ${cm} cm.\nKolik je to ve skutečnosti v METRECH?`,ans:cz(m),hints:[`Nejdřív cm ve skutečnosti, pak ÷ 100 na metry.`,`${cm} × ${mer} ÷ 100`],skill:'anal'};})(),
-   (()=>{const mer=[100,200,500][ri(0,2)];const cmMap=ri(2,8);const real=cmMap*mer;return{text:`Měřítko 1 : ${mer}. Ve skutečnosti ${real} cm.\nKolik cm to měří na mapě?`,ans:String(cmMap),hints:[`Mapa = skutečnost ÷ měřítko.`,`${real} ÷ ${mer}`],skill:'anal'};})(),
+   (()=>{const mer=[100,1000][ri(0,1)];const cm=ri(2,9);const skut=cm*mer;const m=skut/100;return{text:`Měřítko 1 : ${mer}. Na mapě ${cm} cm.\nKolik je to ve skutečnosti v METRECH?`,ans:cz(m),hints:[`Nejdřív cm ve skutečnosti, pak : 100 na metry.`,`${cm} × ${mer} : 100`],skill:'anal'};})(),
+   (()=>{const mer=[100,200,500][ri(0,2)];const cmMap=ri(2,8);const real=cmMap*mer;return{text:`Měřítko 1 : ${mer}. Ve skutečnosti ${real} cm.\nKolik cm to měří na mapě?`,ans:String(cmMap),hints:[`Mapa = skutečnost : měřítko.`,`${real} : ${mer}`],skill:'anal'};})(),
    (()=>{const km=ri(2,9);const cm=km*2;return{text:`Měřítko 1 : 100000 znamená 1 cm = 1 km.\nVzdálenost ${km} km je na mapě kolik cm?`,ans:String(km),hints:[`Při 1:100000 platí 1 cm = 1 km.`,`${km} km → ${km} cm`],skill:'anal'};})(),
    (()=>{const mer=[50,100][ri(0,1)];const cm=ri(2,6);return{text:`Plán pokoje v měřítku 1 : ${mer}.\nNa plánu ${cm} cm. Kolik cm ve skutečnosti?`,ans:String(cm*mer),hints:[`Skutečnost = plán × ${mer}.`,`${cm} × ${mer}`],skill:'anal'};})(),
-   (()=>{const mer=[200,500][ri(0,1)];const realm=ri(2,6)*mer/100;const mapcm=realm*100/mer;return{text:`Měřítko 1 : ${mer}. Skutečná délka ${cz(realm)} m.\nKolik cm to je na mapě?`,ans:String(mapcm),hints:[`Převeď metry na cm (× 100), pak ÷ ${mer}.`,`${cz(realm)} × 100 ÷ ${mer}`],skill:'anal'};})()
+   (()=>{const mer=[200,500][ri(0,1)];const realm=ri(2,6)*mer/100;const mapcm=realm*100/mer;return{text:`Měřítko 1 : ${mer}. Skutečná délka ${cz(realm)} m.\nKolik cm to je na mapě?`,ans:String(mapcm),hints:[`Převeď metry na cm (× 100), pak : ${mer}.`,`${cz(realm)} × 100 : ${mer}`],skill:'anal'};})()
   ]
  }
  ]
@@ -1131,12 +1131,12 @@ const AREAS = [
   intro:'Hromady zlatých mincí čekají na rozdělení. Hlídač zkouší, jestli umíš počítat procenta.',
   mc:true, tc:6,
   tasks:()=>[
-   (()=>{const z=ri(2,9)*100,p=[10,20,25,50][ri(0,3)];return{text:`Vypočítej:\n${p} % z ${z} =`,ans:String(z*p/100),hints:[`1 % = ${z}/100 = ${z/100}. Pak × ${p}.`,`${z} ÷ 100 × ${p}`],skill:'calc'};})(),
+   (()=>{const z=ri(2,9)*100,p=[10,20,25,50][ri(0,3)];return{text:`Vypočítej:\n${p} % z ${z} =`,ans:String(z*p/100),hints:[`1 % = ${z}/100 = ${z/100}. Pak × ${p}.`,`${z} : 100 × ${p}`],skill:'calc'};})(),
    (()=>{const z=ri(2,9)*10,p=[10,20,30,40,50][ri(0,4)];return{text:`Vypočítej:\n${p} % z ${z} =`,ans:String(z*p/100),hints:[`1 % = ${z/100}.`,`${z/100} × ${p}`],skill:'calc'};})(),
-   (()=>{const z=ri(2,9)*100;return{text:`Kolik je 1 % z ${z}?`,ans:String(z/100),hints:[`1 % = celek ÷ 100.`,`${z} ÷ 100`],skill:'calc'};})(),
+   (()=>{const z=ri(2,9)*100;return{text:`Kolik je 1 % z ${z}?`,ans:String(z/100),hints:[`1 % = celek : 100.`,`${z} : 100`],skill:'calc'};})(),
    (()=>{const z=ri(2,8)*100;return{text:`Kolik je 100 % z ${z}?`,ans:String(z),hints:[`100 % = celek.`,`Výsledek: ${z}`],skill:'anal'};})(),
-   (()=>{const z=ri(2,8)*200;return{text:`Kolik je 50 % z ${z}?`,ans:String(z/2),hints:[`50 % = polovina.`,`${z} ÷ 2`],skill:'calc'};})(),
-   (()=>{const z=ri(2,6)*100;return{text:`Kolik je 75 % z ${z}?`,ans:String(z*3/4),hints:[`75 % = tři čtvrtiny.`,`${z} ÷ 4 × 3`],skill:'calc'};})()
+   (()=>{const z=ri(2,8)*200;return{text:`Kolik je 50 % z ${z}?`,ans:String(z/2),hints:[`50 % = polovina.`,`${z} : 2`],skill:'calc'};})(),
+   (()=>{const z=ri(2,6)*100;return{text:`Kolik je 75 % z ${z}?`,ans:String(z*3/4),hints:[`75 % = tři čtvrtiny.`,`${z} : 4 × 3`],skill:'calc'};})()
   ]
  },
  {
@@ -1145,12 +1145,12 @@ const AREAS = [
   intro:'Ve zlaté urně jsou ukryty výpočty pozpátku. Najdi počet procent i původní základ.',
   tc:6,
   tasks:()=>[
-   (()=>{const z=ri(2,8)*100,cast=z/100*[10,20,25,50][ri(0,3)];const p=Math.round(cast/z*100);return{text:`Kolik procent je ${cast} z ${z}?\n(napiš číslo bez znaku %)`,ans:String(p),hints:[`% = část ÷ celek × 100.`,`${cast} ÷ ${z} × 100`],skill:'anal'};})(),
-   (()=>{const cel=ri(2,8)*50;const cast=cel/2;return{text:`${cast} je kolik procent z ${cel}?`,ans:'50',hints:[`Je to přesně polovina.`,`${cast} ÷ ${cel} × 100`],skill:'anal'};})(),
-   (()=>{const p=[10,20,25,50][ri(0,3)];const cast=ri(2,9)*p/100*100;const zaklad=cast*100/p;return{text:`${cast} je ${p} % z neznámého čísla.\nJaký je celek (základ)?`,ans:String(zaklad),hints:[`Základ = část ÷ procenta × 100.`,`${cast} ÷ ${p} × 100`],skill:'anal'};})(),
+   (()=>{const z=ri(2,8)*100,cast=z/100*[10,20,25,50][ri(0,3)];const p=Math.round(cast/z*100);return{text:`Kolik procent je ${cast} z ${z}?\n(napiš číslo bez znaku %)`,ans:String(p),hints:[`% = část : celek × 100.`,`${cast} : ${z} × 100`],skill:'anal'};})(),
+   (()=>{const cel=ri(2,8)*50;const cast=cel/2;return{text:`${cast} je kolik procent z ${cel}?`,ans:'50',hints:[`Je to přesně polovina.`,`${cast} : ${cel} × 100`],skill:'anal'};})(),
+   (()=>{const p=[10,20,25,50][ri(0,3)];const cast=ri(2,9)*p/100*100;const zaklad=cast*100/p;return{text:`${cast} je ${p} % z neznámého čísla.\nJaký je celek (základ)?`,ans:String(zaklad),hints:[`Základ = část : procenta × 100.`,`${cast} : ${p} × 100`],skill:'anal'};})(),
    (()=>{const zaklad=ri(2,9)*100;const cast=zaklad/100;return{text:`${cast} je 1 % z nějakého čísla.\nJaký je ten celek?`,ans:String(zaklad),hints:[`Celek = 1 % × 100.`,`${cast} × 100`],skill:'anal'};})(),
-   (()=>{const cel=ri(2,8)*20;const cast=cel/4;return{text:`Žák získal ${cast} z ${cel} bodů.\nKolik procent to je?`,ans:'25',hints:[`Je to čtvrtina.`,`${cast} ÷ ${cel} × 100`],skill:'anal'};})(),
-   (()=>{const cena=ri(2,8)*100;const sleva=cena*20/100;const nova=cena-sleva;return{text:`Bota stála ${cena} Kč, sleva 20 %.\nKolik Kč stojí po slevě?`,ans:String(nova),hints:[`Spočítej 20 % a odečti od ceny.`,`${cena} - ${cena} ÷ 100 × 20`],skill:'anal'};})()
+   (()=>{const cel=ri(2,8)*20;const cast=cel/4;return{text:`Žák získal ${cast} z ${cel} bodů.\nKolik procent to je?`,ans:'25',hints:[`Je to čtvrtina.`,`${cast} : ${cel} × 100`],skill:'anal'};})(),
+   (()=>{const cena=ri(2,8)*100;const sleva=cena*20/100;const nova=cena-sleva;return{text:`Bota stála ${cena} Kč, sleva 20 %.\nKolik Kč stojí po slevě?`,ans:String(nova),hints:[`Spočítej 20 % a odečti od ceny.`,`${cena} - ${cena} : 100 × 20`],skill:'anal'};})()
   ]
  },
  {
@@ -1159,12 +1159,12 @@ const AREAS = [
   intro:'Pokladník faraona vede účty celé říše. Vyřeš slovní úlohy s procenty bez chyby.',
   tc:6,
   tasks:()=>[
-   (()=>{const cena=ri(2,9)*100,p=[10,20,25][ri(0,2)];const navic=cena*p/100;return{text:`Zboží za ${cena} Kč zdražilo o ${p} %.\nO kolik Kč se zvýšila cena?`,ans:String(navic),hints:[`Spočítej ${p} % z ceny.`,`${cena} ÷ 100 × ${p}`],skill:'anal'};})(),
-   (()=>{const cena=ri(2,9)*100,p=[10,20,25][ri(0,2)];const nova=cena+cena*p/100;return{text:`Zboží za ${cena} Kč zdražilo o ${p} %.\nKolik Kč stojí teď?`,ans:String(nova),hints:[`Přičti zdražení k původní ceně.`,`${cena} + ${cena} ÷ 100 × ${p}`],skill:'anal'};})(),
-   (()=>{const zaci=ri(2,5)*20;const nemoc=zaci*15/100;return{text:`Ve škole je ${zaci} žáků, 15 % onemocnělo.\nKolik žáků chybí?`,ans:String(nemoc),hints:[`15 % z ${zaci}.`,`${zaci} ÷ 100 × 15`],skill:'anal'};})(),
-   (()=>{const puv=ri(2,8)*100;const nova=puv*80/100;return{text:`Cena ${puv} Kč klesla o 20 %.\nKolik Kč je nová cena?`,ans:String(nova),hints:[`Po slevě zůstává 80 %.`,`${puv} ÷ 100 × 80`],skill:'anal'};})(),
-   (()=>{const cena=ri(2,8)*100;const dph=cena*21/100;return{text:`Cena bez DPH je ${cena} Kč, DPH 21 %.\nKolik Kč je samotné DPH?`,ans:String(dph),hints:[`21 % z ${cena}.`,`${cena} ÷ 100 × 21`],skill:'anal'};})(),
-   (()=>{const sporeni=ri(2,8)*1000;const urok=sporeni*2/100;return{text:`Uložíš ${sporeni} Kč s ročním úrokem 2 %.\nKolik Kč úroku dostaneš za rok?`,ans:String(urok),hints:[`2 % z ${sporeni}.`,`${sporeni} ÷ 100 × 2`],skill:'anal'};})()
+   (()=>{const cena=ri(2,9)*100,p=[10,20,25][ri(0,2)];const navic=cena*p/100;return{text:`Zboží za ${cena} Kč zdražilo o ${p} %.\nO kolik Kč se zvýšila cena?`,ans:String(navic),hints:[`Spočítej ${p} % z ceny.`,`${cena} : 100 × ${p}`],skill:'anal'};})(),
+   (()=>{const cena=ri(2,9)*100,p=[10,20,25][ri(0,2)];const nova=cena+cena*p/100;return{text:`Zboží za ${cena} Kč zdražilo o ${p} %.\nKolik Kč stojí teď?`,ans:String(nova),hints:[`Přičti zdražení k původní ceně.`,`${cena} + ${cena} : 100 × ${p}`],skill:'anal'};})(),
+   (()=>{const zaci=ri(2,5)*20;const nemoc=zaci*15/100;return{text:`Ve škole je ${zaci} žáků, 15 % onemocnělo.\nKolik žáků chybí?`,ans:String(nemoc),hints:[`15 % z ${zaci}.`,`${zaci} : 100 × 15`],skill:'anal'};})(),
+   (()=>{const puv=ri(2,8)*100;const nova=puv*80/100;return{text:`Cena ${puv} Kč klesla o 20 %.\nKolik Kč je nová cena?`,ans:String(nova),hints:[`Po slevě zůstává 80 %.`,`${puv} : 100 × 80`],skill:'anal'};})(),
+   (()=>{const cena=ri(2,8)*100;const dph=cena*21/100;return{text:`Cena bez DPH je ${cena} Kč, DPH 21 %.\nKolik Kč je samotné DPH?`,ans:String(dph),hints:[`21 % z ${cena}.`,`${cena} : 100 × 21`],skill:'anal'};})(),
+   (()=>{const sporeni=ri(2,8)*1000;const urok=sporeni*2/100;return{text:`Uložíš ${sporeni} Kč s ročním úrokem 2 %.\nKolik Kč úroku dostaneš za rok?`,ans:String(urok),hints:[`2 % z ${sporeni}.`,`${sporeni} : 100 × 2`],skill:'anal'};})()
   ]
  }
  ]
@@ -1233,9 +1233,9 @@ const AREAS = [
   tasks:()=>[
    (()=>{const a=ri(4,12),v=ri(3,9);return{svg:svgParallelogram(a,v),text:`Rovnoběžník: strana a = ${a} cm, výška v = ${v} cm.\nVypočítej obsah S. (cm²)`,ans:String(a*v),hints:[`S = a × v.`,`${a} × ${v}`],skill:'geo'};})(),
    (()=>{const a=ri(5,12),b=ri(4,10);return{svg:svgParallelogram(a,b),text:`Rovnoběžník má strany ${a} cm a ${b} cm.\nVypočítej obvod O. (cm)`,ans:String(2*(a+b)),hints:[`O = 2 × (a + b).`,`2 × (${a} + ${b})`],skill:'geo'};})(),
-   (()=>{const a=ri(5,12),c=ri(3,a-1),v=ri(2,8);const S=(a+c)*v/2;const ans=Number.isInteger(S)?String(S):cz(S);return{svg:svgTrapezoid(a,c,v),text:`Lichoběžník: základny a = ${a} cm, c = ${c} cm, výška v = ${v} cm.\nVypočítej obsah S. (cm²)`,ans,hints:[`S = (a + c) ÷ 2 × v.`,`(${a} + ${c}) ÷ 2 × ${v}`],skill:'geo'};})(),
-   (()=>{const z=ri(4,12),v=ri(3,9);const S=z*v/2;const ans=Number.isInteger(S)?String(S):cz(S);return{svg:svgTriangle('obecny'),text:`Trojúhelník: základna ${z} cm, výška ${v} cm.\nVypočítej obsah S. (cm²)`,ans,hints:[`S = (z × v) ÷ 2.`,`(${z} × ${v}) ÷ 2`],skill:'geo'};})(),
-   (()=>{const a=ri(4,10),v=ri(3,8),S=a*v;return{text:`Rovnoběžník má obsah ${S} cm² a stranu a = ${a} cm.\nJak velká je výška v? (cm)`,ans:String(v),hints:[`v = S ÷ a.`,`${S} ÷ ${a}`],skill:'anal'};})(),
+   (()=>{const a=ri(5,12),c=ri(3,a-1),v=ri(2,8);const S=(a+c)*v/2;const ans=Number.isInteger(S)?String(S):cz(S);return{svg:svgTrapezoid(a,c,v),text:`Lichoběžník: základny a = ${a} cm, c = ${c} cm, výška v = ${v} cm.\nVypočítej obsah S. (cm²)`,ans,hints:[`S = (a + c) : 2 × v.`,`(${a} + ${c}) : 2 × ${v}`],skill:'geo'};})(),
+   (()=>{const z=ri(4,12),v=ri(3,9);const S=z*v/2;const ans=Number.isInteger(S)?String(S):cz(S);return{svg:svgTriangle('obecny'),text:`Trojúhelník: základna ${z} cm, výška ${v} cm.\nVypočítej obsah S. (cm²)`,ans,hints:[`S = (z × v) : 2.`,`(${z} × ${v}) : 2`],skill:'geo'};})(),
+   (()=>{const a=ri(4,10),v=ri(3,8),S=a*v;return{text:`Rovnoběžník má obsah ${S} cm² a stranu a = ${a} cm.\nJak velká je výška v? (cm)`,ans:String(v),hints:[`v = S : a.`,`${S} : ${a}`],skill:'anal'};})(),
    (()=>{const a=ri(4,9);return{svg:svgParallelogram(a,a),text:`Kosočtverec má všechny strany ${a} cm.\nVypočítej obvod O. (cm)`,ans:String(4*a),hints:[`Kosočtverec má 4 stejné strany.`,`4 × ${a}`],skill:'geo'};})()
   ]
  },
@@ -1250,7 +1250,7 @@ const AREAS = [
    (()=>{const a=ri(2,9);return{svg:svgCuboid(a,a,a),text:`Krychle s hranou a = ${a} cm.\nVypočítej povrch S. (cm²)`,ans:String(6*a*a),hints:[`Krychle má 6 stejných stěn.`,`6 × ${a} × ${a}`],skill:'geo'};})(),
    (()=>{const a=ri(2,7),b=ri(2,7),c=ri(2,7);return{svg:svgCuboid(a,b,c),text:`Kvádr: a = ${a}, b = ${b}, c = ${c} cm.\nVypočítej povrch S. (cm²)`,ans:String(2*(a*b+a*c+b*c)),hints:[`S = 2 × (ab + ac + bc).`,`2 × (${a*b} + ${a*c} + ${b*c})`],skill:'geo'};})(),
    (()=>{const a=ri(2,6),b=ri(2,6),c=ri(2,6);return{svg:svgCuboid(a,b,c),text:`Akvárium tvaru kvádru: ${a} dm × ${b} dm × ${c} dm.\nKolik litrů vody se vejde?\n(1 dm³ = 1 litr)`,ans:String(a*b*c),hints:[`Objem v dm³ = počet litrů.`,`${a} × ${b} × ${c}`],skill:'anal'};})(),
-   (()=>{const a=ri(2,8),b=ri(2,8),c=ri(2,8),V=a*b*c;return{svg:svgCuboid(a,b,c),text:`Kvádr má objem ${V} cm³ a podstavu ${a} × ${b} cm.\nJak vysoký je (hrana c)? (cm)`,ans:String(c),hints:[`c = V ÷ (a × b).`,`${V} ÷ ${a*b}`],skill:'anal'};})()
+   (()=>{const a=ri(2,8),b=ri(2,8),c=ri(2,8),V=a*b*c;return{svg:svgCuboid(a,b,c),text:`Kvádr má objem ${V} cm³ a podstavu ${a} × ${b} cm.\nJak vysoký je (hrana c)? (cm)`,ans:String(c),hints:[`c = V : (a × b).`,`${V} : ${a*b}`],skill:'anal'};})()
   ]
  },
  {

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -897,8 +897,8 @@ const AREAS = [
  text:`Vypočítej:\n(-${a}) × (-${b}) =`,ans:String(ans),
  hints:[`Záporné × záporné = ?`,`Mínus krát mínus dává plus. Spočítej ${a} × ${b}.`],skill:'calc'};})(),
  (()=>{const b=ri(2,12),k=ri(2,9),a=-b*k,ans=a/b;return{
- text:`Vypočítej:\n(${a}) ÷ ${b} =`,ans:String(ans),
- hints:[`Záporné ÷ kladné = záporné.`,`|${a}| ÷ ${b} = ${Math.abs(ans)}.`],skill:'calc'};})(),
+ text:`Vypočítej:\n(${a}) : ${b} =`,ans:String(ans),
+ hints:[`Záporné : kladné = záporné.`,`|${a}| : ${b} = ${Math.abs(ans)}.`],skill:'calc'};})(),
  (()=>{const a=ri(-15,-3),b=ri(-9,-2),c=ri(2,12),ans=a-b+c;return{
  text:`Vypočítej:\n(${a}) - (${b}) + ${c} =`,ans:String(ans),
  hints:[`Nejdřív si přepiš odečítání záporného na sčítání: ${a} + ${Math.abs(b)} + ${c}.`,`Postupuj zleva doprava: ${a + Math.abs(b)} + ${c}.`],skill:'calc'};})()
@@ -941,7 +941,7 @@ const AREAS = [
  hints:[`${p} % znamená ${p}/100, tedy ${p} setin celku.`,`Spočítej ${z} × ${p} a vyděl 100.`],skill:'anal'};})(),
  (()=>{const c=ri(4,20)*10,v=ri(1,c/10)*10;const ans=Math.round(v/c*100);return{
  text:`Kolika procenty je ${v} z ${c}?\n(celé číslo)`,ans:String(ans),
- hints:[`Procento = část ÷ celek × 100.`,`Spočítej ${v} ÷ ${c} × 100.`],skill:'anal'};})(),
+ hints:[`Procento = část : celek × 100.`,`Spočítej ${v} : ${c} × 100.`],skill:'anal'};})(),
  (()=>{const p=ri(1,4)*10,z=ri(10,40)*10;const sleva=Math.round(z*p/100),ans=z-sleva;return{
  text:`Zboží stojí ${z} Kč a je zlevněno o ${p} %.\nKolik stojí teď?`,ans:String(ans),
  hints:[`Nejdřív spočítej slevu — ${p} % z ${z} Kč.`,`Sleva je ${sleva} Kč. Odečti ji od původní ceny.`],skill:'anal'};})(),
@@ -950,10 +950,10 @@ const AREAS = [
  hints:[`Spočítej zvýšení — ${p} % z ${z} Kč.`,`Zvýšení je ${navic} Kč. Přičti k původní ceně.`],skill:'anal'};})(),
  (()=>{const p=ri(2,5)*5,z=ri(8,30)*100;const ans=Math.round(z*p/100);return{
  text:`Na účtu máš ${z} Kč s úrokem ${p} % ročně.\nKolik si připíšeš za rok? (Kč)`,ans:String(ans),
- hints:[`Úrok = ${p} % z částky na účtu.`,`${z} × ${p} ÷ 100 = ?`],skill:'anal'};})(),
+ hints:[`Úrok = ${p} % z částky na účtu.`,`${z} × ${p} : 100 = ?`],skill:'anal'};})(),
  (()=>{const cases=[[20,25,5],[24,25,6],[28,25,7],[30,20,6],[25,20,5],[20,50,10],[30,10,3]];const[tot,p,v]=cases[Math.floor(Math.random()*cases.length)];return{
  text:`${v} žáků ve třídě dostalo jedničku.\nTo je ${p} % třídy.\nKolik žáků je celkem ve třídě?`,ans:String(tot),
- hints:[`Když ${p} % = ${v} žáků, kolik je 100 %?`,`Použij úměru: ${v} ÷ ${p} × 100.`],skill:'anal'};})()
+ hints:[`Když ${p} % = ${v} žáků, kolik je 100 %?`,`Použij úměru: ${v} : ${p} × 100.`],skill:'anal'};})()
  ]
  }
  ]
@@ -1067,9 +1067,9 @@ const AREAS = [
  hints:[`Přičti ${a} k oběma stranám.`,`x = ${b} + ${a} = ?`],skill:'calc'};})(),
  (()=>{const a=ri(2,9),x=ri(2,12);const b=a*x;return{
  text:`Vyřeš rovnici:\n${a}x = ${b}`,ans:String(x),
- hints:[`Vyděl obě strany číslem ${a}.`,`x = ${b} ÷ ${a} = ?`],skill:'calc'};})(),
+ hints:[`Vyděl obě strany číslem ${a}.`,`x = ${b} : ${a} = ?`],skill:'calc'};})(),
  (()=>{const a=ri(2,8),b=ri(2,10);const ans=a*b;return{
- text:`Vyřeš rovnici:\nx ÷ ${a} = ${b}`,ans:String(ans),
+ text:`Vyřeš rovnici:\nx : ${a} = ${b}`,ans:String(ans),
  hints:[`Vynásob obě strany číslem ${a}.`,`x = ${b} × ${a} = ?`],skill:'calc'};})(),
  (()=>{const b=ri(2,8),x=ri(2,10);const a=b+x;return{
  text:`Vyřeš rovnici:\n${a} - x = ${b}`,ans:String(x),
@@ -1128,7 +1128,7 @@ const AREAS = [
  hints:[`Vzdálenost = rychlost × čas.`,`s = ${v} × ${t} = ?`],skill:'anal'};})(),
  (()=>{const parts=ri(2,5),each=ri(4,16)*10,total=parts*each;return{
  text:`${total} Kč si rozdělí ${parts} ${skl(parts,'kamarád','kamarádi','kamarádů')}\nrovným dílem.\nKolik Kč dostane každý?`,ans:String(each),
- hints:[`Vydel celkovou částku počtem kamarádů.`,`${total} ÷ ${parts} = ?`],skill:'anal'};})()
+ hints:[`Vydel celkovou částku počtem kamarádů.`,`${total} : ${parts} = ?`],skill:'anal'};})()
  ]
  }
  ]
@@ -1202,10 +1202,10 @@ const AREAS = [
  hints:[`Hledáš číslo, které dělí ${a*b} i ${a*c}.`,`NSD(${a*b}, ${a*c}) = ?`],skill:'anal'};})(),
  (()=>{const a=ri(2,5),b=ri(2,6),c=ri(2,6);return{
  text:`Vytkni a z výrazu:\n${a} × ${b} + ${a} × ${c} = ${a} × (b+c)\nb+c = ?`,ans:String(b+c),
- hints:[`Po vytyknutí ${a} dostaneš ${a} × (? + ?).`,`${a*b}÷${a} = ${b}, ${a*c}÷${a} = ${c}.`],skill:'anal'};})(),
+ hints:[`Po vytyknutí ${a} dostaneš ${a} × (? + ?).`,`${a*b}:${a} = ${b}, ${a*c}:${a} = ${c}.`],skill:'anal'};})(),
  (()=>{const k=ri(2,7),a=ri(1,6),b=ri(1,6);return{
  text:`${k}x + ${k*a} = ${k} × (x + a)\na = ?`,ans:String(a),
- hints:[`${k*a} ÷ ${k} = ?`,`Druhý člen po vytyknutí ${k} je: ${k*a}÷${k}.`],skill:'anal'};})(),
+ hints:[`${k*a} : ${k} = ?`,`Druhý člen po vytyknutí ${k} je: ${k*a}:${k}.`],skill:'anal'};})(),
  (()=>{const a=ri(2,5),b=ri(2,7),x=ri(2,8);return{
  text:`Vypočítej hodnotu (vytkni ${a}):\n${a*b} + ${a} × ${x}`,ans:String(a*(b+x)),
  hints:[`Vytkni ${a}: ${a} × (${b} + ${x}).`,`${a} × ${b+x} = ?`],skill:'anal'};})(),
@@ -1214,7 +1214,7 @@ const AREAS = [
  hints:[`Rozlož obě čísla na prvočinitele nebo použij Euklidův algoritmus.`,`${b} = ${g} × ${b/g}, ${c} = ${g} × ${c/g}. Největší společný dělitel je?`],skill:'anal'};})(),
  (()=>{const a=ri(2,6),b=ri(2,7),c=ri(2,7);return{
  text:`Vytkni největší společný faktor z:\n${a*b} + ${a*c}\n= ${a} × (? + ?) → b + c = ?`,ans:String(b+c),
- hints:[`Vytkni ${a}: ${a*b} ÷ ${a} = ${b}, ${a*c} ÷ ${a} = ${c}.`,`V závorce bude ${b} + ${c}.`],skill:'anal'};})()
+ hints:[`Vytkni ${a}: ${a*b} : ${a} = ${b}, ${a*c} : ${a} = ${c}.`,`V závorce bude ${b} + ${c}.`],skill:'anal'};})()
  ]
  }
  ]
@@ -1245,10 +1245,10 @@ const AREAS = [
  hints:[`Průměr = 2r, tedy r = ${r}. Vzorec: O = 2πr = πd.`,`O = 3,14 × ${d} = ?`],skill:'geo'};})(),
  (()=>{const r=ri(3,10);const o=2*3.14*r;const ans=(o/2/3.14).toFixed(1);return{
  text:`Obvod kružnice je ${o.toFixed(2)} cm.\nVypočítej poloměr r. (π = 3,14, 1 des. místo)`,ans,
- hints:[`Z O = 2πr plyne r = O ÷ (2π).`,`r = ${o.toFixed(2)} ÷ (2 × 3,14) = ${o.toFixed(2)} ÷ 6,28.`],skill:'geo'};})(),
+ hints:[`Z O = 2πr plyne r = O : (2π).`,`r = ${o.toFixed(2)} : (2 × 3,14) = ${o.toFixed(2)} : 6,28.`],skill:'geo'};})(),
  (()=>{const d=ri(2,8)*2;const r=d/2;const ans=(3.14*r*r).toFixed(2);return{
  text:`Kruh má průměr d = ${d} cm.\nVypočítej obsah kruhu. (π = 3,14)`,ans,
- hints:[`Nejdřív poloměr: r = d ÷ 2 = ${r}. Pak S = πr².`,`S = 3,14 × ${r}² = 3,14 × ${r*r} = ?`],skill:'geo'};})(),
+ hints:[`Nejdřív poloměr: r = d : 2 = ${r}. Pak S = πr².`,`S = 3,14 × ${r}² = 3,14 × ${r*r} = ?`],skill:'geo'};})(),
  (()=>{const r=ri(3,9);const ans=(3.14*r*r).toFixed(2);return{
  text:`Pizzeria prodává pizza s poloměrem ${r} cm.\nJaký je obsah pizzy? cm² (π = 3,14)`,ans,
  hints:[`Pizza = kruh s r = ${r} cm. S = πr².`,`S = 3,14 × ${r*r} = ?`],skill:'geo'};})()
@@ -1305,7 +1305,7 @@ const AREAS = [
  hints:[`Objem = πr²h.`,`V ≈ 3,14 × ${r*r} × ${h} = ?`],skill:'craft'};})(),
  (()=>{const o=ri(5,14)*2;const r=(o/(2*3.14)).toFixed(1);return{
  text:`Obvod kolečka je ${o} cm.\nJaký je jeho poloměr? (1 des. místo, π = 3,14)`,ans:r,
- hints:[`Z O = 2πr: r = O ÷ (2π).`,`r = ${o} ÷ 6,28 = ?`],skill:'geo'};})()
+ hints:[`Z O = 2πr: r = O : (2π).`,`r = ${o} : 6,28 = ?`],skill:'geo'};})()
  ]
  }
  ]
@@ -1324,7 +1324,7 @@ const AREAS = [
  tasks:()=>[
  (()=>{const r=ri(3,10);return{
  text:`Osa úsečky AB délky ${r*2} cm je kolmá přímka\nprocházející středem. Jak daleko je střed\nod každého krajního bodu? (cm)`,ans:String(r),
- hints:[`Střed úsečky = polovina délky.`,`${r*2} ÷ 2 = ?`],skill:'geo'};})(),
+ hints:[`Střed úsečky = polovina délky.`,`${r*2} : 2 = ?`],skill:'geo'};})(),
  (()=>{const a=ri(30,70),b=ri(10,a-5);return{
  text:`Trojúhelník ABC: α = ${a}°, β = ${b}°.\nJaký je úhel γ? (°)`,ans:String(180-a-b),
  hints:[`Součet vnitřních úhlů trojúhelníku = 180°.`,`γ = 180° - ${a}° - ${b}° = ?`],skill:'geo'};})(),
@@ -1351,7 +1351,7 @@ const AREAS = [
  (()=>{const ab=ri(6,20);return{
  svg:svgThales(`AB = ${ab}`),
  text:`Úsečka AB je průměr kružnice.\nAB = ${ab} cm.\nJaký je poloměr Thaletovy kružnice? (cm)`,ans:String(ab/2),
- hints:[`Thaletova kružnice má střed ve středu AB.`,`r = AB ÷ 2 = ${ab} ÷ 2 = ?`],skill:'geo'};})(),
+ hints:[`Thaletova kružnice má střed ve středu AB.`,`r = AB : 2 = ${ab} : 2 = ?`],skill:'geo'};})(),
  (()=>{const a=ri(3,8),b=ri(3,10);const c=Math.sqrt(a*a+b*b).toFixed(2);return{
  svg:svgThales('AB = ?'),
  text:`Bod C leží na Thaletově kružnici nad AB.\nCa = ${a} cm, Cb = ${b} cm.\nUrči délku průměru AB. (2 des. místa)`,ans:c,
@@ -1361,7 +1361,7 @@ const AREAS = [
  hints:[`Pythagorova věta: c² = a² + b².`,`c = √(${a}²+${b}²) = √${a*a+b*b}.`],skill:'geo'};})(),
  (()=>{const a=ri(3,10),b=ri(3,10);const c2=a*a+b*b;const c=Math.sqrt(c2);const r=(c/2).toFixed(2);return{
  text:`Pravoúhlý trojúhelník: odvěsny ${a} a ${b} cm.\nJaký je poloměr opsané kružnice? (2 des. místa)`,ans:r,
- hints:[`U pravoúhlého trojúhelníku je přepona průměr opsané kružnice.`,`přepona c = √(${a}²+${b}²) = √${c2}, r = c ÷ 2.`],skill:'geo'};})(),
+ hints:[`U pravoúhlého trojúhelníku je přepona průměr opsané kružnice.`,`přepona c = √(${a}²+${b}²) = √${c2}, r = c : 2.`],skill:'geo'};})(),
  (()=>{const sides=[3,4,5,5,12,13,8,15,17,7,24,25];const i=ri(0,3)*3;const a=sides[i],b=sides[i+1],c=sides[i+2];return{
  text:`Trojúhelník se stranami ${a}, ${b}, ${c} cm.\nJe to pravoúhlý trojúhelník?\n(ANO / NE)`,ans:'ANO',
  hints:[`Ověř Pythagorovu větu pro největší stranu jako přeponu.`,`${a}² + ${b}² = ${a*a+b*b}, ${c}² = ${c*c}. Souhlasí?`],skill:'geo'};})(),
@@ -1390,7 +1390,7 @@ const AREAS = [
  hints:[`Souměrnost podle osy x: [x, y] → [x, -y].`,`y-souřadnice: -${y} = ?`],skill:'craft'};})(),
  (()=>{const ns=[4,5,6,8,9,10];const n=ns[ri(0,ns.length-1)];const ext=360/n;return{
  text:`Pravidelný ${n}-úhelník má ____° rotační souměrnost.\n(nejmenší úhel otočení, celé číslo)`,ans:String(ext),
- hints:[`Pravidelný n-úhelník se zobrazí sám na sebe otočením o 360°/n.`,`360 ÷ ${n} = ?`],skill:'craft'};})(),
+ hints:[`Pravidelný n-úhelník se zobrazí sám na sebe otočením o 360°/n.`,`360 : ${n} = ?`],skill:'craft'};})(),
  (()=>{const a=ri(2,8);return{
  text:`Střed úsečky PQ leží v bodě M.\nPM = ${a} cm.\nJaká je délka celé úsečky PQ? (cm)`,ans:String(2*a),
  hints:[`Střed rozděluje úsečku na dvě stejné části.`,`PQ = 2 × PM = 2 × ${a} = ?`],skill:'craft'};})()
@@ -1421,13 +1421,13 @@ const AREAS = [
  hints:[`V = πr²h.`,`V ≈ 3,14 × ${r*r} × ${h} = ?`],skill:'geo'};})(),
  (()=>{const aa=ri(3,8),cc=ri(1,aa-1),xx=ri(2,7),bb=ri(1,8),dd=(aa-cc)*xx+bb;return{
  text:`Vyřeš rovnici:\n${aa}x + ${bb} = ${cc}x + ${dd}`,ans:String(xx),
- hints:[`Přesuň x: ${aa-cc}x = ${dd-bb}.`,`x = ${dd-bb} ÷ ${aa-cc} = ?`],skill:'anal'};})(),
+ hints:[`Přesuň x: ${aa-cc}x = ${dd-bb}.`,`x = ${dd-bb} : ${aa-cc} = ?`],skill:'anal'};})(),
  (()=>{const a=ri(4,10),b=ri(1,a-1);return{
  text:`Vypočítej (součin součtu a rozdílu):\n(${a} + ${b})(${a} - ${b})`,ans:String(a*a-b*b),
  hints:[`Vzorec: (a+b)(a-b) = a²-b².`,`${a}²-${b}² = ${a*a}-${b*b}.`],skill:'calc'};})(),
  (()=>{const parts=ri(2,5),each=ri(3,12)*100,total=parts*each;return{
  text:`${parts} ${skl(parts,'kamarád','kamarádi','kamarádů')} si rozdělí výhru ${total} Kč\nrovným dílem.\nKolik Kč dostane každý?`,ans:String(each),
- hints:[`Vydel výhru počtem kamarádů.`,`${total} ÷ ${parts} = ?`],skill:'anal'};})()
+ hints:[`Vydel výhru počtem kamarádů.`,`${total} : ${parts} = ?`],skill:'anal'};})()
  ]
  },
  {
@@ -1444,13 +1444,13 @@ const AREAS = [
  hints:[`Celkem potřebují ${total}, mají ${a+b}.`,`${total} - ${a+b} = ?`],skill:'anal'};})(),
  (()=>{const a=ri(2,8),b=ri(2,8),k=ri(2,6);const ans=(a+b)*k;return{
  text:`Obvod obdélníku je ${ans} cm.\nJedna strana je ${a*k} cm.\nJaká je druhá strana? (cm)`,ans:String(b*k),
- hints:[`O = 2(a+b), tedy a+b = O÷2 = ${ans/2}.`,`Druhá strana = ${ans/2} - ${a*k} = ?`],skill:'geo'};})(),
+ hints:[`O = 2(a+b), tedy a+b = O:2 = ${ans/2}.`,`Druhá strana = ${ans/2} - ${a*k} = ?`],skill:'geo'};})(),
  (()=>{const p=ri(10,40),tot=ri(20,60)*10;const ans=Math.round(tot*p/100);return{
  text:`Ve třídě je ${tot} žáků.\n${p} % z nich je chlapci.\nKolik chlapců je ve třídě?`,ans:String(ans),
- hints:[`${p} % z ${tot} = ${tot} × ${p}÷100.`,`= ?`],skill:'anal'};})(),
+ hints:[`${p} % z ${tot} = ${tot} × ${p}:100.`,`= ?`],skill:'anal'};})(),
  (()=>{const r=ri(4,10);const o=Math.round(2*3.14*r);return{
  text:`Obvod kružnice je ${o} cm. (π = 3,14)\nJaký je poloměr? (cm, celé číslo)`,ans:String(r),
- hints:[`r = O ÷ (2π) = ${o} ÷ 6,28.`,`Výsledek zaokrouhli na celé číslo.`],skill:'geo'};})(),
+ hints:[`r = O : (2π) = ${o} : 6,28.`,`Výsledek zaokrouhli na celé číslo.`],skill:'geo'};})(),
  (()=>{const a=ri(3,12),b=ri(3,12);const c2=a*a+b*b;const c=Math.sqrt(c2).toFixed(2);return{
  text:`Úhlopříčka obdélníku ${a} × ${b} cm.\nJak je dlouhá? (cm, 2 des. místa)`,ans:c,
  hints:[`Úhlopříčka = přepona pravoúhlého trojúhelníku.`,`d = √(${a}²+${b}²) = √${c2}.`],skill:'geo'};})()
@@ -1476,7 +1476,7 @@ const AREAS = [
  hints:[`Po první slevě: ${z} × ${(100-p1)/100} = ${Math.round(z*(1-p1/100))} Kč.`,`Z té pak ${p2} %: × ${(100-p2)/100}.`],skill:'anal'};})(),
  (()=>{const sets=[[20,25],[20,50],[24,25],[30,20],[25,20],[30,10]];const[tot,p]=sets[Math.floor(Math.random()*sets.length)];const ans=tot*p/100;const a=ri(2,Math.floor(tot/3)),b=ri(2,Math.floor(tot/3)),c=tot-a-b;return{
  text:`Třída: ${a} výborných, ${b} chvalitebných, ${c} ostatních.\n${p} % celé třídy pojede na výlet.\nKolik žáků pojede?`,ans:String(ans),
- hints:[`Celkem žáků: ${a}+${b}+${c} = ${tot}.`,`${p} % z ${tot} = ${tot} × ${p} ÷ 100 = ?`],skill:'anal'};})(),
+ hints:[`Celkem žáků: ${a}+${b}+${c} = ${tot}.`,`${p} % z ${tot} = ${tot} × ${p} : 100 = ?`],skill:'anal'};})(),
  (()=>{const c=ri(10,17),a=ri(3,c-3);const b2=c*c-a*a;const b=Math.sqrt(b2).toFixed(2);return{
  text:`Pravoúhlý trojúhelník:\npřepona c = ${c} cm, odvěsna a = ${a} cm.\nOdvěsna b = ? (2 des. místa)`,ans:b,
  hints:[`b² = c² - a².`,`b = √(${c}²-${a}²) = √${b2}.`],skill:'geo'};})()

--- a/projects/rpg-mat-8.html
+++ b/projects/rpg-mat-8.html
@@ -312,7 +312,7 @@ body::before{
 @keyframes fail-skull{0%,100%{transform:scale(1) rotate(-4deg)}50%{transform:scale(1.1) rotate(4deg)}}
 .fail-overlay .ti{font-family:var(--px);font-weight:700;font-size:26px;color:var(--red);text-shadow:3px 3px 0 #000,0 0 16px #e74c3c;margin-bottom:8px;letter-spacing:2px;position:relative;z-index:1;animation:fail-ti .5s steps(4)}
 @keyframes fail-ti{0%{transform:scale(2);opacity:0}100%{transform:scale(1);opacity:1}}
-.fail-overlay .sb{font-family:var(--vt);font-size:21px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
+.fail-overlay .sb{font-family:var(--read);font-size:17px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
 .fail-overlay .btn{position:relative;z-index:1}
 /* combo badge */
 .combo{position:absolute;right:14px;top:12px;font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);text-shadow:2px 2px 0 #000;z-index:6;opacity:0;transition:opacity .25s,font-size .25s}
@@ -360,7 +360,7 @@ body::before{
 .bt-input:focus{animation:input-pulse 1.4s ease-in-out infinite}
 @keyframes input-pulse{0%,100%{opacity:.8}50%{opacity:1}}
 .bt-input:disabled{opacity:.5;animation:none}
-.hint-box{font-family:var(--vt);font-size:21px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
+.hint-box{font-family:var(--read);font-size:17px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
 .hint-box.show{display:block;animation:hint-slide .35s ease-out}
 @keyframes hint-slide{0%{opacity:0;transform:translateY(-10px);max-height:0}100%{opacity:1;transform:translateY(0);max-height:300px}}
 .credits-chip{display:inline-flex;align-items:center;gap:5px;font-family:var(--px);font-size:13px;color:#f4d03f;background:#1a1500;border:2px solid #7a5c00;padding:2px 9px;border-radius:2px}
@@ -746,7 +746,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="bt-fb" class="feedback"></div>
  <div id="bt-explain" style="display:none;margin:8px 0">
   <label style="font-size:13px;color:var(--green);opacity:.85;display:block;margin-bottom:4px">✍ Jak jsi na to přišel? <span style="opacity:.6">(volitelně, 1–2 věty)</span></label>
-  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
+  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--read);font-size:15px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
  <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
@@ -823,7 +823,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 <div class="modal-box">
  <div id="modal-ic" style="font-size:56px;margin-bottom:10px">🎉</div>
  <div id="modal-title" style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);margin-bottom:12px;line-height:1.3;letter-spacing:.5px"></div>
- <div id="modal-txt" style="font-family:var(--vt);font-size:22px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
+ <div id="modal-txt" style="font-family:var(--read);font-size:16px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
  <button class="btn full" onclick="closeModal()">▶ POKRAČOVAT</button>
 </div>
 </div>

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -1162,7 +1162,7 @@ const AREAS = [
    (()=>{const a=ri(240,720),b=ri(130,480);return{text:`Vypočítej:\n${a} + ${b} =`,ans:String(a+b),hints:[`Sčítej po řádech.`,`${a} + ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(560,990),b=ri(130,540);return{text:`Vypočítej:\n${a} - ${b} =`,ans:String(a-b),hints:[`Odečítej pod sebou, pozor na výpůjčky.`,`${a} - ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(13,49),b=ri(4,9);return{text:`Vypočítej:\n${a} × ${b} =`,ans:String(a*b),hints:[`Násob po řádech a sečti.`,`${a} × ${b}`],skill:'calc'};})(),
-   (()=>{const b=ri(3,9),q=ri(13,40),a=b*q;return{text:`Vypočítej:\n${a} ÷ ${b} =`,ans:String(q),hints:[`Kolikrát se ${b} vejde do ${a}?`,`${a} ÷ ${b}`],skill:'calc'};})(),
+   (()=>{const b=ri(3,9),q=ri(13,40),a=b*q;return{text:`Vypočítej:\n${a} : ${b} =`,ans:String(q),hints:[`Kolikrát se ${b} vejde do ${a}?`,`${a} : ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);return{text:`Vypočítej (pozor na závorku):\n${a} × (${b} + ${c}) =`,ans:String(a*(b+c)),hints:[`Nejdřív spočítej závorku.`,`${a} × ${b+c}`],skill:'calc'};})(),
    (()=>{const a=ri(1234,8765);const r=Math.round(a/100)*100;return{text:`Zaokrouhli na stovky:\n${a} ≈`,ans:String(r),hints:[`Rozhoduje číslice desítek (${Math.floor(a/10)%10}).`,`${(a%100)>=50?'Nahoru.':'Dolů.'}`],skill:'calc'};})()
   ]
@@ -1174,8 +1174,8 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const z=ri(2,9)*100,p=[10,20,25,50][ri(0,3)];return{text:`Vypočítej:\n${p} % z ${z} =`,ans:String(z*p/100),hints:[`1 % = ${z/100}, pak × ${p}.`,`${z/100} × ${p}`],skill:'anal'};})(),
-   (()=>{const cel=ri(4,10)*20,cast=cel*[10,25,50][ri(0,2)]/100;return{text:`Kolik procent je ${cast} z ${cel}?`,ans:String(Math.round(cast/cel*100)),hints:[`Část ÷ celek × 100.`,`${cast} ÷ ${cel} × 100`],skill:'anal'};})(),
-   (()=>{const p=[10,20,25,50][ri(0,3)],cel=ri(3,9)*20,cast=cel*p/100;return{text:`${cast} je ${p} % z nějakého čísla.\nJaké je to číslo (celek)?`,ans:String(cel),hints:[`Celek = část ÷ procenta × 100.`,`${cast} ÷ ${p} × 100`],skill:'anal'};})(),
+   (()=>{const cel=ri(4,10)*20,cast=cel*[10,25,50][ri(0,2)]/100;return{text:`Kolik procent je ${cast} z ${cel}?`,ans:String(Math.round(cast/cel*100)),hints:[`Část : celek × 100.`,`${cast} : ${cel} × 100`],skill:'anal'};})(),
+   (()=>{const p=[10,20,25,50][ri(0,3)],cel=ri(3,9)*20,cast=cel*p/100;return{text:`${cast} je ${p} % z nějakého čísla.\nJaké je to číslo (celek)?`,ans:String(cel),hints:[`Celek = část : procenta × 100.`,`${cast} : ${p} × 100`],skill:'anal'};})(),
    (()=>{const z=ri(3,9)*100,p=[10,20,25][ri(0,2)];return{text:`Zboží za ${z} Kč zdraží o ${p} %.\nNová cena? (Kč)`,ans:String(z+z*p/100),hints:[`Přírůstek = ${z} × ${p/100}.`,`${z} + ${z*p/100}`],skill:'anal'};})(),
    (()=>{const z=ri(3,9)*100,p=[10,20,25,50][ri(0,3)];return{text:`Sleva ${p} % z ceny ${z} Kč.\nKolik zaplatíš? (Kč)`,ans:String(z-z*p/100),hints:[`Sleva = ${z} × ${p/100}, pak odečti.`,`${z} - ${z*p/100}`],skill:'anal'};})(),
    (()=>{const y=ri(2,8)*1000,pm=[5,10,20,25][ri(0,3)];return{text:`Vypočítej:\n${pm} ‰ z ${y} =`,ans:String(y*pm/1000),hints:[`Promile = tisícina. 1 ‰ = ${y/1000}.`,`${y/1000} × ${pm}`],skill:'anal'};})()
@@ -1191,7 +1191,7 @@ const AREAS = [
    (()=>{const a=ri(3,12),b=ri(3,12);return{text:`Vypočítej:\n${a} - (-${b}) =`,ans:String(a+b),hints:[`Dvě mínusová znaménka HNED VEDLE SEBE se ruší na plus. (Platí jen vedle sebe nebo při násobení/dělení.)`,`${a} + ${b}`],skill:'calc'};})(),
    (()=>{const a=ri(3,12),b=ri(3,9);return{text:`Vypočítej:\n(-${a}) × ${b} =`,ans:String(-a*b),hints:[`Mínus × plus = mínus.`,`-(${a} × ${b})`],skill:'calc'};})(),
    (()=>{const a=ri(3,12),b=ri(3,9);return{text:`Vypočítej:\n(-${a}) × (-${b}) =`,ans:String(a*b),hints:[`Mínus × mínus = plus.`,`${a} × ${b}`],skill:'calc'};})(),
-   (()=>{const b=ri(3,8),q=ri(3,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ ${b} =`,ans:String(-q),hints:[`Mínus ÷ plus = mínus.`,`-(${a} ÷ ${b})`],skill:'calc'};})(),
+   (()=>{const b=ri(3,8),q=ri(3,9),a=b*q;return{text:`Vypočítej:\n(-${a}) : ${b} =`,ans:String(-q),hints:[`Mínus : plus = mínus.`,`-(${a} : ${b})`],skill:'calc'};})(),
    (()=>{const a=ri(3,9);return{text:`Vypočítej:\n(-${a})² =`,ans:String(a*a),hints:[`Druhá mocnina záporného čísla je kladná.`,`(-${a}) × (-${a})`],skill:'calc'};})()
   ]
  }
@@ -1261,10 +1261,10 @@ const AREAS = [
   tasks:()=>[
    (()=>{const x=ri(2,18),a=ri(2,20),b=x+a;return{text:`Vyřeš rovnici:\nx + ${a} = ${b}`,ans:String(x),hints:[`Odečti ${a} od obou stran.`,`x = ${b} − ${a}`],skill:'calc'};})(),
    (()=>{const x=ri(5,25),a=ri(2,15),b=x-a;return{text:`Vyřeš rovnici:\nx − ${a} = ${b}`,ans:String(x),hints:[`Přičti ${a} k oběma stranám.`,`x = ${b} + ${a}`],skill:'calc'};})(),
-   (()=>{const a=ri(2,9),x=ri(2,12),b=a*x;return{text:`Vyřeš rovnici:\n${a}x = ${b}`,ans:String(x),hints:[`Vyděl obě strany ${a}.`,`x = ${b} ÷ ${a}`],skill:'calc'};})(),
+   (()=>{const a=ri(2,9),x=ri(2,12),b=a*x;return{text:`Vyřeš rovnici:\n${a}x = ${b}`,ans:String(x),hints:[`Vyděl obě strany ${a}.`,`x = ${b} : ${a}`],skill:'calc'};})(),
    (()=>{const a=ri(2,7),x=ri(2,9),v=x*a;return{text:`Vyřeš rovnici:\nx / ${a} = ${x}`,ans:String(v),hints:[`Vynásob obě strany ${a}.`,`x = ${x} × ${a}`],skill:'calc'};})(),
-   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15),c=a*x+b;return{text:`Vyřeš rovnici:\n${a}x + ${b} = ${c}`,ans:String(x),hints:[`Nejdřív odečti ${b}, pak vyděl ${a}.`,`x = ${c-b} ÷ ${a}`],skill:'calc'};})(),
-   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15),c=a*x-b;return{text:`Vyřeš rovnici:\n${a}x − ${b} = ${c}`,ans:String(x),hints:[`Přičti ${b}, pak vyděl ${a}.`,`x = ${c+b} ÷ ${a}`],skill:'calc'};})()
+   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15),c=a*x+b;return{text:`Vyřeš rovnici:\n${a}x + ${b} = ${c}`,ans:String(x),hints:[`Nejdřív odečti ${b}, pak vyděl ${a}.`,`x = ${c-b} : ${a}`],skill:'calc'};})(),
+   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15),c=a*x-b;return{text:`Vyřeš rovnici:\n${a}x − ${b} = ${c}`,ans:String(x),hints:[`Přičti ${b}, pak vyděl ${a}.`,`x = ${c+b} : ${a}`],skill:'calc'};})()
   ]
  },
  {
@@ -1273,9 +1273,9 @@ const AREAS = [
   intro:'Bariéra je složitější — neznámá je na obou stranách rovnice. Roznásob a sjednoť.',
   tc:6,
   tasks:()=>[
-   (()=>{const a=ri(2,6),x=ri(2,9),b=ri(1,8),c=a*(x+b);return{text:`Vyřeš rovnici:\n${a}(x + ${b}) = ${c}`,ans:String(x),hints:[`Roznásob: ${a}x + ${a*b} = ${c}.`,`x = ${(c-a*b)} ÷ ${a}`],skill:'anal'};})(),
+   (()=>{const a=ri(2,6),x=ri(2,9),b=ri(1,8),c=a*(x+b);return{text:`Vyřeš rovnici:\n${a}(x + ${b}) = ${c}`,ans:String(x),hints:[`Roznásob: ${a}x + ${a*b} = ${c}.`,`x = ${(c-a*b)} : ${a}`],skill:'anal'};})(),
    (()=>{const x=ri(2,9),a=ri(3,6),b=ri(2,8),d=ri(1,2),c1=a*x+b,c2d=d;const left=a,right=d;const cR=(a-d)*x+b;return{text:`Vyřeš rovnici:\n${a}x + ${b} = ${d}x + ${cR}`,ans:String(x),hints:[`Převeď x doleva, čísla doprava.`,`${a-d}x = ${cR-b}`],skill:'anal'};})(),
-   (()=>{const x=ri(2,8),a=ri(2,5),b=ri(1,6),c=a*(x-b);return{text:`Vyřeš rovnici:\n${a}(x − ${b}) = ${c}`,ans:String(x),hints:[`Roznásob: ${a}x − ${a*b} = ${c}.`,`x = ${(c+a*b)} ÷ ${a}`],skill:'anal'};})(),
+   (()=>{const x=ri(2,8),a=ri(2,5),b=ri(1,6),c=a*(x-b);return{text:`Vyřeš rovnici:\n${a}(x − ${b}) = ${c}`,ans:String(x),hints:[`Roznásob: ${a}x − ${a*b} = ${c}.`,`x = ${(c+a*b)} : ${a}`],skill:'anal'};})(),
    (()=>{const x=ri(2,6),a=ri(2,4),bb=ri(2,3),e=ri(1,5),c=a*(bb*x-e);return{text:`Vyřeš rovnici:\n${a}(${bb}x − ${e}) = ${c}`,ans:String(x),hints:[`Roznásob: ${a*bb}x − ${a*e} = ${c}.`,`${a*bb}x = ${c+a*e}`],skill:'anal'};})(),
    (()=>{const x=ri(2,8),a=ri(2,4),b=ri(2,7),c=2*(x+a)-b;return{text:`Vyřeš rovnici:\n2(x + ${a}) − ${b} = ${c}`,ans:String(x),hints:[`Roznásob: 2x + ${2*a} − ${b} = ${c}.`,`2x = ${c-(2*a-b)}`],skill:'anal'};})(),
    (()=>{const x=ri(2,9),a=ri(2,6),b=ri(2,9),d=ri(1,3);const c=a*x-b+d*x;return{text:`Vyřeš rovnici:\n${a}x − ${b} = ${c} − ${d}x`,ans:String(x),hints:[`Převeď ${d}x doleva: ${a+d}x − ${b} = ${c}.`,`${a+d}x = ${c+b}`],skill:'anal'};})()
@@ -1288,9 +1288,9 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const a=ri(3,12),b=ri(3,12),o=2*(a+b);return{text:`Obvod obdélníku: o = 2(a+b).\no = ${o} cm, a = ${a} cm. Urči b. (cm)`,ans:String(b),hints:[`b = o/2 − a = ${o/2} − ${a}.`,`Výsledek: ${b}`],skill:'anal'};})(),
-   (()=>{const a=ri(3,12),v=ri(3,12),S=a*v;return{text:`Obsah obdélníku: S = a · v.\nS = ${S} cm², a = ${a} cm. Urči v. (cm)`,ans:String(v),hints:[`v = S / a = ${S} ÷ ${a}.`,`Výsledek: ${v}`],skill:'anal'};})(),
-   (()=>{const v=ri(40,90),t=ri(2,5),sd=v*t;return{text:`Dráha: s = v · t.\ns = ${sd} km, v = ${v} km/h. Urči čas t. (h)`,ans:String(t),hints:[`t = s / v = ${sd} ÷ ${v}.`,`Výsledek: ${t}`],skill:'anal'};})(),
-   (()=>{const v=ri(40,90),t=ri(2,5),sd=v*t;return{text:`Dráha: s = v · t.\ns = ${sd} km, t = ${t} h. Urči rychlost v. (km/h)`,ans:String(v),hints:[`v = s / t = ${sd} ÷ ${t}.`,`Výsledek: ${v}`],skill:'anal'};})(),
+   (()=>{const a=ri(3,12),v=ri(3,12),S=a*v;return{text:`Obsah obdélníku: S = a · v.\nS = ${S} cm², a = ${a} cm. Urči v. (cm)`,ans:String(v),hints:[`v = S / a = ${S} : ${a}.`,`Výsledek: ${v}`],skill:'anal'};})(),
+   (()=>{const v=ri(40,90),t=ri(2,5),sd=v*t;return{text:`Dráha: s = v · t.\ns = ${sd} km, v = ${v} km/h. Urči čas t. (h)`,ans:String(t),hints:[`t = s / v = ${sd} : ${v}.`,`Výsledek: ${t}`],skill:'anal'};})(),
+   (()=>{const v=ri(40,90),t=ri(2,5),sd=v*t;return{text:`Dráha: s = v · t.\ns = ${sd} km, t = ${t} h. Urči rychlost v. (km/h)`,ans:String(v),hints:[`v = s / t = ${sd} : ${t}.`,`Výsledek: ${v}`],skill:'anal'};})(),
    (()=>{const x=ri(12,40),a=ri(5,25),v=x+a;return{text:`Slovní úloha:\nNeznámé číslo zvětšené o ${a} je ${v}. Jaké je?`,ans:String(x),hints:[`x + ${a} = ${v}.`,`x = ${v} − ${a}`],skill:'anal'};})(),
    (()=>{const x=ri(3,12),v=3*x-4;return{text:`Slovní úloha:\nTrojnásobek čísla zmenšený o 4 je ${v}. Jaké je číslo?`,ans:String(x),hints:[`3x − 4 = ${v}.`,`3x = ${v+4}`],skill:'anal'};})()
   ]
@@ -1323,12 +1323,12 @@ const AREAS = [
   intro:'Dosaď hodnotu do lomeného výrazu a zjisti, jaká data skrývá.',
   tc:6,
   tasks:()=>[
-   (()=>{const b=ri(2,6),x=b*ri(2,6),a=ri(1,9);return{text:`Vypočítej hodnotu výrazu (x + ${a})/${b}\npro x = ${x-a}.`,ans:String((x)/b),hints:[`Dosaď: (${x-a} + ${a})/${b}.`,`${x} ÷ ${b}`],skill:'anal'};})(),
-   (()=>{const x=ri(2,6),a=x*ri(1,4);return{text:`Vypočítej hodnotu výrazu (2x + ${a}) / x\npro x = ${x}.`,ans:String(2+a/x),hints:[`Dosaď x = ${x}: (${2*x} + ${a}) ÷ ${x}.`,`${2*x+a} ÷ ${x}`],skill:'anal'};})(),
-   (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(2,6),b=ri(1,9);return{text:`Vypočítej hodnotu výrazu ${k}/x + ${b}\npro x = ${x}.`,ans:String(k/x+b),hints:[`${k} ÷ ${x} = ${k/x}, pak + ${b}.`,`Výsledek: ${k/x+b}`],skill:'anal'};})(),
+   (()=>{const b=ri(2,6),x=b*ri(2,6),a=ri(1,9);return{text:`Vypočítej hodnotu výrazu (x + ${a})/${b}\npro x = ${x-a}.`,ans:String((x)/b),hints:[`Dosaď: (${x-a} + ${a})/${b}.`,`${x} : ${b}`],skill:'anal'};})(),
+   (()=>{const x=ri(2,6),a=x*ri(1,4);return{text:`Vypočítej hodnotu výrazu (2x + ${a}) / x\npro x = ${x}.`,ans:String(2+a/x),hints:[`Dosaď x = ${x}: (${2*x} + ${a}) : ${x}.`,`${2*x+a} : ${x}`],skill:'anal'};})(),
+   (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(2,6),b=ri(1,9);return{text:`Vypočítej hodnotu výrazu ${k}/x + ${b}\npro x = ${x}.`,ans:String(k/x+b),hints:[`${k} : ${x} = ${k/x}, pak + ${b}.`,`Výsledek: ${k/x+b}`],skill:'anal'};})(),
    (()=>{const d=ri(2,9),n=d*ri(2,6),g=gcd(n,d);return{text:`Zkrať zlomek na základní tvar:\n${n}/${d} =`,ans:(d/g===1?String(n/g):`${n/g}/${d/g}`),hints:[`Vyděl čitatele i jmenovatele ${g}.`,`Výsledek: ${d/g===1?String(n/g):n/g+'/'+(d/g)}`],skill:'calc'};})(),
    (()=>{const x=ri(3,9),a=ri(1,2);return{text:`Vypočítej hodnotu výrazu (x − ${a})·(x + ${a})\npro x = ${x}. (= x² − ${a*a})`,ans:String(x*x-a*a),hints:[`x² − ${a}² = ${x*x} − ${a*a}.`,`Výsledek: ${x*x-a*a}`],skill:'anal'};})(),
-   (()=>{const x=ri(3,8),a=x*ri(1,4);return{text:`Vypočítej hodnotu výrazu (x² + ${a}) / x\npro x = ${x}.`,ans:String(x+a/x),hints:[`Dosaď x = ${x}: (${x*x} + ${a}) ÷ ${x}.`,`${x*x+a} ÷ ${x}`],skill:'anal'};})()
+   (()=>{const x=ri(3,8),a=x*ri(1,4);return{text:`Vypočítej hodnotu výrazu (x² + ${a}) / x\npro x = ${x}.`,ans:String(x+a/x),hints:[`Dosaď x = ${x}: (${x*x} + ${a}) : ${x}.`,`${x*x+a} : ${x}`],skill:'anal'};})()
   ]
  },
  {
@@ -1337,11 +1337,11 @@ const AREAS = [
   intro:'Reaktor schoval neznámou do jmenovatele. Vynásob, osvoboď x a dořeš.',
   tc:6,
   tasks:()=>[
-   (()=>{const x=ri(2,9),b=ri(2,6),a=b*x;return{text:`Vyřeš rovnici:\n${a} / x = ${b}`,ans:String(x),hints:[`Vynásob x: ${a} = ${b}x.`,`x = ${a} ÷ ${b}`],skill:'anal'};})(),
+   (()=>{const x=ri(2,9),b=ri(2,6),a=b*x;return{text:`Vyřeš rovnici:\n${a} / x = ${b}`,ans:String(x),hints:[`Vynásob x: ${a} = ${b}x.`,`x = ${a} : ${b}`],skill:'anal'};})(),
    (()=>{const x=ri(2,9),a=ri(1,8),c=ri(2,5),q=(x+a)/c%1===0?(x+a)/c:null,cc=c;const r=Math.ceil((x+a)/cc),bAdj=r*cc-x;return{text:`Vyřeš rovnici:\n(x + ${bAdj}) / ${cc} = ${r}`,ans:String(x),hints:[`Vynásob ${cc}: x + ${bAdj} = ${r*cc}.`,`x = ${r*cc} − ${bAdj}`],skill:'anal'};})(),
-   (()=>{const x=ri(2,8),q=ri(2,6),a=x*q,b=ri(1,5),c=q-b;return{text:`Vyřeš rovnici:\n${a} / x − ${b} = ${c}`,ans:String(x),hints:[`Přičti ${b}: ${a}/x = ${q}.`,`x = ${a} ÷ ${q}`],skill:'anal'};})(),
-   (()=>{const x=ri(2,8),a=ri(2,9),c=x*ri(2,5),left=`${c}/x`,r=c/x;return{text:`Vyřeš rovnici:\n${c} / x = ${r}`,ans:String(x),hints:[`Vynásob x: ${c} = ${r}x.`,`x = ${c} ÷ ${r}`],skill:'anal'};})(),
-   (()=>{const x=ri(2,6),s=x*ri(2,5),a=ri(1,s-1),b=s-a;return{text:`Vyřeš rovnici:\n${a}/x + ${b}/x = ${s/x}`,ans:String(x),hints:[`Sečti zlomky: ${s}/x = ${s/x}.`,`x = ${s} ÷ ${s/x}`],skill:'anal'};})(),
+   (()=>{const x=ri(2,8),q=ri(2,6),a=x*q,b=ri(1,5),c=q-b;return{text:`Vyřeš rovnici:\n${a} / x − ${b} = ${c}`,ans:String(x),hints:[`Přičti ${b}: ${a}/x = ${q}.`,`x = ${a} : ${q}`],skill:'anal'};})(),
+   (()=>{const x=ri(2,8),a=ri(2,9),c=x*ri(2,5),left=`${c}/x`,r=c/x;return{text:`Vyřeš rovnici:\n${c} / x = ${r}`,ans:String(x),hints:[`Vynásob x: ${c} = ${r}x.`,`x = ${c} : ${r}`],skill:'anal'};})(),
+   (()=>{const x=ri(2,6),s=x*ri(2,5),a=ri(1,s-1),b=s-a;return{text:`Vyřeš rovnici:\n${a}/x + ${b}/x = ${s/x}`,ans:String(x),hints:[`Sečti zlomky: ${s}/x = ${s/x}.`,`x = ${s} : ${s/x}`],skill:'anal'};})(),
    (()=>{const x=[2,3,4,5,6][ri(0,4)],sq=x*x;return{text:`Vyřeš rovnici (kladné x):\n${sq} / x = x`,ans:String(x),hints:[`Vynásob x: ${sq} = x². Které kladné číslo na druhou je ${sq}?`,`x = √${sq}`],skill:'anal'};})()
   ]
  }
@@ -1374,11 +1374,11 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const m=ri(2,8)*50,p=[10,20,25,50][ri(0,3)];return{text:`V roztoku o hmotnosti ${m} g je ${p} % soli.\nKolik gramů soli obsahuje?`,ans:String(m*p/100),hints:[`${p} % z ${m} = ${m}·${p/100}.`,`Výsledek: ${m*p/100}`],skill:'anal'};})(),
-   (()=>{const f=[4,5,8,10][ri(0,3)],s=ri(2,9)*10,m=s*f;const p=100/f;return{text:`Roztok má hmotnost ${m} g a obsahuje ${s} g soli.\nKolik procent soli obsahuje?`,ans:cz(p),hints:[`Část ÷ celek × 100.`,`${s} ÷ ${m} × 100 = ${cz(p)}`],skill:'anal'};})(),
-   (()=>{const a=ri(2,5),pa=ri(8,15)*10,b=ri(2,5),pb=ri(2,7)*10;const tot=(a*pa+b*pb)/(a+b);return{text:`Smícháme ${a} kg kávy po ${pa} Kč a ${b} kg po ${pb} Kč.\nCena 1 kg směsi? (Kč)`,ans:String(Math.round(tot)),hints:[`(${a}·${pa} + ${b}·${pb}) ÷ ${a+b}.`,`${a*pa+b*pb} ÷ ${a+b}`],skill:'anal'};})(),
-   (()=>{const t=[4,5,8,10,20,25][ri(0,5)];const pct=100/t;return{text:`Dělník zvládne celou práci za ${t} ${skl(t,'hodinu','hodiny','hodin')}.\nKolik procent práce udělá za 1 hodinu?`,ans:cz(pct),hints:[`Za 1 h udělá 1/${t} práce.`,`100 ÷ ${t} = ${cz(pct)}`],skill:'anal'};})(),
-   (()=>{const t=ri(2,5)*2,h=t/2;return{text:`Stroj udělá zakázku za ${t} ${skl(t,'hodinu','hodiny','hodin')}.\nKolik zakázek (i nedokončených, v %) zvládne za ${h} ${skl(h,'hodinu','hodiny','hodin')}?`,ans:String(Math.round(h/t*100)),hints:[`${h}/${t} celé práce.`,`${h} ÷ ${t} × 100`],skill:'anal'};})(),
-   (()=>{const c=ri(2,6)*10,p=[20,25,40,50][ri(0,3)],voda=c*(100-p)/p;return{text:`Chceš ${p}% roztok. Máš ${c} g soli.\nKolik g vody přidat? (celková hmotnost − sůl)`,ans:String(Math.round(c*100/p - c)),hints:[`Celý roztok = sůl ÷ ${p/100} = ${Math.round(c*100/p)} g.`,`voda = ${Math.round(c*100/p)} − ${c}`],skill:'anal'};})()
+   (()=>{const f=[4,5,8,10][ri(0,3)],s=ri(2,9)*10,m=s*f;const p=100/f;return{text:`Roztok má hmotnost ${m} g a obsahuje ${s} g soli.\nKolik procent soli obsahuje?`,ans:cz(p),hints:[`Část : celek × 100.`,`${s} : ${m} × 100 = ${cz(p)}`],skill:'anal'};})(),
+   (()=>{const a=ri(2,5),pa=ri(8,15)*10,b=ri(2,5),pb=ri(2,7)*10;const tot=(a*pa+b*pb)/(a+b);return{text:`Smícháme ${a} kg kávy po ${pa} Kč a ${b} kg po ${pb} Kč.\nCena 1 kg směsi? (Kč)`,ans:String(Math.round(tot)),hints:[`(${a}·${pa} + ${b}·${pb}) : ${a+b}.`,`${a*pa+b*pb} : ${a+b}`],skill:'anal'};})(),
+   (()=>{const t=[4,5,8,10,20,25][ri(0,5)];const pct=100/t;return{text:`Dělník zvládne celou práci za ${t} ${skl(t,'hodinu','hodiny','hodin')}.\nKolik procent práce udělá za 1 hodinu?`,ans:cz(pct),hints:[`Za 1 h udělá 1/${t} práce.`,`100 : ${t} = ${cz(pct)}`],skill:'anal'};})(),
+   (()=>{const t=ri(2,5)*2,h=t/2;return{text:`Stroj udělá zakázku za ${t} ${skl(t,'hodinu','hodiny','hodin')}.\nKolik zakázek (i nedokončených, v %) zvládne za ${h} ${skl(h,'hodinu','hodiny','hodin')}?`,ans:String(Math.round(h/t*100)),hints:[`${h}/${t} celé práce.`,`${h} : ${t} × 100`],skill:'anal'};})(),
+   (()=>{const c=ri(2,6)*10,p=[20,25,40,50][ri(0,3)],voda=c*(100-p)/p;return{text:`Chceš ${p}% roztok. Máš ${c} g soli.\nKolik g vody přidat? (celková hmotnost − sůl)`,ans:String(Math.round(c*100/p - c)),hints:[`Celý roztok = sůl : ${p/100} = ${Math.round(c*100/p)} g.`,`voda = ${Math.round(c*100/p)} − ${c}`],skill:'anal'};})()
   ]
  },
  {
@@ -1388,9 +1388,9 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const v=ri(5,12)*10,t=ri(2,5);return{text:`Auto jede rychlostí ${v} km/h po dobu ${t} h.\nJakou dráhu ujede? (km)`,ans:String(v*t),hints:[`s = v · t = ${v} · ${t}.`,`Výsledek: ${v*t}`],skill:'anal'};})(),
-   (()=>{const v=ri(6,12)*10,t=ri(2,5),s=v*t;return{text:`Vlak ujel ${s} km rychlostí ${v} km/h.\nJak dlouho jel? (h)`,ans:String(t),hints:[`t = s / v = ${s} ÷ ${v}.`,`Výsledek: ${t}`],skill:'anal'};})(),
-   (()=>{const t=ri(2,5),s=ri(6,15)*10*t/t,v=ri(6,15)*10;const sd=v*t;return{text:`Cyklista ujel ${sd} km za ${t} h.\nJaká byla jeho průměrná rychlost? (km/h)`,ans:String(v),hints:[`v = s / t = ${sd} ÷ ${t}.`,`Výsledek: ${v}`],skill:'anal'};})(),
-   (()=>{const v1=ri(4,7)*10,v2=ri(4,7)*10,d=ri(2,5)*(v1+v2);return{text:`Dvě města jsou ${d} km daleko. Auta vyjedou proti sobě rychlostmi ${v1} a ${v2} km/h.\nZa kolik hodin se potkají?`,ans:String(d/(v1+v2)),hints:[`Sbližují se rychlostí ${v1+v2} km/h.`,`${d} ÷ ${v1+v2}`],skill:'anal'};})(),
+   (()=>{const v=ri(6,12)*10,t=ri(2,5),s=v*t;return{text:`Vlak ujel ${s} km rychlostí ${v} km/h.\nJak dlouho jel? (h)`,ans:String(t),hints:[`t = s / v = ${s} : ${v}.`,`Výsledek: ${t}`],skill:'anal'};})(),
+   (()=>{const t=ri(2,5),s=ri(6,15)*10*t/t,v=ri(6,15)*10;const sd=v*t;return{text:`Cyklista ujel ${sd} km za ${t} h.\nJaká byla jeho průměrná rychlost? (km/h)`,ans:String(v),hints:[`v = s / t = ${sd} : ${t}.`,`Výsledek: ${v}`],skill:'anal'};})(),
+   (()=>{const v1=ri(4,7)*10,v2=ri(4,7)*10,d=ri(2,5)*(v1+v2);return{text:`Dvě města jsou ${d} km daleko. Auta vyjedou proti sobě rychlostmi ${v1} a ${v2} km/h.\nZa kolik hodin se potkají?`,ans:String(d/(v1+v2)),hints:[`Sbližují se rychlostí ${v1+v2} km/h.`,`${d} : ${v1+v2}`],skill:'anal'};})(),
    (()=>{const v=ri(8,12)*10,t=[1.5,2.5,3.5][ri(0,2)],s=v*t;return{text:`Rychlík jede ${v} km/h.\nJak daleko dojede za ${cz(t)} h? (km)`,ans:String(s),hints:[`s = v · t = ${v} · ${cz(t)}.`,`Výsledek: ${s}`],skill:'anal'};})(),
    (()=>{const v1=ri(3,5)*10,v2=v1+ri(2,4)*10,t=ri(2,4);const nask=(v2-v1)*t;return{text:`Pomalejší auto jede ${v1} km/h, rychlejší ${v2} km/h, stejným směrem.\nO kolik km je rychlejší vepředu po ${t} h?`,ans:String(nask),hints:[`Náskok roste rychlostí ${v2-v1} km/h.`,`${v2-v1} · ${t}`],skill:'anal'};})()
   ]
@@ -1411,7 +1411,7 @@ const AREAS = [
   tasks:()=>[
    (()=>{const k=ri(2,5),q=ri(-4,6),x=ri(2,6),y=k*x+q;return{svg:svgLineGraph(k,q),text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nVypočítej f(${x}).`,ans:String(y),hints:[`Dosaď x = ${x}: ${k}·${x} ${q<0?'− '+(-q):'+ '+q}.`,`Výsledek: ${y}`],skill:'geo'};})(),
    (()=>{const k=ri(2,5),q=ri(-6,8);return{svg:svgLineGraph(k,q),text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nKde protíná přímka osu y? (hodnota q)`,ans:String(q),hints:[`Osu y protne pro x = 0, takže y = q.`,`q = ${q}`],skill:'geo'};})(),
-   (()=>{const k=ri(2,4),x0=ri(1,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nPro jaké x je y = 0?`,ans:String(x0),hints:[`${k}x ${q<0?'− '+(-q):'+ '+q} = 0.`,`x = ${-q} ÷ ${k}`],skill:'geo'};})(),
+   (()=>{const k=ri(2,4),x0=ri(1,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nPro jaké x je y = 0?`,ans:String(x0),hints:[`${k}x ${q<0?'− '+(-q):'+ '+q} = 0.`,`x = ${-q} : ${k}`],skill:'geo'};})(),
    (()=>{const k=ri(2,6);return{text:`Lineární funkce y = ${k}x.\nKolik je f(1)?`,ans:String(k),hints:[`Dosaď x = 1.`,`Výsledek: ${k}`],skill:'geo'};})(),
    (()=>{const k=ri(2,5),q=ri(1,6),x=ri(2,5),y=k*x+q;return{text:`y = ${k}x + ${q}\nVypočítej f(${x}).`,ans:String(y),hints:[`${k}·${x} + ${q}.`,`Výsledek: ${y}`],skill:'geo'};})(),
    (()=>{const x1=ri(1,3),y1=ri(2,5),x2=x1+1,k=ri(2,4),y2=y1+k;return{text:`Přímka prochází body [${x1}, ${y1}] a [${x2}, ${y2}].\nJaká je směrnice k? (změna y na 1 krok x)`,ans:String(k),hints:[`k = (${y2} − ${y1}) / (${x2} − ${x1}).`,`= ${k}`],skill:'geo'};})()
@@ -1426,7 +1426,7 @@ const AREAS = [
    (()=>{const k=ri(2,6),q=ri(-5,5);return{text:`Je funkce y = ${k}x ${q<0?'− '+(-q):'+ '+q} rostoucí?\nNapiš ANO / NE.`,ans:'ANO',hints:[`Rostoucí ⇔ k > 0. Tady k = ${k}.`,`Výsledek: ANO`],skill:'anal'};})(),
    (()=>{const k=ri(2,6),q=ri(-5,5);return{text:`Je funkce y = −${k}x ${q<0?'− '+(-q):'+ '+q} rostoucí?\nNapiš ANO / NE.`,ans:'NE',hints:[`k = −${k} < 0, takže je klesající.`,`Výsledek: NE`],skill:'anal'};})(),
    (()=>{const k=ri(2,5),q=ri(2,8);return{text:`y = ${k}x + ${q}\nV jakém bodě protíná osu y? (napiš jen y-ovou souřadnici)`,ans:String(q),hints:[`Pro x = 0 je y = q.`,`Výsledek: ${q}`],skill:'anal'};})(),
-   (()=>{const k=ri(2,4),x0=ri(2,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nV jakém bodě protíná osu x? (napiš jen x-ovou souřadnici)`,ans:String(x0),hints:[`Polož y = 0.`,`x = ${-q} ÷ ${k}`],skill:'anal'};})(),
+   (()=>{const k=ri(2,4),x0=ri(2,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nV jakém bodě protíná osu x? (napiš jen x-ovou souřadnici)`,ans:String(x0),hints:[`Polož y = 0.`,`x = ${-q} : ${k}`],skill:'anal'};})(),
    (()=>{const q=ri(2,8);return{text:`Je funkce y = ${q} (konstantní) rostoucí?\nNapiš ANO / NE.`,ans:'NE',hints:[`Konstantní funkce není rostoucí ani klesající (k = 0).`,`Výsledek: NE`],skill:'anal'};})(),
    (()=>{const k=ri(2,4),q=ri(1,5),x=ri(2,5),y=k*x+q;return{text:`Prochází graf funkce y = ${k}x + ${q} bodem [${x}, ${y}]?\nNapiš ANO / NE.`,ans:'ANO',hints:[`Dosaď x = ${x} do předpisu a porovnej, jestli vyjde ${y}.`],skill:'anal'};})()
   ]
@@ -1437,12 +1437,12 @@ const AREAS = [
   intro:'Nepřímá úměra: čím větší x, tím menší y. Spočítej hodnoty na hyperbole.',
   tc:6,
   tasks:()=>[
-   (()=>{const x=[2,3,4,6][ri(0,3)],k=x*ri(2,8),y=k/x;return{text:`y = ${k}/x\nVypočítej f(${x}).`,ans:String(y),hints:[`Dosaď: ${k} ÷ ${x}.`,`Výsledek: ${y}`],skill:'geo'};})(),
-   (()=>{const y=[2,3,4,5][ri(0,3)],k=y*ri(2,8),x=k/y;return{text:`y = ${k}/x\nPro jaké x je y = ${y}?`,ans:String(x),hints:[`${k}/x = ${y}, tedy x = ${k} ÷ ${y}.`,`Výsledek: ${x}`],skill:'geo'};})(),
+   (()=>{const x=[2,3,4,6][ri(0,3)],k=x*ri(2,8),y=k/x;return{text:`y = ${k}/x\nVypočítej f(${x}).`,ans:String(y),hints:[`Dosaď: ${k} : ${x}.`,`Výsledek: ${y}`],skill:'geo'};})(),
+   (()=>{const y=[2,3,4,5][ri(0,3)],k=y*ri(2,8),x=k/y;return{text:`y = ${k}/x\nPro jaké x je y = ${y}?`,ans:String(x),hints:[`${k}/x = ${y}, tedy x = ${k} : ${y}.`,`Výsledek: ${x}`],skill:'geo'};})(),
    (()=>{return{text:`Pro jaké x není funkce y = 12/x definována?\nx ≠`,ans:'0',hints:[`Jmenovatel nesmí být nula.`,`x = 0`],skill:'geo'};})(),
    (()=>{const x=ri(2,6),y=ri(2,8),k=x*y;return{text:`Lomená funkce y = k/x prochází bodem [${x}, ${y}].\nUrči koeficient k.`,ans:String(k),hints:[`k = x · y = ${x} · ${y}.`,`Výsledek: ${k}`],skill:'geo'};})(),
-   (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(3,9),y=k/x;return{text:`Nepřímá úměrnost: y = ${k}/x.\nVypočítej hodnotu pro x = ${x}.`,ans:String(y),hints:[`${k} ÷ ${x}.`,`Výsledek: ${y}`],skill:'geo'};})(),
-   (()=>{const k=[12,24,36,48][ri(0,3)],x=[2,3,4,6][ri(0,3)],y=k/x;return{text:`y = ${k}/x\nVyplň tabulku: pro x = ${x} je y = ?`,ans:String(y),hints:[`${k} ÷ ${x}.`,`Výsledek: ${y}`],skill:'geo'};})()
+   (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(3,9),y=k/x;return{text:`Nepřímá úměrnost: y = ${k}/x.\nVypočítej hodnotu pro x = ${x}.`,ans:String(y),hints:[`${k} : ${x}.`,`Výsledek: ${y}`],skill:'geo'};})(),
+   (()=>{const k=[12,24,36,48][ri(0,3)],x=[2,3,4,6][ri(0,3)],y=k/x;return{text:`y = ${k}/x\nVyplň tabulku: pro x = ${x} je y = ?`,ans:String(y),hints:[`${k} : ${x}.`,`Výsledek: ${y}`],skill:'geo'};})()
   ]
  }
  ]
@@ -1460,9 +1460,9 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const a=ri(3,9),k=ri(2,4);return{svg:svgSimilar(k),text:`Trojúhelníky jsou podobné s koeficientem k = ${k}.\nStraně ${a} cm odpovídá strana? (cm)`,ans:String(a*k),hints:[`Vynásob koeficientem: ${a} · ${k}.`,`Výsledek: ${a*k}`],skill:'geo'};})(),
-   (()=>{const k=ri(2,4),orig=ri(4,9)*k;return{text:`Obrazec zmenšíme koeficientem k = 1/${k}.\nStrana ${orig} cm bude mít? (cm)`,ans:String(orig/k),hints:[`Vyděl ${k}: ${orig} ÷ ${k}.`,`Výsledek: ${orig/k}`],skill:'geo'};})(),
-   (()=>{const a=ri(2,6),k=ri(2,4),b=a*k;return{text:`Strana originálu je ${a} cm, odpovídající strana obrazu ${b} cm.\nJaký je koeficient podobnosti k?`,ans:String(k),hints:[`k = obraz / originál = ${b} ÷ ${a}.`,`Výsledek: ${k}`],skill:'geo'};})(),
-   (()=>{const real=ri(2,9),mer=1000,onmap=real;return{text:`Mapa v měřítku 1 : ${mer}. Úsek na mapě měří ${onmap} cm.\nKolik metrů je to ve skutečnosti?`,ans:String(onmap*mer/100),hints:[`${onmap} cm · ${mer} = ${onmap*mer} cm = ? m.`,`${onmap*mer} ÷ 100`],skill:'geo'};})(),
+   (()=>{const k=ri(2,4),orig=ri(4,9)*k;return{text:`Obrazec zmenšíme koeficientem k = 1/${k}.\nStrana ${orig} cm bude mít? (cm)`,ans:String(orig/k),hints:[`Vyděl ${k}: ${orig} : ${k}.`,`Výsledek: ${orig/k}`],skill:'geo'};})(),
+   (()=>{const a=ri(2,6),k=ri(2,4),b=a*k;return{text:`Strana originálu je ${a} cm, odpovídající strana obrazu ${b} cm.\nJaký je koeficient podobnosti k?`,ans:String(k),hints:[`k = obraz / originál = ${b} : ${a}.`,`Výsledek: ${k}`],skill:'geo'};})(),
+   (()=>{const real=ri(2,9),mer=1000,onmap=real;return{text:`Mapa v měřítku 1 : ${mer}. Úsek na mapě měří ${onmap} cm.\nKolik metrů je to ve skutečnosti?`,ans:String(onmap*mer/100),hints:[`${onmap} cm · ${mer} = ${onmap*mer} cm = ? m.`,`${onmap*mer} : 100`],skill:'geo'};})(),
    (()=>{const o=ri(3,8)*3,k=ri(2,4);return{text:`Dva podobné obrazce, k = ${k}. Obvod originálu je ${o} cm.\nObvod obrazu? (cm)`,ans:String(o*k),hints:[`Obvod se mění stejně jako strany: × ${k}.`,`Výsledek: ${o*k}`],skill:'geo'};})(),
    (()=>{const v1=ri(2,6),v2=ri(7,15);return{text:`Strom vrhá stín ${v2} m, tyč vysoká ${v1} m vrhá stín ${v1} m (slunce 45°).\nJak vysoký je strom? (m)`,ans:String(v2),hints:[`Při stejném úhlu je výška = délka stínu.`,`= ${v2} m`],skill:'geo'};})()
   ]
@@ -1488,7 +1488,7 @@ const AREAS = [
   tc:6,
   tasks:()=>[
    (()=>{const a=ri(6,13);return{text:`Vypočítej:\n${a}² =`,ans:String(a*a),hints:[`${a} × ${a}.`,`Výsledek: ${a*a}`],skill:'calc'};})(),
-   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15),c=a*x+b;return{text:`Vyřeš rovnici:\n${a}x + ${b} = ${c}`,ans:String(x),hints:[`Odečti ${b}, vyděl ${a}.`,`x = ${c-b} ÷ ${a}`],skill:'anal'};})(),
+   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15),c=a*x+b;return{text:`Vyřeš rovnici:\n${a}x + ${b} = ${c}`,ans:String(x),hints:[`Odečti ${b}, vyděl ${a}.`,`x = ${c-b} : ${a}`],skill:'anal'};})(),
    (()=>{const z=ri(2,8)*100,p=[10,20,25,50][ri(0,3)];return{text:`Vypočítej:\n${p} % z ${z} =`,ans:String(z*p/100),hints:[`1 % = ${z/100}, pak × ${p}.`,`Výsledek: ${z*p/100}`],skill:'anal'};})(),
    (()=>{const t=[[3,4,5],[6,8,10],[5,12,13]][ri(0,2)];return{svg:svgTriangle('pravo',{v:['C','A','B']}),text:`Pravoúhlý trojúhelník, odvěsny ${t[0]} a ${t[1]} cm.\nPřepona c? (cm)`,ans:String(t[2]),hints:[`c² = ${t[0]*t[0]} + ${t[1]*t[1]}.`,`c = √${t[2]*t[2]}`],skill:'geo'};})(),
    (()=>{const r=ri(2,5),v=ri(5,10),V=Math.round(3.14*r*r*v);return{svg:svgCylinder(r,v),text:`Válec r = ${r} cm, v = ${v} cm.\nObjem? (cm³, π = 3,14)`,ans:String(V),hints:[`V = 3,14 · ${r*r} · ${v}.`,`Výsledek: ${V}`],skill:'geo'};})(),

--- a/projects/rpg-mat-9.html
+++ b/projects/rpg-mat-9.html
@@ -312,7 +312,7 @@ body::before{
 @keyframes fail-skull{0%,100%{transform:scale(1) rotate(-4deg)}50%{transform:scale(1.1) rotate(4deg)}}
 .fail-overlay .ti{font-family:var(--px);font-weight:700;font-size:26px;color:var(--red);text-shadow:3px 3px 0 #000,0 0 16px #e74c3c;margin-bottom:8px;letter-spacing:2px;position:relative;z-index:1;animation:fail-ti .5s steps(4)}
 @keyframes fail-ti{0%{transform:scale(2);opacity:0}100%{transform:scale(1);opacity:1}}
-.fail-overlay .sb{font-family:var(--vt);font-size:21px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
+.fail-overlay .sb{font-family:var(--read);font-size:17px;color:var(--text);margin-bottom:14px;position:relative;z-index:1}
 .fail-overlay .btn{position:relative;z-index:1}
 /* combo badge */
 .combo{position:absolute;right:14px;top:12px;font-family:var(--px);font-weight:700;font-size:14px;color:var(--gold);text-shadow:2px 2px 0 #000;z-index:6;opacity:0;transition:opacity .25s,font-size .25s}
@@ -360,7 +360,7 @@ body::before{
 .bt-input:focus{animation:input-pulse 1.4s ease-in-out infinite}
 @keyframes input-pulse{0%,100%{opacity:.8}50%{opacity:1}}
 .bt-input:disabled{opacity:.5;animation:none}
-.hint-box{font-family:var(--vt);font-size:21px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
+.hint-box{font-family:var(--read);font-size:17px;padding:12px;background:#0f1a0f;border:2px solid var(--green);color:#7fe87f;margin-bottom:10px;display:none;white-space:pre-wrap;line-height:1.4}
 .hint-box.show{display:block;animation:hint-slide .35s ease-out}
 @keyframes hint-slide{0%{opacity:0;transform:translateY(-10px);max-height:0}100%{opacity:1;transform:translateY(0);max-height:300px}}
 .feedback{font-family:var(--px);font-weight:700;font-size:16px;text-align:center;padding:10px;margin-bottom:10px;display:none}
@@ -613,7 +613,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
  <div id="bt-fb" class="feedback"></div>
  <div id="bt-explain" style="display:none;margin:8px 0">
   <label style="font-size:13px;color:var(--green);opacity:.85;display:block;margin-bottom:4px">✍ Jak jsi na to přišel? <span style="opacity:.6">(volitelně, 1–2 věty)</span></label>
-  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--vt);font-size:18px;resize:vertical" placeholder="Napsal jsem…"></textarea>
+  <textarea id="bt-explain-txt" rows="2" aria-label="Jak jsi na to přišel?" style="width:100%;box-sizing:border-box;background:#0a0a0f;color:#d0d0e0;border:1px solid var(--green);border-radius:4px;padding:6px;font-family:var(--read);font-size:15px;resize:vertical" placeholder="Napsal jsem…"></textarea>
  </div>
  <div style="display:flex;gap:8px;flex-wrap:wrap">
  <button class="btn sm b" id="hint-btn" onclick="showHint()">💡 NÁPOVĚDA</button>
@@ -844,7 +844,7 @@ html[data-theme="violet"]{--gold:#b06cff;--panel:#100a20;--panel2:#18103a;--blue
 <div class="modal-box">
  <div id="modal-ic" style="font-size:56px;margin-bottom:10px">🎉</div>
  <div id="modal-title" style="font-family:var(--px);font-weight:700;font-size:17px;color:var(--gold);margin-bottom:12px;line-height:1.3;letter-spacing:.5px"></div>
- <div id="modal-txt" style="font-family:var(--vt);font-size:22px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
+ <div id="modal-txt" style="font-family:var(--read);font-size:16px;color:var(--text);margin-bottom:16px;line-height:1.4;white-space:pre-wrap"></div>
  <button class="btn full" onclick="closeModal()">▶ POKRAČOVAT</button>
 </div>
 </div>

--- a/projects/rpg-tasks-6.js
+++ b/projects/rpg-tasks-6.js
@@ -23,14 +23,14 @@ function gen_1_1(){
   const e=ri(12,40),f=ri(11,30);
   tasks.push({text:`Vypočítej: ${e} × ${f} = ?`,ans:e*f,hints:[`Rozlož ${f} na desítky a jednotky.`,`${e}×${f} = ${e*f}`],skill:'calc'});
   const g=ri(3,9),h=g*ri(10,30);
-  tasks.push({text:`Vypočítej: ${h} ÷ ${g} = ?`,ans:h/g,hints:['Kolikrát se '+g+' vejde do '+h+'?',`${h}÷${g} = ${h/g}`],skill:'calc'});
+  tasks.push({text:`Vypočítej: ${h} : ${g} = ?`,ans:h/g,hints:['Kolikrát se '+g+' vejde do '+h+'?',`${h}:${g} = ${h/g}`],skill:'calc'});
   const i=ri(100,900);
   tasks.push({text:`Zaokrouhli ${i} na stovky.`,ans:Math.round(i/100)*100,hints:['Podívej se na číslici desítek.',`≈ ${Math.round(i/100)*100}`],skill:'calc'});
   const j=ri(2,9),k=ri(2,9),l=ri(2,9);
   tasks.push({text:`Vypočítej: ${j} × ${k} + ${l} = ?`,ans:j*k+l,hints:['Nejdřív násobení, pak sčítání.',`${j*k}+${l} = ${j*k+l}`],skill:'calc'});
   { const a=ri(300,900),b=ri(50,250),c=ri(20,90); tasks.push({text:`Vypočítej: ${a} − ${b} − ${c} = ?`,ans:a-b-c,hints:['Odečítej postupně zleva doprava.',`${a}−${b} = ${a-b}, pak −${c}`],skill:'calc'}); }
   { const a=ri(13,29),b=ri(13,29); tasks.push({text:`Vypočítej: ${a} × ${b} = ?`,ans:a*b,hints:[`Rozlož ${b} na desítky a jednotky.`,`${a}×${b} = ${a*b}`],skill:'calc'}); }
-  { const g=ri(4,9),h=g*ri(12,40); tasks.push({text:`Vypočítej: ${h} ÷ ${g} = ?`,ans:h/g,hints:[`Kolikrát se ${g} vejde do ${h}?`,`${h}÷${g} = ${h/g}`],skill:'calc'}); }
+  { const g=ri(4,9),h=g*ri(12,40); tasks.push({text:`Vypočítej: ${h} : ${g} = ?`,ans:h/g,hints:[`Kolikrát se ${g} vejde do ${h}?`,`${h}:${g} = ${h/g}`],skill:'calc'}); }
   { const a=ri(2,9),b=ri(2,9),c=ri(2,12); tasks.push({text:`Vypočítej: ${a} × ${b} − ${c} = ?`,ans:a*b-c,hints:['Nejdřív násobení, pak odčítání.',`${a*b}−${c} = ${a*b-c}`],skill:'calc'}); }
   return tasks;
 }
@@ -64,7 +64,7 @@ function gen_1_3(){
   tasks.push({text:`V krabici je ${a} ${skl(a,'sáček','sáčky','sáčků')}, v každém ${b} bonbónů. Kolik bonbónů je celkem?`,ans:a*b,hints:['Počet sáčků × bonbonů v sáčku.',`${a}·${b} = ${a*b}`],skill:'anal'});
   const c=ri(50,200),d=ri(3,9);
   const rem=c%d;
-  tasks.push({text:`Rozdělíme ${c} kuliček mezi ${d} ${skl(d,'dítě','děti','dětí')} rovnoměrně. Kolik kuliček zbude?`,ans:rem,hints:['Spočítej zbytek po dělení '+c+' ÷ '+d+'.',`zbytek = ${rem}`],skill:'anal'});
+  tasks.push({text:`Rozdělíme ${c} kuliček mezi ${d} ${skl(d,'dítě','děti','dětí')} rovnoměrně. Kolik kuliček zbude?`,ans:rem,hints:['Spočítej zbytek po dělení '+c+' : '+d+'.',`zbytek = ${rem}`],skill:'anal'});
   const e=ri(2,6),f=ri(20,60);
   tasks.push({text:`Auto ujede za hodinu ${f} km. Kolik km ujede za ${e} ${skl(e,'hodinu','hodiny','hodin')}?`,ans:e*f,hints:['Vzdálenost = rychlost × čas.',`${e}·${f} = ${e*f} km`],skill:'anal'});
   const g=ri(100,500),h=ri(20,80);
@@ -106,7 +106,7 @@ function gen_2_1(){
   return tasks;
 }
 
-// 2-2 Počítání s desetinnými (+ − × ÷)
+// 2-2 Počítání s desetinnými (+ − × :)
 function gen_2_2(){
   const tasks=[];
   const a=ri(100,500)/10,b=ri(50,300)/10;
@@ -116,14 +116,14 @@ function gen_2_2(){
   const e=ri(11,49)/10,f=ri(2,6);
   tasks.push({text:`${cz(e)} × ${f} = ?`,ans:r1(e*f),hints:['Násob jako celá, pak doplň čárku.',`= ${r1(e*f)}`],skill:'calc'});
   const g=ri(2,5),h=ri(10,40)/10;
-  tasks.push({text:`${cz(h*g)} ÷ ${g} = ?`,ans:r1(h),hints:['Děl jako celá čísla, hlídej čárku.',`= ${r1(h)}`],skill:'calc'});
+  tasks.push({text:`${cz(h*g)} : ${g} = ?`,ans:r1(h),hints:['Děl jako celá čísla, hlídej čárku.',`= ${r1(h)}`],skill:'calc'});
   const i=ri(10,30)/10,j=ri(10,30)/10;
   tasks.push({text:`${cz(i)} × ${cz(j)} = ?`,ans:r2(i*j),hints:['Spočítej '+Math.round(i*10)+'×'+Math.round(j*10)+' a poděl 100.',`= ${r2(i*j)}`],skill:'calc'});
   const k=ri(20,80)/10,l=ri(20,80)/10;
   tasks.push({text:`Kolik zaplatím za 2 položky: ${cz(k)} Kč a ${cz(l)} Kč?`,ans:r1(k+l),hints:['Sečti obě ceny.',`= ${r1(k+l)} Kč`],skill:'calc'});
   { const a=ri(100,500)/10,b=ri(50,250)/10; tasks.push({text:`${cz(a)} + ${cz(b)} = ?`,ans:r1(a+b),hints:['Zarovnej čárky pod sebe.',`= ${r1(a+b)}`],skill:'calc'}); }
   { const a=ri(30,49)/10,b=ri(2,6); tasks.push({text:`${cz(a)} × ${b} = ?`,ans:r1(a*b),hints:['Násob jako celá čísla, pak doplň čárku.',`= ${r1(a*b)}`],skill:'calc'}); }
-  { const b=ri(2,5),h=ri(10,40)/10; tasks.push({text:`${r1(h*b)} ÷ ${b} = ?`,ans:r1(h),hints:['Děl jako celá čísla, hlídej čárku.',`= ${r1(h)}`],skill:'calc'}); }
+  { const b=ri(2,5),h=ri(10,40)/10; tasks.push({text:`${r1(h*b)} : ${b} = ?`,ans:r1(h),hints:['Děl jako celá čísla, hlídej čárku.',`= ${r1(h)}`],skill:'calc'}); }
   { const a=ri(100,990)/100; tasks.push({text:`Zaokrouhli ${cz(a)} na desetiny.`,ans:r1(a),hints:['Rozhodují setiny.',`≈ ${r1(a)}`],skill:'calc'}); }
   return tasks;
 }

--- a/projects/rpg-tasks-7.js
+++ b/projects/rpg-tasks-7.js
@@ -27,7 +27,7 @@ function gen_1_1(){
   tasks.push({text:`Vypočítej zpaměti: ${e} × ${f} = ?`,ans:e*f,hints:[`Rozlož ${f} = ${Math.floor(f/2)} + ${f-Math.floor(f/2)}.`,`${e} × ${f} = ${e*f}`],skill:'calc'});
   // dělení
   const g=ri(3,9),h=g*ri(4,12);
-  tasks.push({text:`Vypočítej zpaměti: ${h} ÷ ${g} = ?`,ans:h/g,hints:[`Kolikrát se vejde ${g} do ${h}?`,`${h} ÷ ${g} = ${h/g}`],skill:'calc'});
+  tasks.push({text:`Vypočítej zpaměti: ${h} : ${g} = ?`,ans:h/g,hints:[`Kolikrát se vejde ${g} do ${h}?`,`${h} : ${g} = ${h/g}`],skill:'calc'});
   // mix
   const i=ri(5,15),j=ri(3,8);
   tasks.push({text:`Vypočítej zpaměti: ${i} × ${j} − ${j} = ?`,ans:i*j-j,hints:[`Vytknout ${j}: ${j}·(${i}−1).`,`${j}·${i-1} = ${i*j-j}`],skill:'calc'});
@@ -35,12 +35,12 @@ function gen_1_1(){
   tasks.push({text:`Vypočítej zpaměti: ${k} + ${l} × ${l} = ?`,ans:k+l*l,hints:[`Nejdřív ${l}×${l} = ${l*l}, pak přičti.`,`${k} + ${l*l} = ${k+l*l}`],skill:'calc'});
   { const a=ri(120,480),b=ri(110,360); tasks.push({text:`Vypočítej: ${a} + ${b} = ?`,ans:a+b,hints:['Sčítej po řádech (jednotky, desítky, stovky).',`${a}+${b} = ${a+b}`],skill:'calc'}); }
   { const a=ri(13,29),b=ri(13,29); tasks.push({text:`Vypočítej: ${a} × ${b} = ?`,ans:a*b,hints:[`Rozlož ${b} na desítky a jednotky.`,`${a}×${b} = ${a*b}`],skill:'calc'}); }
-  { const g=ri(4,9),h=g*ri(11,30); tasks.push({text:`Vypočítej: ${h} ÷ ${g} = ?`,ans:h/g,hints:[`Kolikrát se ${g} vejde do ${h}?`,`${h}÷${g} = ${h/g}`],skill:'calc'}); }
+  { const g=ri(4,9),h=g*ri(11,30); tasks.push({text:`Vypočítej: ${h} : ${g} = ?`,ans:h/g,hints:[`Kolikrát se ${g} vejde do ${h}?`,`${h}:${g} = ${h/g}`],skill:'calc'}); }
   { const a=ri(2,9),b=ri(2,9),c=ri(2,9); tasks.push({text:`Vypočítej: ${a} × ${b} + ${c} = ?`,ans:a*b+c,hints:['Nejdřív násobení, pak sčítání.',`${a*b}+${c} = ${a*b+c}`],skill:'calc'}); }
   return tasks;
 }
 
-// 1-2 Desetinná čísla (+−×÷)
+// 1-2 Desetinná čísla (+−×:)
 function gen_1_2(){
   const tasks=[];
   const a=ri(10,50)/10, b=ri(5,30)/10;
@@ -50,7 +50,7 @@ function gen_1_2(){
   const e=ri(2,9), f=ri(11,49)/10;
   tasks.push({text:`${e} × ${cz(f)} = ?`,ans:r2(e*f),hints:[`Přepočti: ${e} × ${Math.round(f*10)} desetin.`,`Výsledek = ${r2(e*f)}`],skill:'calc'});
   const g=ri(11,49)/10, h=ri(2,5);
-  tasks.push({text:`${cz(g)} ÷ ${h} = ?`,ans:r2(g/h),hints:[`Dělíme ${Math.round(g*10)} desetin číslem ${h}.`,`Výsledek = ${r2(g/h)}`],skill:'calc'});
+  tasks.push({text:`${cz(g)} : ${h} = ?`,ans:r2(g/h),hints:[`Dělíme ${Math.round(g*10)} desetin číslem ${h}.`,`Výsledek = ${r2(g/h)}`],skill:'calc'});
   const i=ri(10,30)/10, j=ri(10,30)/10;
   tasks.push({text:`${cz(i)} × ${cz(j)} = ?`,ans:r2(i*j),hints:[`Počítej: ${Math.round(i*10)} × ${Math.round(j*10)} = ${Math.round(i*10)*Math.round(j*10)}, poděl 100.`,`Výsledek = ${r2(i*j)}`],skill:'calc'});
   const k=ri(15,60)/10, l=ri(10,30)/10;
@@ -182,7 +182,7 @@ function gen_2_3(){
   const g=ri(2,5),h=ri(3,8),i=ri(2,5),j=ri(3,8);
   const topD=g*j,botD=h*i,gD=gcd(topD,botD);
   const ansD=gD===botD?String(topD/gD):`${topD/gD}/${botD/gD}`;
-  tasks.push({text:`${g}/${h} ÷ ${i}/${j} = ?`,ans:ansD,hints:['Dělení zlomkem = násobení převráceným zlomkem.',`${g}/${h} × ${j}/${i} = ${topD}/${botD} → zkrať.`],skill:'calc'});
+  tasks.push({text:`${g}/${h} : ${i}/${j} = ?`,ans:ansD,hints:['Dělení zlomkem = násobení převráceným zlomkem.',`${g}/${h} × ${j}/${i} = ${topD}/${botD} → zkrať.`],skill:'calc'});
   // zlomek z čísla
   const k=ri(2,5),l=ri(3,8),m=ri(2,6)*l;
   const topK=k*m,gK=gcd(topK,l);
@@ -196,7 +196,7 @@ function gen_2_3(){
   const ansR=gR===s?String(topR/gR):`${topR/gR}/${s/gR}`;
   tasks.push({text:`${r} ${skl(r,'celá','celé','celých')} ${1}/${s} × ${t} = ? (smíšené číslo: výsledek jako čitatel po zkrácení)`,ans:topR/gR,hints:['Smíšené číslo převeď na zlomek: celá část × jmenovatel + čitatel.','('+topR+'/'+gR+')/'+s/gR],skill:'calc'});
   { const a=ri(2,5),b=ri(3,8);const g=gcd(a,b);const ans=g===b?String(a/g):`${a/g}/${b/g}`;tasks.push({text:`${a}/${b} × ${b}/${a} = ?`,ans:'1',hints:['Číslo × jeho převrácená = 1.','= 1'],skill:'calc'}); }
-  { const a=ri(2,6),b=ri(3,8),k=ri(2,4);const top=a*k,g=gcd(top,b);const ans=g===b?String(top/g):`${top/g}/${b/g}`;tasks.push({text:`${k} ÷ ${b}/${a} = ?`,ans,hints:['Dělení zlomkem = násobení převráceným.',`${k} × ${a}/${b} = ${k*a}/${b}`],skill:'calc'}); }
+  { const a=ri(2,6),b=ri(3,8),k=ri(2,4);const top=a*k,g=gcd(top,b);const ans=g===b?String(top/g):`${top/g}/${b/g}`;tasks.push({text:`${k} : ${b}/${a} = ?`,ans,hints:['Dělení zlomkem = násobení převráceným.',`${k} × ${a}/${b} = ${k*a}/${b}`],skill:'calc'}); }
   { const a=ri(2,5),b=ri(2,a);const ans=`${b}/${a}`;tasks.push({text:`Jaké je převrácené číslo k ${a}/${b}?`,ans,hints:['Převrácená hodnota: vyměň čitatel a jmenovatel.',`${b}/${a}`],skill:'calc'}); }
   { const a=ri(2,4),b=ri(3,8),c=ri(2,5),d=ri(3,8);const top=a*c,bot=b*d,g=gcd(top,bot);const ans=g===bot?String(top/g):`${top/g}/${bot/g}`;tasks.push({text:`${a}/${b} × ${c}/${d} = ?`,ans,hints:['Čitatele × čitatele, jmenovatele × jmenovatele.',`${a*c}/${b*d} zkrať.`],skill:'calc'}); }
   return tasks;
@@ -238,14 +238,14 @@ function gen_3_2(){
   const e=ri(2,9),f=ri(2,9);
   tasks.push({text:`${e} × (−${f}) = ?`,ans:-(e*f),hints:['Kladné × záporné = záporné.','= −'+(e*f)],skill:'calc'});
   const g=ri(2,8),h=g*ri(2,9);
-  tasks.push({text:`(−${h}) ÷ ${g} = ?`,ans:-(h/g),hints:['Záporné ÷ kladné = záporné.','= −'+(h/g)],skill:'calc'});
+  tasks.push({text:`(−${h}) : ${g} = ?`,ans:-(h/g),hints:['Záporné : kladné = záporné.','= −'+(h/g)],skill:'calc'});
   const i=ri(2,8),j=i*ri(2,9);
-  tasks.push({text:`(−${j}) ÷ (−${i}) = ?`,ans:j/i,hints:['Záporné ÷ záporné = kladné.','= '+(j/i)],skill:'calc'});
+  tasks.push({text:`(−${j}) : (−${i}) = ?`,ans:j/i,hints:['Záporné : záporné = kladné.','= '+(j/i)],skill:'calc'});
   const k=ri(2,6),l=ri(2,6),m=ri(2,6);
   tasks.push({text:`(−${k}) × ${l} × (−${m}) = ?`,ans:k*l*m,hints:['Dvě záporná čísla → výsledek kladný.','= '+(k*l*m)],skill:'calc'});
   { const a=ri(2,9),b=ri(2,9); tasks.push({text:`${a} × (−${b}) = ?`,ans:-(a*b),hints:['Kladné × záporné = záporné.','= −'+(a*b)],skill:'calc'}); }
   { const a=ri(2,9),b=ri(2,9); tasks.push({text:`(−${a}) × (−${b}) = ?`,ans:a*b,hints:['Záporné × záporné = kladné.','= '+(a*b)],skill:'calc'}); }
-  { const a=ri(2,8),b=a*ri(2,9); tasks.push({text:`${b} ÷ (−${a}) = ?`,ans:-(b/a),hints:['Kladné ÷ záporné = záporné.','= −'+(b/a)],skill:'calc'}); }
+  { const a=ri(2,8),b=a*ri(2,9); tasks.push({text:`${b} : (−${a}) = ?`,ans:-(b/a),hints:['Kladné : záporné = záporné.','= −'+(b/a)],skill:'calc'}); }
   { const a=ri(2,6),b=ri(2,6),c=ri(2,6); tasks.push({text:`(−${a}) × (−${b}) × (−${c}) = ?`,ans:-(a*b*c),hints:['Tři záporná čísla → výsledek záporný.','= −'+(a*b*c)],skill:'calc'}); }
   return tasks;
 }
@@ -263,7 +263,7 @@ function gen_3_3(){
   tasks.push({text:`(−${cz(h)}) + ${cz(i)} = ?`,ans:r1(i-h),hints:['Záporné + kladné: odečti menší od většího.','= '+r1(i-h)],skill:'calc'});
   const j=ri(2,6), k=ri(3,9);
   const jk=j*k;
-  tasks.push({text:`(−${jk}) ÷ (−${j}) = ?`,ans:k,hints:['Záporné ÷ záporné = kladné.','= '+k],skill:'calc'});
+  tasks.push({text:`(−${jk}) : (−${j}) = ?`,ans:k,hints:['Záporné : záporné = kladné.','= '+k],skill:'calc'});
   const m=ri(1,5),n=ri(3,8),o=ri(1,m-1)||1;
   tasks.push({text:`−${m}/${n} − (−${o}/${n}) = ?`,ans:(o-m)===0?'0':`${o-m}/${n}`,hints:['Odečíst záporné = přičíst kladné.','−'+m+'/'+n+' + '+o+'/'+n+' = '+(o-m)+'/'+n],skill:'calc'});
   { const a=ri(2,5),b=ri(3,9),c=ri(2,5);const top=a*c,g=gcd(top,b);const ans=g===b?String(-top/g):`-${top/g}/${b/g}`;tasks.push({text:`(−${a}/${b}) × ${c} = ?`,ans,hints:['Záporný zlomek × kladné = záporné.',`−${a*c}/${b} zkrať.`],skill:'calc'}); }
@@ -355,7 +355,7 @@ function gen_4_3(){
   tasks.push({text:`Místnost je na plánu (1 : ${ne}) ${e} cm × ${f} cm. Jaký je skutečný obsah v m²?`,ans:r2(e*f*ne*ne/10000),hints:['Skutečné strany: '+e+'×'+ne+' cm a '+f+'×'+ne+' cm.',r2(e*ne/100)+'×'+r2(f*ne/100)+' = '+r2(e*f*ne*ne/10000)+' m²'],skill:'geo'});
   // zpět na mapu z plochy
   const g=ri(3,9),h=ri(3,9),ng=50;
-  tasks.push({text:`Políčko je ${g} m × ${h} m. V měřítku 1 : ${ng*100} jaké jsou rozměry na plánu (cm × cm)? Zadej součin obou rozměrů (cm²).`,ans:r2(g*100/(ng*100)*100)*r2(h*100/(ng*100)*100),hints:['Každý rozměr ÷ měřítko v cm.',String(r2(g*100/(ng*100)*100))+' × '+String(r2(h*100/(ng*100)*100))],skill:'anal'});
+  tasks.push({text:`Políčko je ${g} m × ${h} m. V měřítku 1 : ${ng*100} jaké jsou rozměry na plánu (cm × cm)? Zadej součin obou rozměrů (cm²).`,ans:r2(g*100/(ng*100)*100)*r2(h*100/(ng*100)*100),hints:['Každý rozměr : měřítko v cm.',String(r2(g*100/(ng*100)*100))+' × '+String(r2(h*100/(ng*100)*100))],skill:'anal'});
   { const a=ri(3,9),ma=ri(2,4)*50000; tasks.push({text:`Na mapě (1:${ma.toLocaleString('cs-CZ')}) měří úsek ${a} cm. Skutečná vzdálenost v km?`,ans:r1(a*ma/100000),hints:['Skutečnost = mapa × měřítko.',r1(a*ma/100000)+' km'],skill:'anal'}); }
   { const b=ri(2,8),mb=200; tasks.push({text:`Plán (1:${mb}), stěna ${b} cm na plánu. Skutečná délka v metrech?`,ans:r2(b*mb/100),hints:['Skutečnost = plán × měřítko.',`${b}×${mb} cm = ${b*mb} cm = ${r2(b*mb/100)} m`],skill:'anal'}); }
   { const c=ri(50,200),nc=25000; tasks.push({text:`Skutečná vzdálenost ${c} m, měřítko 1:${nc.toLocaleString('cs-CZ')}. Na mapě? (v cm)`,ans:r2(c*100/nc),hints:['Mapa = skutečnost(cm) / měřítko.',r2(c*100/nc)+' cm'],skill:'anal'}); }

--- a/projects/rpg-tasks-8.js
+++ b/projects/rpg-tasks-8.js
@@ -28,7 +28,7 @@ window.RPG_TASK_EXTRA_8 = {
   (()=>{const a=ri(8,40),b=ri(8,40);return{text:`Vypočítej:\n(-${a}) + (-${b}) =`,ans:String(-a-b),hints:[`Obě čísla záporná → sečti a dej minus.`,`-(${a}+${b})`],skill:'calc'};})(),
   (()=>{const a=ri(10,40),b=ri(10,40);return{text:`Vypočítej:\n(-${a}) - (-${b}) =`,ans:String(-a+b),hints:[`- (-${b}) = + ${b}.`,`-${a} + ${b}`],skill:'calc'};})(),
   (()=>{const a=ri(3,12),b=ri(3,9);return{text:`Vypočítej:\n(-${a}) × ${b} =`,ans:String(-a*b),hints:[`Mínus × plus = mínus.`],skill:'calc'};})(),
-  (()=>{const b=ri(3,9),q=ri(3,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ (-${b}) =`,ans:String(q),hints:[`Mínus ÷ mínus = plus.`,`${a} ÷ ${b}`],skill:'calc'};})(),
+  (()=>{const b=ri(3,9),q=ri(3,9),a=b*q;return{text:`Vypočítej:\n(-${a}) : (-${b}) =`,ans:String(q),hints:[`Mínus : mínus = plus.`,`${a} : ${b}`],skill:'calc'};})(),
   (()=>{const a=ri(5,20);return{text:`Vypočítej absolutní hodnotu:\n|-${a}| =`,ans:String(a),hints:[`Absolutní hodnota je vždy nezáporná.`],skill:'calc'};})(),
   (()=>{const a=ri(10,30),b=ri(31,60);return{text:`Vypočítej:\n${a} - ${b} =`,ans:String(a-b),hints:[`Menší minus větší → výsledek záporný.`,`-(${b}-${a})`],skill:'calc'};})(),
   (()=>{const a=ri(2,8);return{text:`Vypočítej:\n(-${a})² =`,ans:String(a*a),hints:[`Záporné číslo na sudou mocninu → kladné: ${a}×${a}.`],skill:'calc'};})(),
@@ -45,20 +45,20 @@ window.RPG_TASK_EXTRA_8 = {
   (()=>{const a=ri(2,8),k=ri(1,9);return{text:`Vypočítej:\n${a} + 0,${k} =`,ans:r1(a+k/10),hints:[`Zarovnej desetinné čárky.`],skill:'calc'};})(),
   (()=>{const a=ri(2,5),b=ri(2,5);const num=a+b,g=gcd(num,6);const ans=6/g===1?String(num/g):`${num/g}/${6/g}`;return{text:`Vypočítej:\n${a}/6 + ${b}/6 =`,ans,hints:[`Stejný jmenovatel.`,`${num}/6 → zkrať.`],skill:'calc'};})(),
   (()=>{const a=ri(2,5),b=ri(3,8);const c=a*b;return{text:`Smíšené číslo: ${a} ${Math.floor(1/2)+1}/${b} — převeď na zlomek.\n(${a}·${b}+1)/${b} = ?`,ans:`${a*b+1}/${b}`,hints:[`Celý díl × jmenovatel + čitatel.`,`${a*b+1}/${b}`],skill:'calc'};})(),
-  (()=>{const a=ri(2,6),b=ri(2,4);const div=a*b;const g=gcd(a,div);const ans=div/g===1?String(a/g):`${a/g}/${div/g}`;return{text:`Vypočítej:\n${a} ÷ ${b} =`,ans:String(a/b%1===0?a/b:`${a}/${b}`),hints:[`Dělení = násobení převráceným číslem.`,`${a} × 1/${b}`],skill:'calc'};})(),
+  (()=>{const a=ri(2,6),b=ri(2,4);const div=a*b;const g=gcd(a,div);const ans=div/g===1?String(a/g):`${a/g}/${div/g}`;return{text:`Vypočítej:\n${a} : ${b} =`,ans:String(a/b%1===0?a/b:`${a}/${b}`),hints:[`Dělení = násobení převráceným číslem.`,`${a} × 1/${b}`],skill:'calc'};})(),
   (()=>{const a=ri(1,4),b=ri(5,9);return{text:`Je ${a}/${b} větší než 1/2?\n(ANO/NE)`,ans:2*a>b?'ANO':'NE',hints:[`Porovnej 2·${a} s ${b}.`,`2·${a}=${2*a}, ${2*a>b?'>':'≤'} ${b}`],skill:'calc'};})()
  ],
  '1-3': () => [   // Procenta
-  (()=>{const z=ri(2,12)*10,p=ri(2,9)*5;return{text:`Kolik je ${p} % z ${z}?`,ans:String(Math.round(z*p/100)),hints:[`${p} % = ${p}/100.`,`${z} × ${p} ÷ 100`],skill:'anal'};})(),
-  (()=>{const c=ri(4,20)*10,v=ri(1,c/10)*10;return{text:`Kolika procenty je ${v} z ${c}?\n(celé číslo)`,ans:String(Math.round(v/c*100)),hints:[`Část ÷ celek × 100.`,`${v} ÷ ${c} × 100`],skill:'anal'};})(),
+  (()=>{const z=ri(2,12)*10,p=ri(2,9)*5;return{text:`Kolik je ${p} % z ${z}?`,ans:String(Math.round(z*p/100)),hints:[`${p} % = ${p}/100.`,`${z} × ${p} : 100`],skill:'anal'};})(),
+  (()=>{const c=ri(4,20)*10,v=ri(1,c/10)*10;return{text:`Kolika procenty je ${v} z ${c}?\n(celé číslo)`,ans:String(Math.round(v/c*100)),hints:[`Část : celek × 100.`,`${v} : ${c} × 100`],skill:'anal'};})(),
   (()=>{const z=ri(10,40)*10,p=ri(1,4)*10;const ans=z-Math.round(z*p/100);return{text:`Zboží stojí ${z} Kč, sleva ${p} %.\nNová cena? (Kč)`,ans:String(ans),hints:[`Sleva = ${p} % z ${z}.`,`${z} - ${Math.round(z*p/100)}`],skill:'anal'};})(),
   (()=>{const z=ri(10,30)*10,p=ri(1,5)*5;const ans=z+Math.round(z*p/100);return{text:`Cena ${z} Kč vzrostla o ${p} %.\nNová cena? (Kč)`,ans:String(ans),hints:[`Přírůstek = ${p} % z ${z}.`],skill:'anal'};})(),
   (()=>{const z=ri(8,30)*100,p=ri(1,4)*2;return{text:`Vklad ${z} Kč, úrok ${p} % ročně.\nÚrok za rok? (Kč)`,ans:String(Math.round(z*p/100)),hints:[`Úrok = ${p} % z vkladu.`],skill:'anal'};})(),
-  (()=>{const p=[10,20,25,50][ri(0,3)],cel=ri(3,9)*20,cast=Math.round(cel*p/100);return{text:`${cast} je ${p} % celku.\nJaký je celek?`,ans:String(cel),hints:[`Celek = část ÷ ${p} × 100.`],skill:'anal'};})(),
+  (()=>{const p=[10,20,25,50][ri(0,3)],cel=ri(3,9)*20,cast=Math.round(cel*p/100);return{text:`${cast} je ${p} % celku.\nJaký je celek?`,ans:String(cel),hints:[`Celek = část : ${p} × 100.`],skill:'anal'};})(),
   (()=>{const cena=ri(10,40)*10,dph=21;const s_dph=Math.round(cena*(1+dph/100));return{text:`Cena bez DPH: ${cena} Kč.\nCena s DPH ${dph} %? (Kč)`,ans:String(s_dph),hints:[`${dph} % z ${cena} = ${Math.round(cena*dph/100)}.`,`${cena} + ${Math.round(cena*dph/100)}`],skill:'anal'};})(),
-  (()=>{const orig=ri(200,800),nov=ri(1,4)*50;const pct=Math.round((nov/orig)*100);return{text:`Plat vzrostl z ${orig} Kč o ${nov} Kč.\nO kolik procent?`,ans:String(pct),hints:[`${nov} ÷ ${orig} × 100.`],skill:'anal'};})(),
-  (()=>{const z=ri(2,6)*100,p=ri(5,9)*10;const cast=z*p/100;return{text:`${p} % ze čtvrtletního výdělku ${z} Kč jde na nájem.\nKolik Kč? (Kč)`,ans:String(cast),hints:[`${p} ÷ 100 × ${z}.`],skill:'anal'};})(),
-  (()=>{const nov=ri(5,15)*10,orig=nov+ri(1,5)*10;return{text:`Cena klesla z ${orig} Kč na ${nov} Kč.\nO kolik procent? (celé číslo)`,ans:String(Math.round((orig-nov)/orig*100)),hints:[`Pokles ÷ původní × 100.`,`${orig-nov} ÷ ${orig} × 100`],skill:'anal'};})()
+  (()=>{const orig=ri(200,800),nov=ri(1,4)*50;const pct=Math.round((nov/orig)*100);return{text:`Plat vzrostl z ${orig} Kč o ${nov} Kč.\nO kolik procent?`,ans:String(pct),hints:[`${nov} : ${orig} × 100.`],skill:'anal'};})(),
+  (()=>{const z=ri(2,6)*100,p=ri(5,9)*10;const cast=z*p/100;return{text:`${p} % ze čtvrtletního výdělku ${z} Kč jde na nájem.\nKolik Kč? (Kč)`,ans:String(cast),hints:[`${p} : 100 × ${z}.`],skill:'anal'};})(),
+  (()=>{const nov=ri(5,15)*10,orig=nov+ri(1,5)*10;return{text:`Cena klesla z ${orig} Kč na ${nov} Kč.\nO kolik procent? (celé číslo)`,ans:String(Math.round((orig-nov)/orig*100)),hints:[`Pokles : původní × 100.`,`${orig-nov} : ${orig} × 100`],skill:'anal'};})()
  ],
 
  // ───────── OBLAST 2 — PYTHAGORAS ─────────
@@ -127,14 +127,14 @@ window.RPG_TASK_EXTRA_8 = {
  '3-3': () => [   // Slovní úlohy
   (()=>{const x=ri(3,15),a=ri(2,5),b=ri(2,12);return{text:`Myslím si číslo. Když ho vynásobím ${a} a přičtu ${b},\ndostanu ${a*x+b}. Jaké je číslo?`,ans:String(x),hints:[`Rovnice: ${a}x + ${b} = ${a*x+b}.`],skill:'anal'};})(),
   (()=>{const syn=ri(8,14),roz=ri(20,30);return{text:`Otci je o ${roz} let více než synovi (${syn} let).\nKolik let je otci?`,ans:String(syn+roz),hints:[`${syn} + ${roz}.`],skill:'anal'};})(),
-  (()=>{const cena=ri(3,9)*10,ks=ri(3,8);return{text:`${ks} stejných sešitů stálo ${cena*ks} Kč.\nKolik stál jeden? (Kč)`,ans:String(cena),hints:[`Celek ÷ počet.`,`${cena*ks} ÷ ${ks}`],skill:'anal'};})(),
+  (()=>{const cena=ri(3,9)*10,ks=ri(3,8);return{text:`${ks} stejných sešitů stálo ${cena*ks} Kč.\nKolik stál jeden? (Kč)`,ans:String(cena),hints:[`Celek : počet.`,`${cena*ks} : ${ks}`],skill:'anal'};})(),
   (()=>{const cel=ri(4,9)*10,prvni=ri(10,cel-10);return{text:`Lano ${cel} m rozdělíme na dva kusy.\nJeden má ${prvni} m. Druhý? (m)`,ans:String(cel-prvni),hints:[`${cel} - ${prvni}.`],skill:'anal'};})(),
   (()=>{const x=ri(5,20);return{text:`Číslo zvětšené o svou polovinu je ${x*1.5}.\nJaké je číslo?`,ans:String(x),hints:[`x + x/2 = 1,5x.`,`1,5x = ${x*1.5}`],skill:'anal'};})(),
   (()=>{const aut=ri(8,15),kol=aut+ri(3,9);return{text:`Na parkovišti je ${aut} aut a ${kol} kol.\nO kolik víc je kol než aut?`,ans:String(kol-aut),hints:[`${kol} - ${aut}.`],skill:'anal'};})(),
   (()=>{const a=ri(5,12),b=ri(3,10);return{text:`Obvod obdélníku je ${2*(a+b)} cm, jedna strana ${a} cm.\nDruhá strana? (cm)`,ans:String(b),hints:[`o = 2(a+b), b = o/2 − a.`,`${a+b} − ${a}`],skill:'anal'};})(),
-  (()=>{const v=ri(6,12)*5,t=ri(2,4);return{text:`Auto ujelo ${v*t} km za ${t} h.\nPrůměrná rychlost? (km/h)`,ans:String(v),hints:[`v = dráha ÷ čas.`,`${v*t} ÷ ${t}`],skill:'anal'};})(),
+  (()=>{const v=ri(6,12)*5,t=ri(2,4);return{text:`Auto ujelo ${v*t} km za ${t} h.\nPrůměrná rychlost? (km/h)`,ans:String(v),hints:[`v = dráha : čas.`,`${v*t} : ${t}`],skill:'anal'};})(),
   (()=>{const x=ri(4,12),n=ri(3,5);return{text:`Součet ${n} po sobě jdoucích čísel je ${n*x+(n*(n-1)/2)}.\nNejmenší číslo?`,ans:String(x),hints:[`${n} čísel: x, x+1, …, x+${n-1}.`,`${n}x + ${n*(n-1)/2} = ${n*x+(n*(n-1)/2)}`],skill:'anal'};})(),
-  (()=>{const ks=ri(4,9),a=ri(10,30)*2,more=ks+ri(1,4);return{text:`${ks} ${skl(ks,'jablko stálo','jablka stála','jablek stálo')} ${ks*a} Kč.\nKolik stojí ${more} ${skl(more,'jablko','jablka','jablek')}?`,ans:String(more*a),hints:[`Cena za 1 jablko = ${ks*a} ÷ ${ks}.`],skill:'anal'};})()
+  (()=>{const ks=ri(4,9),a=ri(10,30)*2,more=ks+ri(1,4);return{text:`${ks} ${skl(ks,'jablko stálo','jablka stála','jablek stálo')} ${ks*a} Kč.\nKolik stojí ${more} ${skl(more,'jablko','jablka','jablek')}?`,ans:String(more*a),hints:[`Cena za 1 jablko = ${ks*a} : ${ks}.`],skill:'anal'};})()
  ],
 
  // ───────── OBLAST 4 — VÝRAZY ─────────
@@ -165,12 +165,12 @@ window.RPG_TASK_EXTRA_8 = {
  '4-3': () => [   // Vytýkání (NSD)
   (()=>{const g=ri(2,8),a=g*ri(2,5),b=g*ri(2,5);const gg=gcd(a,b);return{text:`Vytkni největší společné číslo z:\n${a}x + ${b}\nJaké číslo vytkneš?`,ans:String(gg),hints:[`Hledej NSD čísel ${a} a ${b}.`,`NSD = ${gg}`],skill:'calc'};})(),
   (()=>{const a=ri(2,9)*ri(2,4),b=ri(2,9)*ri(2,4);const gg=gcd(a,b);return{text:`Najdi největší společný dělitel:\nNSD(${a}, ${b}) =`,ans:String(gg),hints:[`Rozlož na prvočísla.`],skill:'calc'};})(),
-  (()=>{const k=ri(2,6),a=ri(2,5),b=ri(2,5);return{text:`Vytkni ${k}:\n${k*a}x + ${k*b} = ${k}(__ x + ${b})\nDoplň první číslo:`,ans:String(a),hints:[`${k*a} ÷ ${k}.`],skill:'calc'};})(),
-  (()=>{const k=ri(2,7),a=ri(3,8);return{text:`Vytkni společné x:\n${a}x² + ${k}x = x(__ x + ${k})\nDoplň první číslo:`,ans:String(a),hints:[`${a}x² ÷ x = ${a}x.`],skill:'calc'};})(),
+  (()=>{const k=ri(2,6),a=ri(2,5),b=ri(2,5);return{text:`Vytkni ${k}:\n${k*a}x + ${k*b} = ${k}(__ x + ${b})\nDoplň první číslo:`,ans:String(a),hints:[`${k*a} : ${k}.`],skill:'calc'};})(),
+  (()=>{const k=ri(2,7),a=ri(3,8);return{text:`Vytkni společné x:\n${a}x² + ${k}x = x(__ x + ${k})\nDoplň první číslo:`,ans:String(a),hints:[`${a}x² : x = ${a}x.`],skill:'calc'};})(),
   (()=>{const g=ri(3,9),a=g*ri(2,6),b=g*ri(2,6),c=g*ri(2,6);return{text:`Společné číslo k vytknutí z:\n${a}x + ${b}y + ${c}\nNSD koeficientů =`,ans:String(gcd(gcd(a,b),c)),hints:[`NSD všech tří čísel.`],skill:'calc'};})(),
   (()=>{const a=ri(2,6);return{text:`Vytkni z výrazu ${a}a + ${a}b společné číslo.\nJaké číslo vytkneš?`,ans:String(a),hints:[`Obě části mají činitel ${a}.`],skill:'calc'};})(),
-  (()=>{const k=ri(2,5),a=ri(2,4),b=ri(2,4);return{text:`Vytkni x:\n${k}x² − ${a}x = x(${k}x − ?)`,ans:String(a),hints:[`Druhý člen: ${a}x ÷ x = ${a}.`],skill:'calc'};})(),
-  (()=>{const g=ri(2,4),a=g*ri(2,4),b=g*ri(3,6);return{text:`Vytkni NSD z:\n${a}a² + ${b}a = ${g}a(? + ${b/g})\nDoplň ?:`,ans:String(a/g)+'a',hints:[`${a}a² ÷ (${g}a) = ${a/g}a.`],skill:'calc'};})(),
+  (()=>{const k=ri(2,5),a=ri(2,4),b=ri(2,4);return{text:`Vytkni x:\n${k}x² − ${a}x = x(${k}x − ?)`,ans:String(a),hints:[`Druhý člen: ${a}x : x = ${a}.`],skill:'calc'};})(),
+  (()=>{const g=ri(2,4),a=g*ri(2,4),b=g*ri(3,6);return{text:`Vytkni NSD z:\n${a}a² + ${b}a = ${g}a(? + ${b/g})\nDoplň ?:`,ans:String(a/g)+'a',hints:[`${a}a² : (${g}a) = ${a/g}a.`],skill:'calc'};})(),
   (()=>{const a=ri(4,8),b=ri(3,6);const g=gcd(a,b);return{text:`Výraz ${a}x + ${b}y − ${g}.\nNajdi číslo, které nelze vytknout z celého výrazu:`,ans:String(g+ri(1,3)),hints:[`Vytknout lze jen NSD = ${g}.`],skill:'calc'};})(),
   (()=>{const k=ri(2,5),a=ri(2,4),b=ri(2,4);return{text:`Je ${k} NSD z ${k*a} a ${k*b}?\n(ANO/NE)`,ans:gcd(k*a,k*b)===k?'ANO':'NE',hints:[`NSD(${k*a},${k*b}) = ${gcd(k*a,k*b)}.`],skill:'calc'};})()
  ],
@@ -182,10 +182,10 @@ window.RPG_TASK_EXTRA_8 = {
   (()=>{const d=ri(4,16);return{text:`Kruh o průměru d = ${d}.\nObvod? (π = 3,14)`,ans:r2(PI*d),hints:[`o = πd.`,`3,14 × ${d}`],skill:'geo'};})(),
   (()=>{const d=ri(4,12);const r=d/2;return{text:`Kruh o průměru d = ${d}.\nObsah? (π = 3,14)`,ans:r2(PI*r*r),hints:[`r = ${r}, S = πr².`,`3,14 × ${r}²`],skill:'geo'};})(),
   (()=>{const r=ri(3,8);return{text:`Polovina kruhu o poloměru ${r}.\nObsah půlkruhu? (π = 3,14)`,ans:r2(PI*r*r/2),hints:[`Půlka z πr².`],skill:'geo'};})(),
-  (()=>{const r=ri(2,7);return{text:`Kruh o poloměru ${r}.\nObvod ÷ 2 = (π = 3,14)`,ans:r2(PI*r),hints:[`2πr ÷ 2 = πr.`],skill:'geo'};})(),
-  (()=>{const r=ri(3,8);return{text:`Čtvrtina kruhu o poloměru ${r}.\nObsah čtvrtiny? (π = 3,14)`,ans:r2(PI*r*r/4),hints:[`¼ z πr².`,`3,14 × ${r*r} ÷ 4`],skill:'geo'};})(),
+  (()=>{const r=ri(2,7);return{text:`Kruh o poloměru ${r}.\nObvod : 2 = (π = 3,14)`,ans:r2(PI*r),hints:[`2πr : 2 = πr.`],skill:'geo'};})(),
+  (()=>{const r=ri(3,8);return{text:`Čtvrtina kruhu o poloměru ${r}.\nObsah čtvrtiny? (π = 3,14)`,ans:r2(PI*r*r/4),hints:[`¼ z πr².`,`3,14 × ${r*r} : 4`],skill:'geo'};})(),
   (()=>{const d=ri(6,14);return{text:`Průměr kola d = ${d} cm.\nObvod (π = 3,14)?`,ans:r2(PI*d),hints:[`o = πd.`,`3,14 × ${d}`],skill:'geo'};})(),
-  (()=>{const r=ri(2,6);return{text:`Obsah kruhu = ${r2(PI*r*r)} cm².\nJaký je poloměr? (π = 3,14)`,ans:String(r),hints:[`S = πr², r = √(S/π).`,`r = √(${r2(PI*r*r)} ÷ 3,14) = ${r}`],skill:'geo'};})(),
+  (()=>{const r=ri(2,6);return{text:`Obsah kruhu = ${r2(PI*r*r)} cm².\nJaký je poloměr? (π = 3,14)`,ans:String(r),hints:[`S = πr², r = √(S/π).`,`r = √(${r2(PI*r*r)} : 3,14) = ${r}`],skill:'geo'};})(),
   (()=>{const r=ri(3,7);return{text:`Tři čtvrtiny kruhu o poloměru ${r}.\nObsah? (π = 3,14)`,ans:r2(3*PI*r*r/4),hints:[`¾ × πr².`,`3 × ${r2(PI*r*r/4)}`],skill:'geo'};})()
  ],
  '5-2': () => [   // Válec
@@ -228,7 +228,7 @@ window.RPG_TASK_EXTRA_8 = {
  ],
  '6-2': () => [   // Thaletova kružnice
   (()=>{return{text:`Úhel nad průměrem (Thaletova kružnice)\nmá vždy kolik stupňů?`,ans:'90',hints:[`Thaletova věta → pravý úhel.`],skill:'geo'};})(),
-  (()=>{const c=ri(6,16);return{text:`Přepona pravoúhlého trojúhelníku = ${c}.\nPoloměr Thaletovy kružnice?`,ans:r1(c/2),hints:[`Poloměr = polovina přepony.`,`${c} ÷ 2`],skill:'geo'};})(),
+  (()=>{const c=ri(6,16);return{text:`Přepona pravoúhlého trojúhelníku = ${c}.\nPoloměr Thaletovy kružnice?`,ans:r1(c/2),hints:[`Poloměr = polovina přepony.`,`${c} : 2`],skill:'geo'};})(),
   (()=>{return{text:`Vrchol pravého úhlu trojúhelníku leží\nna Thaletově kružnici. Platí?\n(ANO/NE)`,ans:'ANO',hints:[`To je podstata Thaletovy věty.`],skill:'geo'};})(),
   (()=>{const r=ri(3,9);return{text:`Thaletova kružnice má poloměr ${r}.\nDélka přepony (= průměr)?`,ans:String(2*r),hints:[`Přepona = průměr = 2r.`],skill:'geo'};})(),
   (()=>{return{text:`Je úhel nad průměrem tupý?\n(ANO/NE)`,ans:'NE',hints:[`Je přesně pravý (90°), ne tupý.`],skill:'geo'};})(),
@@ -236,7 +236,7 @@ window.RPG_TASK_EXTRA_8 = {
   (()=>{return{text:`Pokud je úhel v trojúhelníku nad průměrem\nostrý, leží jeho vrchol na Thaletově kružnici?\n(ANO/NE)`,ans:'NE',hints:[`Vrchol musí ležet PŘÍMO NA kružnici → úhel = 90°.`],skill:'geo'};})(),
   (()=>{const d=ri(8,18);return{text:`Střed Thaletovy kružnice je uprostřed průměru ${d} cm.\nVzdálenost středu od vrcholu pravého úhlu?`,ans:String(d/2),hints:[`Poloměr = d/2.`],skill:'geo'};})(),
   (()=>{return{text:`Leží střed Thaletovy kružnice vždy uvnitř\ntrojúhelníku?\n(ANO/NE)`,ans:'ANO',hints:[`Střed je na přeponě (straně trojúhelníku).`],skill:'geo'};})(),
-  (()=>{const c=ri(6,14);return{text:`Přepona = ${c} cm. Jak daleko je vrchol pravého\núhlu od středu Thaletovy kružnice? (cm)`,ans:String(c/2),hints:[`Vzdálenost = poloměr = přepona ÷ 2.`],skill:'geo'};})()
+  (()=>{const c=ri(6,14);return{text:`Přepona = ${c} cm. Jak daleko je vrchol pravého\núhlu od středu Thaletovy kružnice? (cm)`,ans:String(c/2),hints:[`Vzdálenost = poloměr = přepona : 2.`],skill:'geo'};})()
  ],
  '6-3': () => [   // Osy a souměrnosti
   (()=>{return{text:`Kolik os souměrnosti má čtverec?`,ans:'4',hints:[`2 úhlopříčky + 2 střední.`],skill:'geo'};})(),
@@ -253,7 +253,7 @@ window.RPG_TASK_EXTRA_8 = {
 
  // ───────── OBLAST 7 — FINÁLE ─────────
  '7-1': () => [   // Zkouška ohněm (mix)
-  (()=>{const z=ri(2,8)*100,p=ri(1,4)*5;return{text:`${p} % z ${z} =`,ans:String(Math.round(z*p/100)),hints:[`${z} × ${p} ÷ 100.`],skill:'anal'};})(),
+  (()=>{const z=ri(2,8)*100,p=ri(1,4)*5;return{text:`${p} % z ${z} =`,ans:String(Math.round(z*p/100)),hints:[`${z} × ${p} : 100.`],skill:'anal'};})(),
   (()=>{const t=PYT[ri(0,PYT.length-1)];return{text:`Odvěsny ${t[0]} a ${t[1]}, přepona?`,ans:String(t[2]),hints:[`Pythagoras.`],skill:'geo'};})(),
   (()=>{const x=ri(3,12),a=ri(2,6),b=ri(2,12);return{text:`${a}x + ${b} = ${a*x+b}, x = ?`,ans:String(x),hints:[`Odečti ${b}, vyděl ${a}.`],skill:'anal'};})(),
   (()=>{const r=ri(2,7);return{text:`Obsah kruhu o poloměru ${r}? (π = 3,14)`,ans:r2(PI*r*r),hints:[`πr².`],skill:'geo'};})(),
@@ -269,7 +269,7 @@ window.RPG_TASK_EXTRA_8 = {
   (()=>{const r=ri(10,30);const o=2*PI*r;return{text:`Kolo o poloměru ${r} cm.\nKolik cm ujede za 1 otáčku? (π = 3,14)`,ans:r2(o),hints:[`Obvod = 2πr.`],skill:'geo'};})(),
   (()=>{const a=ri(30,60),b=ri(20,50);const c=Math.sqrt(a*a+b*b);return{text:`Obdélníkové hřiště ${a} × ${b} m.\nDélka úhlopříčky? (2 des. místa)`,ans:r2(c),hints:[`√(${a}² + ${b}²).`],skill:'geo'};})(),
   (()=>{const lidi=ri(4,9)*5,p=ri(2,8)*5;return{text:`Ve třídě je ${lidi} žáků, ${p} % jsou dívky.\nKolik je dívek?`,ans:String(Math.round(lidi*p/100)),hints:[`${p} % z ${lidi}.`],skill:'anal'};})(),
-  (()=>{const km=ri(60,120),h=ri(2,4);return{text:`Auto ujelo ${km*h} km za ${h} h.\nPrůměrná rychlost? (km/h)`,ans:String(km),hints:[`Dráha ÷ čas.`,`${km*h} ÷ ${h}`],skill:'anal'};})(),
+  (()=>{const km=ri(60,120),h=ri(2,4);return{text:`Auto ujelo ${km*h} km za ${h} h.\nPrůměrná rychlost? (km/h)`,ans:String(km),hints:[`Dráha : čas.`,`${km*h} : ${h}`],skill:'anal'};})(),
   (()=>{const cel=ri(4,9)*3,t=cel/3;return{text:`Třetina žáků (${t}) odešla.\nKolik žáků bylo původně, je-li to třetina?`,ans:String(cel),hints:[`Třetina = ${t}, celek = 3×.`],skill:'anal'};})(),
   (()=>{const x=ri(3,10),a=ri(2,5),b=ri(2,8);return{text:`Rovnice: ${a}(x + ${b}) = ${a*(x+b)}\nx = ?`,ans:String(x),hints:[`Vyděl ${a}: x + ${b} = ${x+b}.`],skill:'anal'};})(),
   (()=>{const r=ri(2,5),h=ri(5,12);return{text:`Válec: r = ${r} cm, výška ${h} cm.\nObjem? (cm³, π = 3,14)`,ans:r2(PI*r*r*h),hints:[`V = πr²h.`],skill:'geo'};})(),

--- a/projects/rpg-tasks-9.js
+++ b/projects/rpg-tasks-9.js
@@ -21,7 +21,7 @@ window.RPG_TASK_EXTRA_9 = {
  '1-1': () => [
   (()=>{const a=ri(120,460),b=ri(120,460),c=ri(50,200);return{text:`Vypočítej:\n${a} + ${b} + ${c} =`,ans:String(a+b+c),hints:[`Sčítej postupně.`,`${a+b} + ${c}`],skill:'calc'};})(),
   (()=>{const a=ri(11,30),b=ri(3,9);return{text:`Vypočítej:\n${a} × ${b} =`,ans:String(a*b),hints:[`Rozlož na desítky a jednotky.`],skill:'calc'};})(),
-  (()=>{const b=ri(6,12),q=ri(4,12),a=b*q;return{text:`Vypočítej:\n${a} ÷ ${b} =`,ans:String(q),hints:[`${b} × ? = ${a}.`],skill:'calc'};})(),
+  (()=>{const b=ri(6,12),q=ri(4,12),a=b*q;return{text:`Vypočítej:\n${a} : ${b} =`,ans:String(q),hints:[`${b} × ? = ${a}.`],skill:'calc'};})(),
   (()=>{const a=ri(11,29);return{text:`Vypočítej:\n${a}² =`,ans:String(a*a),hints:[`${a} × ${a}.`],skill:'calc'};})(),
   (()=>{const a=ri(2,9),b=ri(2,9),c=ri(2,9);return{text:`Vypočítej (závorka první):\n(${a} + ${b}) × ${c} =`,ans:String((a+b)*c),hints:[`${a+b} × ${c}.`],skill:'calc'};})(),
   (()=>{const a=ri(1000,9000);const r=Math.round(a/1000)*1000;return{text:`Zaokrouhli na tisíce:\n${a} ≈`,ans:String(r),hints:[`Rozhoduje číslice stovek (${Math.floor(a/100)%10}).`],skill:'calc'};})(),
@@ -33,20 +33,20 @@ window.RPG_TASK_EXTRA_9 = {
  '1-2': () => [
   (()=>{const z=ri(2,9)*200,p=[5,10,20,50][ri(0,3)];return{text:`Vypočítej:\n${p} % z ${z} =`,ans:String(z*p/100),hints:[`1 % = ${z/100}.`,`${z/100} × ${p}`],skill:'anal'};})(),
   (()=>{const z=ri(2,9)*100,p=[10,20,25][ri(0,2)];return{text:`Cena ${z} Kč klesne o ${p} %.\nNová cena? (Kč)`,ans:String(z-z*p/100),hints:[`Sleva ${z*p/100} Kč.`],skill:'anal'};})(),
-  (()=>{const cel=ri(4,10)*25,cast=cel*[20,40,60][ri(0,2)]/100;return{text:`Kolik % je ${cast} z ${cel}?`,ans:String(Math.round(cast/cel*100)),hints:[`${cast} ÷ ${cel} × 100.`],skill:'anal'};})(),
+  (()=>{const cel=ri(4,10)*25,cast=cel*[20,40,60][ri(0,2)]/100;return{text:`Kolik % je ${cast} z ${cel}?`,ans:String(Math.round(cast/cel*100)),hints:[`${cast} : ${cel} × 100.`],skill:'anal'};})(),
   (()=>{const y=ri(2,9)*1000,pm=[2,4,5,8][ri(0,3)];return{text:`Vypočítej:\n${pm} ‰ z ${y} =`,ans:String(y*pm/1000),hints:[`1 ‰ = ${y/1000}.`],skill:'anal'};})(),
-  (()=>{const p=[10,20,25,50][ri(0,3)],cel=ri(3,9)*40,cast=cel*p/100;return{text:`${cast} je ${p} % z nějakého čísla.\nJaké to je?`,ans:String(cel),hints:[`Celek = ${cast} ÷ ${p} × 100.`],skill:'anal'};})(),
+  (()=>{const p=[10,20,25,50][ri(0,3)],cel=ri(3,9)*40,cast=cel*p/100;return{text:`${cast} je ${p} % z nějakého čísla.\nJaké to je?`,ans:String(cel),hints:[`Celek = ${cast} : ${p} × 100.`],skill:'anal'};})(),
   (()=>{const z=ri(3,9)*100,p=[10,20,50][ri(0,2)];return{text:`Plat ${z} Kč vzroste o ${p} %.\nNový plat? (Kč)`,ans:String(z+z*p/100),hints:[`+ ${z*p/100} Kč.`],skill:'anal'};})(),
   (()=>{const z=ri(2,8)*100,dph=21;return{text:`Cena bez DPH: ${z} Kč.\nCena s DPH 21 %? (Kč, zaokrouhli)`,ans:String(Math.round(z*1.21)),hints:[`${z} × 1,21.`],skill:'anal'};})(),
   (()=>{const z=ri(3,8)*100,p=[10,20,50][ri(0,2)];return{text:`Cena po ${p}% slevě z ${z} Kč? (Kč)`,ans:String(z-z*p/100),hints:[`Sleva = ${z*p/100} Kč.`],skill:'anal'};})(),
-  (()=>{const a=ri(2,5)*10,b=ri(2,5)*10;return{text:`Kolik % je ${a} z ${a+b}?`,ans:String(Math.round(a/(a+b)*100)),hints:[`${a} ÷ ${a+b} × 100.`],skill:'anal'};})(),
-  (()=>{const z=ri(2,8)*100,p=[10,25,50][ri(0,2)];const after=z*(1+p/100);return{text:`Po zdražení o ${p} % stojí zboží ${after} Kč.\nPůvodní cena? (Kč)`,ans:String(z),hints:[`${after} ÷ ${cz(1+p/100)}.`],skill:'anal'};})()
+  (()=>{const a=ri(2,5)*10,b=ri(2,5)*10;return{text:`Kolik % je ${a} z ${a+b}?`,ans:String(Math.round(a/(a+b)*100)),hints:[`${a} : ${a+b} × 100.`],skill:'anal'};})(),
+  (()=>{const z=ri(2,8)*100,p=[10,25,50][ri(0,2)];const after=z*(1+p/100);return{text:`Po zdražení o ${p} % stojí zboží ${after} Kč.\nPůvodní cena? (Kč)`,ans:String(z),hints:[`${after} : ${cz(1+p/100)}.`],skill:'anal'};})()
  ],
  '1-3': () => [
   (()=>{const a=ri(5,20),b=ri(3,15);return{text:`Vypočítej:\n${a} + (-${b}) =`,ans:String(a-b),hints:[`Přičíst záporné číslo znamená odečíst ho.`,`${a} − ${b}`],skill:'calc'};})(),
   (()=>{const a=ri(4,15),b=ri(4,15);return{text:`Vypočítej:\n(-${a}) − (-${b}) =`,ans:String(-a+b),hints:[`− (−${b}) = + ${b}.`,`−${a} + ${b}`],skill:'calc'};})(),
   (()=>{const a=ri(2,9),b=ri(2,9);return{text:`Vypočítej:\n(-${a}) × (-${b}) =`,ans:String(a*b),hints:[`− × − = +.`],skill:'calc'};})(),
-  (()=>{const b=ri(2,6),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) ÷ (-${b}) =`,ans:String(q),hints:[`− ÷ − = +.`],skill:'calc'};})(),
+  (()=>{const b=ri(2,6),q=ri(2,9),a=b*q;return{text:`Vypočítej:\n(-${a}) : (-${b}) =`,ans:String(q),hints:[`− : − = +.`],skill:'calc'};})(),
   (()=>{const a=ri(3,9);return{text:`Vypočítej:\n−${a}² =`,ans:String(-a*a),hints:[`Umocní se jen ${a}, mínus zůstává: −(${a*a}).`],skill:'calc'};})(),
   (()=>{const a=ri(3,10),b=ri(3,10),c=ri(2,8);return{text:`Vypočítej:\n(-${a}) + ${b} − ${c} =`,ans:String(-a+b-c),hints:[`Postupuj zleva doprava.`],skill:'calc'};})(),
   (()=>{const a=ri(2,4);return{text:`Vypočítej:\n(-${a})³ =`,ans:String(-(a**3)),hints:[`Lichá mocnina záporného → záporné.`],skill:'calc'};})(),
@@ -97,7 +97,7 @@ window.RPG_TASK_EXTRA_9 = {
  '3-1': () => [
   (()=>{const x=ri(2,20),a=ri(2,20);return{text:`Vyřeš rovnici:\nx + ${a} = ${x+a}`,ans:String(x),hints:[`x = ${x+a} − ${a}.`],skill:'calc'};})(),
   (()=>{const x=ri(5,25),a=ri(2,15);return{text:`Vyřeš rovnici:\nx − ${a} = ${x-a}`,ans:String(x),hints:[`x = ${x-a} + ${a}.`],skill:'calc'};})(),
-  (()=>{const a=ri(2,9),x=ri(2,12);return{text:`Vyřeš rovnici:\n${a}x = ${a*x}`,ans:String(x),hints:[`x = ${a*x} ÷ ${a}.`],skill:'calc'};})(),
+  (()=>{const a=ri(2,9),x=ri(2,12);return{text:`Vyřeš rovnici:\n${a}x = ${a*x}`,ans:String(x),hints:[`x = ${a*x} : ${a}.`],skill:'calc'};})(),
   (()=>{const a=ri(2,7),v=ri(2,9);return{text:`Vyřeš rovnici:\nx / ${a} = ${v}`,ans:String(v*a),hints:[`x = ${v} × ${a}.`],skill:'calc'};})(),
   (()=>{const a=ri(2,8),x=ri(2,12),b=ri(2,15);return{text:`Vyřeš rovnici:\n${a}x + ${b} = ${a*x+b}`,ans:String(x),hints:[`Odečti ${b}, vyděl ${a}.`],skill:'calc'};})(),
   (()=>{const a=ri(2,8),x=ri(3,14),b=ri(2,15);return{text:`Vyřeš rovnici:\n${a}x − ${b} = ${a*x-b}`,ans:String(x),hints:[`Přičti ${b}, vyděl ${a}.`],skill:'calc'};})(),
@@ -120,7 +120,7 @@ window.RPG_TASK_EXTRA_9 = {
  ],
  '3-3': () => [
   (()=>{const a=ri(3,12),b=ri(3,12);return{text:`o = 2(a+b).\no = ${2*(a+b)} cm, b = ${b} cm. Urči a. (cm)`,ans:String(a),hints:[`a = o/2 − b = ${(a+b)} − ${b}.`],skill:'anal'};})(),
-  (()=>{const a=ri(3,12),v=ri(3,12);return{text:`S = a · v.\nS = ${a*v} cm², v = ${v} cm. Urči a. (cm)`,ans:String(a),hints:[`a = S / v = ${a*v} ÷ ${v}.`],skill:'anal'};})(),
+  (()=>{const a=ri(3,12),v=ri(3,12);return{text:`S = a · v.\nS = ${a*v} cm², v = ${v} cm. Urči a. (cm)`,ans:String(a),hints:[`a = S / v = ${a*v} : ${v}.`],skill:'anal'};})(),
   (()=>{const vv=ri(40,90),t=ri(2,5);return{text:`s = v · t.\ns = ${vv*t} km, v = ${vv} km/h. Urči t. (h)`,ans:String(t),hints:[`t = s / v.`],skill:'anal'};})(),
   (()=>{const x=ri(10,40),a=ri(5,25);return{text:`Slovní úloha:\nČíslo zmenšené o ${a} je ${x-a}. Jaké je?`,ans:String(x),hints:[`x − ${a} = ${x-a}.`],skill:'anal'};})(),
   (()=>{const x=ri(3,12);return{text:`Slovní úloha:\nDvojnásobek čísla zvětšený o 5 je ${2*x+5}. Číslo?`,ans:String(x),hints:[`2x + 5 = ${2*x+5}.`],skill:'anal'};})(),
@@ -145,15 +145,15 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const a=ri(1,6),b=ri(1,6);return{text:`Pro jaké x není (x+${a})/(x−${b}) definováno?\nx ≠`,ans:String(b),hints:[`Jmenovatel: x − ${b} = 0.`],skill:'anal'};})()
  ],
  '4-2': () => [
-  (()=>{const x=ri(2,6),a=x*ri(1,4);return{text:`Vypočítej hodnotu (3x + ${a}) / x\npro x = ${x}.`,ans:String(3+a/x),hints:[`(${3*x} + ${a}) ÷ ${x}.`],skill:'anal'};})(),
+  (()=>{const x=ri(2,6),a=x*ri(1,4);return{text:`Vypočítej hodnotu (3x + ${a}) / x\npro x = ${x}.`,ans:String(3+a/x),hints:[`(${3*x} + ${a}) : ${x}.`],skill:'anal'};})(),
   (()=>{const d=ri(2,9),n=d*ri(2,6),g=gcd(n,d);return{text:`Zkrať na základní tvar:\n${n}/${d} =`,ans:(d/g===1?String(n/g):`${n/g}/${d/g}`),hints:[`Vyděl čitatele i jmenovatele ${g}.`],skill:'calc'};})(),
   (()=>{const x=ri(3,9),a=ri(1,3);return{text:`Vypočítej hodnotu (x − ${a})(x + ${a})\npro x = ${x}.`,ans:String(x*x-a*a),hints:[`x² − ${a*a} = ${x*x} − ${a*a}.`],skill:'anal'};})(),
-  (()=>{const x=ri(2,6),a=x*ri(1,5);return{text:`Vypočítej hodnotu (x² + ${a}) / x\npro x = ${x}.`,ans:String(x+a/x),hints:[`(${x*x} + ${a}) ÷ ${x}.`],skill:'anal'};})(),
-  (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(2,6),b=ri(1,9);return{text:`Vypočítej hodnotu ${k}/x + ${b}\npro x = ${x}.`,ans:String(k/x+b),hints:[`${k} ÷ ${x} = ${k/x}, + ${b}.`],skill:'anal'};})(),
-  (()=>{const b=ri(2,6),x=b*ri(2,6),a=ri(1,9);return{text:`Vypočítej hodnotu (x + ${a})/${b}\npro x = ${x-a}.`,ans:String(x/b),hints:[`(${x-a} + ${a}) ÷ ${b}.`],skill:'anal'};})(),
-  (()=>{const x=ri(2,6),a=ri(2,5),c=ri(1,4)*x;return{text:`Vypočítej hodnotu (${a}x + ${c}) / x\npro x = ${x}.`,ans:String(a+c/x),hints:[`(${a*x+c}) ÷ ${x}.`],skill:'anal'};})(),
-  (()=>{const x=ri(2,6),k=ri(2,8)*x;return{text:`Vypočítej hodnotu ${k}/x\npro x = ${x}.`,ans:String(k/x),hints:[`${k} ÷ ${x}.`],skill:'anal'};})(),
-  (()=>{const x=ri(3,8),n=ri(1,x-1);return{text:`Vypočítej hodnotu (x² − ${n*x}) / x\npro x = ${x}.`,ans:String(x-n),hints:[`(${x*x} − ${n*x}) ÷ ${x} = ${x-n}.`],skill:'anal'};})(),
+  (()=>{const x=ri(2,6),a=x*ri(1,5);return{text:`Vypočítej hodnotu (x² + ${a}) / x\npro x = ${x}.`,ans:String(x+a/x),hints:[`(${x*x} + ${a}) : ${x}.`],skill:'anal'};})(),
+  (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(2,6),b=ri(1,9);return{text:`Vypočítej hodnotu ${k}/x + ${b}\npro x = ${x}.`,ans:String(k/x+b),hints:[`${k} : ${x} = ${k/x}, + ${b}.`],skill:'anal'};})(),
+  (()=>{const b=ri(2,6),x=b*ri(2,6),a=ri(1,9);return{text:`Vypočítej hodnotu (x + ${a})/${b}\npro x = ${x-a}.`,ans:String(x/b),hints:[`(${x-a} + ${a}) : ${b}.`],skill:'anal'};})(),
+  (()=>{const x=ri(2,6),a=ri(2,5),c=ri(1,4)*x;return{text:`Vypočítej hodnotu (${a}x + ${c}) / x\npro x = ${x}.`,ans:String(a+c/x),hints:[`(${a*x+c}) : ${x}.`],skill:'anal'};})(),
+  (()=>{const x=ri(2,6),k=ri(2,8)*x;return{text:`Vypočítej hodnotu ${k}/x\npro x = ${x}.`,ans:String(k/x),hints:[`${k} : ${x}.`],skill:'anal'};})(),
+  (()=>{const x=ri(3,8),n=ri(1,x-1);return{text:`Vypočítej hodnotu (x² − ${n*x}) / x\npro x = ${x}.`,ans:String(x-n),hints:[`(${x*x} − ${n*x}) : ${x} = ${x-n}.`],skill:'anal'};})(),
   (()=>{const x=ri(2,8),a=ri(2,6);return{text:`Vypočítej hodnotu ${a}/x + 1\npro x = ${a}.`,ans:'2',hints:[`${a}/${a} + 1 = 1 + 1.`],skill:'anal'};})()
  ],
  '4-3': () => [
@@ -162,7 +162,7 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const x=[2,3,4,5,6,7][ri(0,5)];return{text:`Vyřeš rovnici (kladné x):\n${x*x} / x = x`,ans:String(x),hints:[`${x*x} = x².`],skill:'anal'};})(),
   (()=>{const x=ri(2,8),r=ri(2,5),c=r*x;return{text:`Vyřeš rovnici:\n${c} / x = ${r}`,ans:String(x),hints:[`${c} = ${r}x.`],skill:'anal'};})(),
   (()=>{const x=ri(2,6),s=x*ri(2,5),a=ri(1,s-1),b=s-a;return{text:`Vyřeš rovnici:\n${a}/x + ${b}/x = ${s/x}`,ans:String(x),hints:[`${s}/x = ${s/x}.`],skill:'anal'};})(),
-  (()=>{const x=ri(2,8),a=ri(2,6),c=a*x;return{text:`Vyřeš rovnici:\nx = ${c} / ${a}`,ans:String(x),hints:[`${c} ÷ ${a}.`],skill:'anal'};})(),
+  (()=>{const x=ri(2,8),a=ri(2,6),c=a*x;return{text:`Vyřeš rovnici:\nx = ${c} / ${a}`,ans:String(x),hints:[`${c} : ${a}.`],skill:'anal'};})(),
   (()=>{const x=ri(2,6),a=x*ri(2,5),b=ri(2,6);return{text:`Vyřeš rovnici:\n${a}/x + ${b} = ${a/x+b}`,ans:String(x),hints:[`${a}/x = ${a/x}.`],skill:'anal'};})(),
   (()=>{const x=ri(2,6),a=x*ri(2,4),b=ri(1,4);return{text:`Vyřeš rovnici:\n${a}/x − ${b} = ${a/x-b}`,ans:String(x),hints:[`${a}/x = ${a/x}.`],skill:'anal'};})(),
   (()=>{const x=ri(2,6),a=x*ri(1,4),b=x*ri(1,4);return{text:`Vyřeš rovnici:\n${a}/x + ${b}/x = ${(a+b)/x}`,ans:String(x),hints:[`${a+b}/x = ${(a+b)/x}.`],skill:'anal'};})(),
@@ -180,19 +180,19 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const x=ri(2,8),y=ri(2,8),a=ri(2,4);return{text:`Vyřeš soustavu, urči y:\n${a}x + y = ${a*x+y}\nx = ${x}`,ans:String(y),hints:[`${a*x} + y = ${a*x+y}.`],skill:'anal'};})(),
   (()=>{const x=ri(2,8),y=ri(2,8);return{text:`Vyřeš soustavu, urči x:\n2x + 3y = ${2*x+3*y}\ny = ${y}`,ans:String(x),hints:[`2x = ${2*x+3*y} − ${3*y}.`],skill:'anal'};})(),
   (()=>{const x=ri(2,6),y=ri(2,6);return{text:`Vyřeš soustavu, urči x + y:\nx − y = ${x-y}\nx + y = ${x+y}`,ans:String(x+y),hints:[`Součet obou rovnic.`],skill:'anal'};})(),
-  (()=>{const s=ri(5,14)*2,d=ri(1,s/2-1)*2;const x=(s+d)/2,y=(s-d)/2;return{text:`Dvě čísla: součet ${s}, rozdíl ${d}.\nMenší číslo?`,ans:String(y),hints:[`(${s} − ${d}) ÷ 2.`],skill:'anal'};})()
+  (()=>{const s=ri(5,14)*2,d=ri(1,s/2-1)*2;const x=(s+d)/2,y=(s-d)/2;return{text:`Dvě čísla: součet ${s}, rozdíl ${d}.\nMenší číslo?`,ans:String(y),hints:[`(${s} − ${d}) : 2.`],skill:'anal'};})()
  ],
  '5-2': () => [
   (()=>{const m=ri(2,8)*50,p=[10,20,25,50][ri(0,3)];return{text:`Roztok ${m} g obsahuje ${p} % soli.\nKolik g soli?`,ans:String(m*p/100),hints:[`${p} % z ${m}.`],skill:'anal'};})(),
-  (()=>{const s=ri(2,9)*10,m=s*ri(4,8);return{text:`Roztok ${m} g, v něm ${s} g soli.\nKolik %?`,ans:String(Math.round(s/m*100)),hints:[`${s} ÷ ${m} × 100.`],skill:'anal'};})(),
-  (()=>{const t=ri(4,10);return{text:`Práci zvládne dělník za ${t} h.\nKolik % udělá za 1 h?`,ans:String(Math.round(100/t)),hints:[`100 ÷ ${t}.`],skill:'anal'};})(),
-  (()=>{const a=ri(2,5),pa=ri(8,15)*10,b=ri(2,5),pb=ri(2,7)*10;const tot=Math.round((a*pa+b*pb)/(a+b));return{text:`${a} kg po ${pa} Kč a ${b} kg po ${pb} Kč.\nCena 1 kg směsi? (Kč)`,ans:String(tot),hints:[`(${a*pa} + ${b*pb}) ÷ ${a+b}.`],skill:'anal'};})(),
-  (()=>{const t=ri(2,5)*2,h=t/2;return{text:`Zakázka za ${t} h.\nKolik % hotovo za ${h} h?`,ans:String(Math.round(h/t*100)),hints:[`${h} ÷ ${t} × 100.`],skill:'anal'};})(),
+  (()=>{const s=ri(2,9)*10,m=s*ri(4,8);return{text:`Roztok ${m} g, v něm ${s} g soli.\nKolik %?`,ans:String(Math.round(s/m*100)),hints:[`${s} : ${m} × 100.`],skill:'anal'};})(),
+  (()=>{const t=ri(4,10);return{text:`Práci zvládne dělník za ${t} h.\nKolik % udělá za 1 h?`,ans:String(Math.round(100/t)),hints:[`100 : ${t}.`],skill:'anal'};})(),
+  (()=>{const a=ri(2,5),pa=ri(8,15)*10,b=ri(2,5),pb=ri(2,7)*10;const tot=Math.round((a*pa+b*pb)/(a+b));return{text:`${a} kg po ${pa} Kč a ${b} kg po ${pb} Kč.\nCena 1 kg směsi? (Kč)`,ans:String(tot),hints:[`(${a*pa} + ${b*pb}) : ${a+b}.`],skill:'anal'};})(),
+  (()=>{const t=ri(2,5)*2,h=t/2;return{text:`Zakázka za ${t} h.\nKolik % hotovo za ${h} h?`,ans:String(Math.round(h/t*100)),hints:[`${h} : ${t} × 100.`],skill:'anal'};})(),
   (()=>{const n=ri(2,6),one=ri(3,8);return{text:`Jeden dělník udělá ${one} ${skl(one,'díl','díly','dílů')} za hodinu.\nKolik dílů ${n} ${skl(n,'dělník','dělníci','dělníků')} za hodinu?`,ans:String(n*one),hints:[`${n} × ${one}.`],skill:'anal'};})(),
   (()=>{const m=ri(2,8)*100,p=[10,20,30][ri(0,2)];return{text:`Roztok ${m} g obsahuje ${p} % cukru.\nKolik g vody?`,ans:String(m-m*p/100),hints:[`Voda = ${100-p} % z ${m}.`],skill:'anal'};})(),
   (()=>{const n=ri(3,6),t=ri(4,8);return{text:`${n} ${skl(n,'dělník udělá','dělníci udělají','dělníků udělá')} práci za ${t} ${skl(t,'den','dny','dní')}.\nKolik dní 1 dělník?`,ans:String(n*t),hints:[`${n} × ${t}.`],skill:'anal'};})(),
   (()=>{const m=ri(3,8)*50,p=[10,20,50][ri(0,2)];return{text:`Zdraží o ${p} %. Původní cena ${m} Kč.\nNová cena? (Kč)`,ans:String(m*(1+p/100)),hints:[`${m} + ${m*p/100} Kč.`],skill:'anal'};})(),
-  (()=>{const s1=ri(2,4)*100,p1=20,s2=ri(2,4)*100,p2=40;const pOut=Math.round((s1*p1+s2*p2)/(s1+s2));return{text:`Smíchám ${s1} g (${p1}% soli) a ${s2} g (${p2}% soli).\nVýsledná koncentrace? (%)`,ans:String(pOut),hints:[`(${s1*p1/100}+${s2*p2/100}) ÷ ${s1+s2} × 100.`],skill:'anal'};})()
+  (()=>{const s1=ri(2,4)*100,p1=20,s2=ri(2,4)*100,p2=40;const pOut=Math.round((s1*p1+s2*p2)/(s1+s2));return{text:`Smíchám ${s1} g (${p1}% soli) a ${s2} g (${p2}% soli).\nVýsledná koncentrace? (%)`,ans:String(pOut),hints:[`(${s1*p1/100}+${s2*p2/100}) : ${s1+s2} × 100.`],skill:'anal'};})()
  ],
  '5-3': () => [
   (()=>{const v=ri(5,12)*10,t=ri(2,5);return{text:`Rychlost ${v} km/h, čas ${t} h.\nDráha? (km)`,ans:String(v*t),hints:[`s = v · t.`],skill:'anal'};})(),
@@ -202,8 +202,8 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const v1=ri(3,5)*10,v2=v1+ri(2,4)*10,t=ri(2,4);return{text:`${v1} a ${v2} km/h stejným směrem.\nNáskok rychlejšího po ${t} h? (km)`,ans:String((v2-v1)*t),hints:[`(${v2}−${v1}) · ${t}.`],skill:'anal'};})(),
   (()=>{const v=ri(8,12)*10,t=[1.5,2.5][ri(0,1)];return{text:`Rychlost ${v} km/h.\nDráha za ${cz(t)} h? (km)`,ans:String(v*t),hints:[`${v} · ${cz(t)}.`],skill:'anal'};})(),
   (()=>{const v1=ri(4,8)*10,v2=ri(4,8)*10,t=ri(1,3);return{text:`Dva vlaky jedou vstříc, ${v1} a ${v2} km/h.\nZa ${t} h ujedou dohromady? (km)`,ans:String((v1+v2)*t),hints:[`${v1+v2} km/h × ${t} h.`],skill:'anal'};})(),
-  (()=>{const v=ri(6,12)*10,d=ri(2,6)*v;return{text:`Dráha ${d} km, rychlost ${v} km/h.\nČas? (h)`,ans:String(d/v),hints:[`t = ${d} ÷ ${v}.`],skill:'anal'};})(),
-  (()=>{const v=ri(6,12)*10,t=ri(2,5);return{text:`Ujel ${v*t} km za ${t} h.\nPrůměrná rychlost? (km/h)`,ans:String(v),hints:[`v = ${v*t} ÷ ${t}.`],skill:'anal'};})(),
+  (()=>{const v=ri(6,12)*10,d=ri(2,6)*v;return{text:`Dráha ${d} km, rychlost ${v} km/h.\nČas? (h)`,ans:String(d/v),hints:[`t = ${d} : ${v}.`],skill:'anal'};})(),
+  (()=>{const v=ri(6,12)*10,t=ri(2,5);return{text:`Ujel ${v*t} km za ${t} h.\nPrůměrná rychlost? (km/h)`,ans:String(v),hints:[`v = ${v*t} : ${t}.`],skill:'anal'};})(),
   (()=>{const v1=ri(4,8)*10,v2=v1+ri(2,4)*10,t=ri(1,3);return{text:`Začnou zároveň, rychlosti ${v1} a ${v2} km/h.\nO kolik km je jeden před druhým po ${t} h?`,ans:String((v2-v1)*t),hints:[`(${v2} − ${v1}) × ${t}.`],skill:'anal'};})()
  ],
 
@@ -211,7 +211,7 @@ window.RPG_TASK_EXTRA_9 = {
  '6-1': () => [
   (()=>{const k=ri(2,5),q=ri(1,6),x=ri(2,5);return{svg:svgLineGraph(k,q),text:`y = ${k}x + ${q}\nVypočítej f(${x}).`,ans:String(k*x+q),hints:[`${k}·${x} + ${q}.`],skill:'geo'};})(),
   (()=>{const k=ri(2,5),q=ri(2,8);return{svg:svgLineGraph(k,q),text:`y = ${k}x + ${q}\nKde protíná osu y? (y)`,ans:String(q),hints:[`x = 0 → y = q.`],skill:'geo'};})(),
-  (()=>{const k=ri(2,4),x0=ri(1,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nPro jaké x je y = 0?`,ans:String(x0),hints:[`x = ${-q} ÷ ${k}.`],skill:'geo'};})(),
+  (()=>{const k=ri(2,4),x0=ri(1,5),q=-k*x0;return{text:`y = ${k}x ${q<0?'− '+(-q):'+ '+q}\nPro jaké x je y = 0?`,ans:String(x0),hints:[`x = ${-q} : ${k}.`],skill:'geo'};})(),
   (()=>{const k=ri(2,6);return{text:`y = ${k}x\nVypočítej f(2).`,ans:String(2*k),hints:[`${k} · 2.`],skill:'geo'};})(),
   (()=>{const k=ri(2,4);return{text:`Přímka prochází body [0, 0] a [1, ${k}].\nSměrnice k?`,ans:String(k),hints:[`Změna y na 1 krok x.`],skill:'geo'};})(),
   (()=>{const k=ri(2,5),q=ri(1,7),x=ri(2,6);return{text:`y = ${k}x + ${q}\nVypočítej f(${x}).`,ans:String(k*x+q),hints:[`${k}·${x} + ${q}.`],skill:'geo'};})(),
@@ -233,29 +233,29 @@ window.RPG_TASK_EXTRA_9 = {
   (()=>{const k=ri(2,4),x0=ri(2,5),q=-k*x0;return{text:`Protíná y = ${k}x ${q<0?'− '+(-q):'+ '+q} osu x v bodě x = ${x0}?\nANO / NE`,ans:'ANO',hints:[`y = 0: ${k}x = ${-q}, x = ${x0}.`],skill:'anal'};})()
  ],
  '6-3': () => [
-  (()=>{const x=[2,3,4,6][ri(0,3)],k=x*ri(2,8);return{text:`y = ${k}/x\nVypočítej f(${x}).`,ans:String(k/x),hints:[`${k} ÷ ${x}.`],skill:'geo'};})(),
-  (()=>{const y=[2,3,4,5][ri(0,3)],k=y*ri(2,8);return{text:`y = ${k}/x\nPro jaké x je y = ${y}?`,ans:String(k/y),hints:[`x = ${k} ÷ ${y}.`],skill:'geo'};})(),
+  (()=>{const x=[2,3,4,6][ri(0,3)],k=x*ri(2,8);return{text:`y = ${k}/x\nVypočítej f(${x}).`,ans:String(k/x),hints:[`${k} : ${x}.`],skill:'geo'};})(),
+  (()=>{const y=[2,3,4,5][ri(0,3)],k=y*ri(2,8);return{text:`y = ${k}/x\nPro jaké x je y = ${y}?`,ans:String(k/y),hints:[`x = ${k} : ${y}.`],skill:'geo'};})(),
   (()=>{const x=ri(2,6),y=ri(2,8);return{text:`y = k/x prochází bodem [${x}, ${y}].\nUrči k.`,ans:String(x*y),hints:[`k = x · y.`],skill:'geo'};})(),
   (()=>{return{text:`Pro jaké x není y = 20/x definována?\nx ≠`,ans:'0',hints:[`Jmenovatel nesmí být 0.`],skill:'geo'};})(),
-  (()=>{const k=[12,24,36,48][ri(0,3)],x=[2,3,4,6][ri(0,3)];return{text:`y = ${k}/x\nPro x = ${x} je y = ?`,ans:String(k/x),hints:[`${k} ÷ ${x}.`],skill:'geo'};})(),
-  (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(3,9);return{text:`y = ${k}/x\nVypočítej f(${x}).`,ans:String(k/x),hints:[`${k} ÷ ${x}.`],skill:'geo'};})(),
-  (()=>{const k=ri(2,8)*6,x=[2,3,6][ri(0,2)];return{text:`y = ${k}/x\nUrči y pro x = ${x}.`,ans:String(k/x),hints:[`${k} ÷ ${x}.`],skill:'geo'};})(),
+  (()=>{const k=[12,24,36,48][ri(0,3)],x=[2,3,4,6][ri(0,3)];return{text:`y = ${k}/x\nPro x = ${x} je y = ?`,ans:String(k/x),hints:[`${k} : ${x}.`],skill:'geo'};})(),
+  (()=>{const x=[2,4,5,10][ri(0,3)],k=x*ri(3,9);return{text:`y = ${k}/x\nVypočítej f(${x}).`,ans:String(k/x),hints:[`${k} : ${x}.`],skill:'geo'};})(),
+  (()=>{const k=ri(2,8)*6,x=[2,3,6][ri(0,2)];return{text:`y = ${k}/x\nUrči y pro x = ${x}.`,ans:String(k/x),hints:[`${k} : ${x}.`],skill:'geo'};})(),
   (()=>{const y=ri(2,8),x=ri(2,6);return{text:`Hyperbola y = k/x prochází bodem [${x}, ${y}].\nUrči k.`,ans:String(x*y),hints:[`k = x · y = ${x} · ${y}.`],skill:'geo'};})(),
-  (()=>{const k=ri(2,6)*4,x=[2,4][ri(0,1)];return{text:`y = ${k}/x\nUrči y pro x = ${x}.`,ans:String(k/x),hints:[`${k} ÷ ${x}.`],skill:'geo'};})(),
+  (()=>{const k=ri(2,6)*4,x=[2,4][ri(0,1)];return{text:`y = ${k}/x\nUrči y pro x = ${x}.`,ans:String(k/x),hints:[`${k} : ${x}.`],skill:'geo'};})(),
   (()=>{return{text:`Je funkce y = 12/x rostoucí pro x > 0?\nANO / NE`,ans:'NE',hints:[`Hyperbola pro x > 0 klesá.`],skill:'geo'};})()
  ],
 
  // ───────── OBLAST 7 — JÁDRO SYSTÉMU ─────────
  '7-1': () => [
   (()=>{const a=ri(3,9),k=ri(2,4);return{svg:svgSimilar(k),text:`Podobné trojúhelníky, k = ${k}.\nStraně ${a} cm odpovídá? (cm)`,ans:String(a*k),hints:[`${a} · ${k}.`],skill:'geo'};})(),
-  (()=>{const k=ri(2,4),orig=ri(4,9)*k;return{text:`Zmenšení k = 1/${k}.\nStrana ${orig} cm → ? (cm)`,ans:String(orig/k),hints:[`${orig} ÷ ${k}.`],skill:'geo'};})(),
-  (()=>{const a=ri(2,6),k=ri(2,4);return{text:`Originál ${a} cm, obraz ${a*k} cm.\nKoeficient k?`,ans:String(k),hints:[`${a*k} ÷ ${a}.`],skill:'geo'};})(),
+  (()=>{const k=ri(2,4),orig=ri(4,9)*k;return{text:`Zmenšení k = 1/${k}.\nStrana ${orig} cm → ? (cm)`,ans:String(orig/k),hints:[`${orig} : ${k}.`],skill:'geo'};})(),
+  (()=>{const a=ri(2,6),k=ri(2,4);return{text:`Originál ${a} cm, obraz ${a*k} cm.\nKoeficient k?`,ans:String(k),hints:[`${a*k} : ${a}.`],skill:'geo'};})(),
   (()=>{const onmap=ri(2,9),mer=500;return{text:`Mapa 1 : ${mer}. Úsek na mapě ${onmap} cm.\nKolik m ve skutečnosti?`,ans:String(onmap*mer/100),hints:[`${onmap} × ${mer} cm → m.`],skill:'geo'};})(),
   (()=>{const o=ri(3,8)*3,k=ri(2,4);return{text:`Podobné, k = ${k}. Obvod originálu ${o} cm.\nObvod obrazu? (cm)`,ans:String(o*k),hints:[`× ${k}.`],skill:'geo'};})(),
   (()=>{const onmap=ri(2,8),mer=2000;return{text:`Mapa 1 : ${mer}. Na mapě ${onmap} cm.\nKolik m ve skutečnosti?`,ans:String(onmap*mer/100),hints:[`${onmap} × ${mer} cm → m.`],skill:'geo'};})(),
   (()=>{const a=ri(5,20),k=ri(2,4);return{text:`Podobné tvary, k = ${k}.\nObvod originálu ${a} cm → obvod obrazu? (cm)`,ans:String(a*k),hints:[`Obvod × k.`],skill:'geo'};})(),
-  (()=>{const onmap=ri(3,9),mer=[200,500,1000][ri(0,2)];return{text:`Mapa 1 : ${mer}. Na mapě ${onmap} cm.\nSkutečná vzdálenost? (m)`,ans:String(onmap*mer/100),hints:[`${onmap} × ${mer} ÷ 100.`],skill:'geo'};})(),
-  (()=>{const orig=ri(4,12),k=ri(2,4);return{text:`Originál ${orig} cm, obraz ${orig*k} cm.\nJe to zvětšení k = ${k}?\nANO / NE`,ans:'ANO',hints:[`${orig*k} ÷ ${orig} = ${k}.`],skill:'geo'};})(),
+  (()=>{const onmap=ri(3,9),mer=[200,500,1000][ri(0,2)];return{text:`Mapa 1 : ${mer}. Na mapě ${onmap} cm.\nSkutečná vzdálenost? (m)`,ans:String(onmap*mer/100),hints:[`${onmap} × ${mer} : 100.`],skill:'geo'};})(),
+  (()=>{const orig=ri(4,12),k=ri(2,4);return{text:`Originál ${orig} cm, obraz ${orig*k} cm.\nJe to zvětšení k = ${k}?\nANO / NE`,ans:'ANO',hints:[`${orig*k} : ${orig} = ${k}.`],skill:'geo'};})(),
   (()=>{const k=ri(2,3),a=ri(3,10),b=ri(3,10);return{text:`Obdélník ${a} × ${b} cm zvětšen k = ${k}.\nObsah obrazu? (cm²)`,ans:String(a*k*b*k),hints:[`(${a*k}) × (${b*k}).`],skill:'geo'};})()
  ],
  '7-2': () => [

--- a/projects/rpg-tasktypes.js
+++ b/projects/rpg-tasktypes.js
@@ -33,11 +33,11 @@ window.RPGTaskTypes = (function () {
       'color:var(--gold,#f4d03f);letter-spacing:1px;margin-bottom:10px;text-align:center}' +
       '.ttm-cols{display:flex;gap:10px;align-items:stretch}' +
       '.ttm-col{flex:1;display:flex;flex-direction:column;gap:8px;min-width:0}' +
-      '.ttm-q,.ttm-a{font-family:var(--vt,monospace);font-size:17px;line-height:1.35;' +
+      '.ttm-q,.ttm-a{font-family:var(--px,monospace);font-size:16px;line-height:1.35;' +
       'text-align:left;padding:9px 10px;border-radius:8px;cursor:pointer;' +
       'border:2px solid var(--line,#2a3450);background:rgba(255,255,255,.04);' +
       'color:var(--text,#e8eaf6);transition:.12s;word-break:break-word}' +
-      '.ttm-a{text-align:center;font-weight:700;font-size:19px}' +
+      '.ttm-a{text-align:center;font-weight:700;font-size:18px}' +
       '.ttm-q.sel{border-color:var(--blue,#5dc8f0);background:rgba(93,200,240,.14)}' +
       '.ttm-q.done,.ttm-a.done{border-color:#4ade80;background:rgba(74,222,128,.14);' +
       'color:#4ade80;cursor:default;opacity:.8}' +
@@ -45,7 +45,7 @@ window.RPGTaskTypes = (function () {
       'animation:ttmshake .35s}' +
       '@keyframes ttmshake{0%,100%{transform:translateX(0)}25%{transform:translateX(-5px)}75%{transform:translateX(5px)}}' +
       '.tto-row{display:flex;gap:10px;flex-wrap:wrap;justify-content:center}' +
-      '.tto-chip{font-family:var(--vt,monospace);font-size:21px;font-weight:700;' +
+      '.tto-chip{font-family:var(--px,monospace);font-size:18px;font-weight:700;' +
       'padding:11px 16px;border-radius:9px;cursor:pointer;' +
       'border:2px solid var(--line,#2a3450);background:rgba(255,255,255,.04);' +
       'color:var(--text,#e8eaf6);transition:.12s}' +
@@ -172,7 +172,7 @@ window.RPGTaskTypes = (function () {
       css.textContent =
         '.ttp-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}' +
         '@media(max-width:480px){.ttp-grid{grid-template-columns:repeat(2,1fr)}}' +
-        '.ttp-card{font-family:var(--vt,monospace);font-size:16px;line-height:1.3;min-height:74px;' +
+        '.ttp-card{font-family:var(--px,monospace);font-size:14px;line-height:1.3;min-height:74px;' +
         'padding:8px;border-radius:9px;cursor:pointer;border:2px solid var(--line,#2a3450);' +
         'background:rgba(255,255,255,.05);color:transparent;transition:.15s;word-break:break-word;' +
         'display:flex;align-items:center;justify-content:center;text-align:center;position:relative}' +


### PR DESCRIPTION
## Co se změnilo\n\n### 1. Nahrazení děleno `÷` → `:` (česká notace)\n259 výskytů ve všech 8 souborech (`rpg-mat-6/7/8/9.html` + `rpg-tasks-6/7/8/9.js`).\nTéž v textu úloh i v nápovědách (`${a} : ${b}` místo `${a} ÷ ${b}`).\n\n### 2. Font spojovačky / řazení / pexesa (`rpg-tasktypes.js`)\nTlačítka `.ttm-q`, `.ttm-a`, `.tto-chip`, `.ttp-card` přepnuty z `var(--vt)` (VT323) na `var(--px)` (Roboto Mono).\nVT323 má špatnou podporu českých diakritických znaků (á, č, ě, ž…) — Roboto Mono je korektní.\nFontové velikosti mírně sníženy (17→16 px, 21→18 px, 16→14 px) aby kompenzovaly hustší sazbu Roboto Mono vs. VT323.\n\n## Testy\n- 🟢 `sprite-magenta.audit.cjs` — čistý\n- 🟢 `rpg-tasks-9.audit.cjs` — 630 000 generací, 0 problémů\n- 🟢 `vstudents-deep.harness.cjs` — 65/65

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1y2gtL6iKXn4rCnSZ11st)_